### PR TITLE
fix(opoi): scan confirmed blocks for AiRequests + persist response ac…

### DIFF
--- a/src/client/grpc.rs
+++ b/src/client/grpc.rs
@@ -4,15 +4,15 @@ use crate::pow::BlockSeed::{FullBlock, PartialBlock};
 use crate::proto::kaspad_message::Payload;
 use crate::proto::rpc_client::RpcClient;
 use crate::proto::{
-    GetBlockTemplateRequestMessage, GetInfoRequestMessage, KaspadMessage, NotifyBlockAddedRequestMessage,
-    NotifyNewBlockTemplateRequestMessage,
+    GetBlockRequestMessage, GetBlockTemplateRequestMessage, GetInfoRequestMessage, KaspadMessage,
+    NotifyBlockAddedRequestMessage, NotifyNewBlockTemplateRequestMessage,
 };
 use crate::{miner::MinerManager, Error};
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use log::{error, info, warn};
 use rand::{thread_rng, RngCore};
-use semver::Version;
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc::{self, error::SendError, Sender}, oneshot};
@@ -22,7 +22,6 @@ use tokio_util::sync::{PollSendError, PollSender};
 use tonic::{transport::Channel as TonicChannel, Streaming};
 
 static EXTRA_DATA: &str = concat!(env!("CARGO_PKG_VERSION"), "/", env!("PACKAGE_COMPILE_TIME"));
-static VERSION_UPDATE: &str = "0.11.15";
 type BlockHandle = JoinHandle<Result<(), PollSendError<KaspadMessage>>>;
 
 #[allow(dead_code)]
@@ -39,14 +38,19 @@ pub struct KeryxdHandler {
     block_channel: Sender<BlockSeed>,
     block_handle: BlockHandle,
 
-    /// Pending AI response tag to embed in the next coinbase extra_data.
+    /// Queue of AiRequests seen in confirmed blocks or mempool, waiting for inference.
+    /// Each entry: (payload_prefix_16, prompt, max_tokens).
+    /// Fed by both BlockAdded scans and block template scans.
+    ai_request_queue: VecDeque<(String, String, usize)>,
+
+    /// Prefixes already queued or in-flight — used for deduplication.
+    ai_seen_prefixes: std::collections::HashSet<String>,
+
+    /// Pending AI response tag ready to embed in the next coinbase extra_data.
     /// Format: "ai:r:{payload_prefix_16}:{base64_result}"
-    /// Set when an AiRequest TX is detected in the current block template.
-    /// Consumed (and cleared) on the next GetBlockTemplate call.
     pending_ai_response: Option<String>,
 
     /// In-flight SLM inference task: (payload_prefix, result_receiver).
-    /// Polled each time a new block template is requested.
     inference_rx: Option<(String, oneshot::Receiver<String>)>,
 }
 
@@ -105,6 +109,8 @@ impl KeryxdHandler {
                 .unwrap_or_else(|| Arc::new(AtomicU16::new((thread_rng().next_u64() % 10_000u64) as u16))),
             block_channel,
             block_handle,
+            ai_request_queue: VecDeque::new(),
+            ai_seen_prefixes: std::collections::HashSet::new(),
             pending_ai_response: None,
             inference_rx: None,
         }))
@@ -146,59 +152,109 @@ impl KeryxdHandler {
         let nonce_hex = format!("{:016x}", thread_rng().next_u64());
         // OPoI Phase 1: run the deterministic MLP (matches node validation).
         let opoi_tag = keryx_miner::inference::compute_opoi_tag(&nonce_hex);
-        // Append TinyLlama AI response if one is ready from a previous block template scan.
-        // Format appended: "/ai:r:{payload_prefix_16}:{base64url_result}"
-        let ai_response = self.pending_ai_response.take()
+        // Embed the pending AI response in every template request until a block is
+        // successfully submitted. Using clone (not take) so the response survives
+        // template rotations — at 10 BPS most templates are replaced before the
+        // miner finds a valid nonce, so a single take() would silently drop responses.
+        let ai_response = self.pending_ai_response
+            .as_deref()
             .map(|r| format!("/{}", r))
             .unwrap_or_default();
         let extra_data = format!("{}/{}/ai:v1:{}{}", EXTRA_DATA, nonce_hex, opoi_tag, ai_response);
         self.client_send(GetBlockTemplateRequestMessage { pay_address, extra_data }).await
     }
 
+    /// Scans a slice of transactions for AiRequest payloads and pushes new
+    /// entries into `ai_request_queue` (deduplication by prefix).
+    fn scan_txs_for_ai_requests(&mut self, txs: &[crate::proto::RpcTransaction]) {
+        for tx in txs {
+            if tx.inputs.is_empty() {
+                continue; // skip coinbase
+            }
+            if let Some((prefix, prompt, max_tokens)) =
+                keryx_miner::inference::extract_ai_request(&tx.payload)
+            {
+                if !self.ai_seen_prefixes.contains(&prefix) {
+                    info!("OPoI: queued AiRequest prefix={}", prefix);
+                    self.ai_seen_prefixes.insert(prefix.clone());
+                    self.ai_request_queue.push_back((prefix, prompt, max_tokens));
+                }
+            }
+        }
+    }
+
+    /// Starts SLM inference for the next queued AiRequest, if no inference is
+    /// already in flight and a response slot is free.
+    fn try_start_inference(&mut self) {
+        if self.pending_ai_response.is_some() || self.inference_rx.is_some() {
+            return;
+        }
+        if let Some((prefix, prompt, max_tokens)) = self.ai_request_queue.pop_front() {
+            info!("OPoI: spawning SLM inference for prefix={}", prefix);
+            let (tx_done, rx_done) = oneshot::channel::<String>();
+            tokio::task::spawn_blocking(move || {
+                let result = keryx_miner::slm::run_inference(&prompt, max_tokens);
+                let _ = tx_done.send(result);
+            });
+            self.inference_rx = Some((prefix, rx_done));
+        }
+    }
+
+    /// Polls the in-flight inference task and promotes the result to
+    /// `pending_ai_response` when ready.
+    fn poll_inference(&mut self) {
+        if self.pending_ai_response.is_some() {
+            return;
+        }
+        if let Some((ref prefix, ref mut rx)) = self.inference_rx {
+            if let Ok(result) = rx.try_recv() {
+                use base64::Engine as _;
+                let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+                    .encode(result.as_bytes());
+                let tag = format!("ai:r:{}:{}", prefix, encoded);
+                info!("OPoI: inference complete, queued response {}", tag);
+                self.pending_ai_response = Some(tag);
+                self.inference_rx = None;
+            }
+        }
+    }
+
     async fn handle_message(&mut self, msg: Payload, miner: &mut MinerManager) -> Result<(), Error> {
         match msg {
-            Payload::BlockAddedNotification(_) => self.client_get_block_template().await?,
+            // BlockAdded: scan confirmed block for AiRequests that may have been
+            // confirmed before the miner saw them in the mempool.
+            // Do NOT trigger a new block template here — NewBlockTemplate handles that.
+            Payload::BlockAddedNotification(notif) => {
+                if let Some(block) = notif.block {
+                    if !block.transactions.is_empty() {
+                        // Full block included — scan directly.
+                        self.scan_txs_for_ai_requests(&block.transactions.clone());
+                        self.try_start_inference();
+                    } else {
+                        // Transactions absent — fetch the full block from the node.
+                        let hash = block
+                            .verbose_data
+                            .as_ref()
+                            .map(|v| v.hash.clone())
+                            .unwrap_or_default();
+                        if !hash.is_empty() {
+                            self.client_send(GetBlockRequestMessage {
+                                hash,
+                                include_transactions: true,
+                            })
+                            .await?;
+                        }
+                    }
+                }
+            }
             Payload::NewBlockTemplateNotification(_) => self.client_get_block_template().await?,
             Payload::GetBlockTemplateResponse(template) => {
-                // Poll the in-flight SLM inference task if one is running.
-                if self.pending_ai_response.is_none() {
-                    if let Some((ref prefix, ref mut rx)) = self.inference_rx {
-                        if let Ok(result) = rx.try_recv() {
-                            use base64::Engine as _;
-                            // URL_SAFE_NO_PAD avoids '/' and '=' which would
-                            // break the '/' delimiter used in extra_data parsing.
-                            let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
-                                .encode(result.as_bytes());
-                            let tag = format!("ai:r:{}:{}", prefix, encoded);
-                            info!("OPoI: inference complete, queued response {}", tag);
-                            self.pending_ai_response = Some(tag);
-                            self.inference_rx = None;
-                        }
-                    }
+                // Poll any in-flight inference and scan mempool TXs.
+                self.poll_inference();
+                if let Some(ref block) = template.block {
+                    self.scan_txs_for_ai_requests(&block.transactions.clone());
                 }
-                // Scan non-coinbase TXs for AiRequest payloads.
-                // When found, kick off SLM inference in a blocking thread.
-                if self.pending_ai_response.is_none() && self.inference_rx.is_none() {
-                    if let Some(ref block) = template.block {
-                        for tx in &block.transactions {
-                            if tx.inputs.is_empty() {
-                                continue; // skip coinbase
-                            }
-                            if let Some((prefix, prompt, max_tokens)) =
-                                keryx_miner::inference::extract_ai_request(&tx.payload)
-                            {
-                                info!("OPoI: detected AiRequest (prefix={}), spawning SLM inference", prefix);
-                                let (tx_done, rx_done) = oneshot::channel::<String>();
-                                tokio::task::spawn_blocking(move || {
-                                    let result = keryx_miner::slm::run_inference(&prompt, max_tokens);
-                                    let _ = tx_done.send(result);
-                                });
-                                self.inference_rx = Some((prefix, rx_done));
-                                break;
-                            }
-                        }
-                    }
-                }
+                self.try_start_inference();
                 match (template.block, template.is_synced, template.error) {
                     (Some(b), true, None) => miner.process_block(Some(FullBlock(Box::new(b)))).await?,
                     (Some(b), false, None) if self.mine_when_not_synced => {
@@ -211,26 +267,36 @@ impl KeryxdHandler {
                     (None, true, None) => error!("No block and No Error!"),
                 }
             }
-            Payload::SubmitBlockResponse(res) => match res.error {
-                None => info!("block submitted successfully!"),
-                Some(e) => warn!("Failed submitting block: {:?}", e),
-            },
+            // GetBlock response: arrives after we requested a full block from BlockAdded.
+            // Scan its transactions for AiRequests.
             Payload::GetBlockResponse(msg) => {
                 if let Some(e) = msg.error {
-                    return Err(e.message.into());
-                } else {
-                    info!("Get block response: {:?}", msg);
+                    warn!("GetBlockResponse error: {}", e.message);
+                } else if let Some(block) = msg.block {
+                    self.scan_txs_for_ai_requests(&block.transactions.clone());
+                    self.try_start_inference();
                 }
             }
+            Payload::SubmitBlockResponse(res) => match res.error {
+                None => {
+                    info!("block submitted successfully!");
+                    // Clear the pending response — the block carrying it is now on-chain.
+                    // The next queued AiRequest (if any) will start on the next template.
+                    if self.pending_ai_response.take().is_some() {
+                        info!("OPoI: response committed on-chain, slot cleared");
+                        self.try_start_inference();
+                    }
+                }
+                Some(e) => warn!("Failed submitting block: {:?}", e),
+            },
             Payload::GetInfoResponse(info) => {
                 info!("Keryxd version: {}", info.server_version);
-                let keryxd_version = Version::parse(&info.server_version)?;
-                let update_version = Version::parse(VERSION_UPDATE)?;
-                match keryxd_version >= update_version {
-                    true => self.client_send(NotifyNewBlockTemplateRequestMessage {}).await?,
-                    false => self.client_send(NotifyBlockAddedRequestMessage {}).await?,
-                };
-
+                // Register for both notification types:
+                // - NewBlockTemplate drives the mining loop
+                // - BlockAdded lets us scan confirmed blocks for AiRequests
+                //   that were confirmed before the miner saw them in mempool
+                self.client_send(NotifyNewBlockTemplateRequestMessage {}).await?;
+                self.client_send(NotifyBlockAddedRequestMessage {}).await?;
                 self.client_get_block_template().await?;
             }
             Payload::NotifyNewBlockTemplateResponse(res) => match res.error {
@@ -238,8 +304,8 @@ impl KeryxdHandler {
                 Some(e) => error!("Failed registering for new template notifications: {:?}", e),
             },
             Payload::NotifyBlockAddedResponse(res) => match res.error {
-                None => info!("Registered for block notifications (upgrade your Keryxd for better experience)"),
-                Some(e) => error!("Failed registering for block notifications: {:?}", e),
+                None => info!("Registered for block added notifications (AI request scanning)"),
+                Some(e) => error!("Failed registering for block added notifications: {:?}", e),
             },
             msg => info!("got unknown msg: {:?}", msg),
         }

--- a/src/keryxd_messages.rs
+++ b/src/keryxd_messages.rs
@@ -1,6 +1,7 @@
 use crate::proto::{
-    kaspad_message::Payload, GetBlockTemplateRequestMessage, GetInfoRequestMessage, KaspadMessage,
-    NotifyBlockAddedRequestMessage, NotifyNewBlockTemplateRequestMessage, RpcBlock, SubmitBlockRequestMessage,
+    kaspad_message::Payload, GetBlockRequestMessage, GetBlockTemplateRequestMessage, GetInfoRequestMessage,
+    KaspadMessage, NotifyBlockAddedRequestMessage, NotifyNewBlockTemplateRequestMessage, RpcBlock,
+    SubmitBlockRequestMessage,
 };
 use crate::{
     pow::{self, HeaderHasher},
@@ -42,6 +43,12 @@ impl From<NotifyBlockAddedRequestMessage> for KaspadMessage {
 impl From<GetBlockTemplateRequestMessage> for KaspadMessage {
     fn from(a: GetBlockTemplateRequestMessage) -> Self {
         KaspadMessage { payload: Some(Payload::GetBlockTemplateRequest(a)) }
+    }
+}
+
+impl From<GetBlockRequestMessage> for KaspadMessage {
+    fn from(a: GetBlockRequestMessage) -> Self {
+        KaspadMessage { payload: Some(Payload::GetBlockRequest(a)) }
     }
 }
 


### PR DESCRIPTION
…ross templates

  Two bugs fixed that caused AiRequests to remain PENDING indefinitely:

  1. Miner now registers for both NewBlockTemplate and BlockAdded notifications.

     BlockAdded handler scans each confirmed block for AiRequests, feeding a

     persistent VecDeque queue (dedup by prefix). Previously, requests confirmed

     before the miner saw them in the mempool were silently dropped.

  2. pending_ai_response is now cloned into every GetBlockTemplate request

     (not take'd on the first one). The response slot is cleared only on a

     successful SubmitBlockResponse. At 10 BPS, most templates are rotated

     before the miner finds a valid nonce — the previous take() was losing

     responses permanently on the first template rotation.