### PR TITLE
Add stratum DAA score support for pool mining

### DIFF
--- a/src/client/stratum.rs
+++ b/src/client/stratum.rs
@@ -35,6 +35,7 @@ use tokio_util::sync::{PollSendError, PollSender};
 
 //const DIFFICULTY_1_TARGET: Uint256 = Uint256([0x00000000ffff0000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000]);
 const DIFFICULTY_1_TARGET: (u64, i16) = (0xffffu64, 208); // 0xffff 2^208
+const KERYX_STRATUM_DAA_CAPABILITY: &str = "keryx-stratum-v2";
 const LOG_RATE: Duration = Duration::from_secs(30);
 
 type BlockHandle = JoinHandle<Result<(), PollSendError<StratumLine>>>;
@@ -115,9 +116,9 @@ impl Client for StratumHandler {
             .send(StratumLine {
                 id,
                 payload: StratumLinePayload::StratumCommand(StratumCommand::Subscribe(
-                    MiningSubscribe::MiningSubscribeDefault((
+                    MiningSubscribe::MiningSubscribeOptions((
                         format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION")),
-                        //self.extranonce.clone().unwrap_or("0xffffffff".into())
+                        KERYX_STRATUM_DAA_CAPABILITY.into(),
                     )),
                 )),
                 jsonrpc: None,
@@ -305,6 +306,29 @@ impl StratumHandler {
                             ref nonce_size,
                         ))) => self.set_extranonce(extranonce.as_str(), nonce_size),
                         StratumCommand::MiningSetDifficulty((ref difficulty,)) => self.set_difficulty(difficulty),
+                        StratumCommand::MiningNotify(MiningNotify::MiningNotifyShortV2((
+                            id,
+                            header_hash,
+                            timestamp,
+                            daa_score,
+                        ))) => {
+                            self.block_template_ctr
+                                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| Some((v + 1) % 10_000))
+                                .unwrap();
+                            miner
+                                .process_block(Some(PartialBlock {
+                                    id,
+                                    header_hash,
+                                    timestamp,
+                                    daa_score,
+                                    nonce: 0,
+                                    target: self.target_pool,
+                                    nonce_mask: self.nonce_mask,
+                                    nonce_fixed: self.nonce_fixed,
+                                    hash: None,
+                                }))
+                                .await
+                        }
                         StratumCommand::MiningNotify(MiningNotify::MiningNotifyShort((id, header_hash, timestamp))) => {
                             self.block_template_ctr
                                 .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| Some((v + 1) % 10_000))
@@ -314,6 +338,7 @@ impl StratumHandler {
                                     id,
                                     header_hash,
                                     timestamp,
+                                    daa_score: crate::pow::heavy_hash::POW_SALT_V2_ACTIVATION_DAA,
                                     nonce: 0,
                                     target: self.target_pool,
                                     nonce_mask: self.nonce_mask,

--- a/src/client/stratum/statum_codec.rs
+++ b/src/client/stratum/statum_codec.rs
@@ -37,6 +37,7 @@ pub(crate) struct StratumError(pub(crate) ErrorCode, pub(crate) String, #[serde(
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub(crate) enum MiningNotify {
+    MiningNotifyShortV2((String, [u64; 4], u64, u64)),
     MiningNotifyShort((String, [u64; 4], u64)),
     MiningNotifyLong((String, String, String, String, Vec<String>, String, String, String, bool)),
 }

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -27,6 +27,7 @@ pub enum BlockSeed {
         id: String,
         header_hash: [u64; 4],
         timestamp: u64,
+        daa_score: u64,
         nonce: u64,
         target: Uint256,
         nonce_mask: u64,
@@ -96,6 +97,7 @@ impl State {
             BlockSeed::PartialBlock {
                 ref header_hash,
                 ref timestamp,
+                daa_score: ref block_daa_score,
                 ref target,
                 nonce_fixed: fixed,
                 nonce_mask: mask,
@@ -104,7 +106,7 @@ impl State {
                 pre_pow_hash = Hash::new(*header_hash);
                 header_timestamp = *timestamp;
                 header_target = *target;
-                daa_score = 0; // stratum shares have no daa_score; always use v1 salt
+                daa_score = *block_daa_score;
                 nonce_mask = mask;
                 nonce_fixed = fixed
             }


### PR DESCRIPTION
## Summary

This PR adds an opt-in stratum notify format for pool mining so pools can pass the block DAA score to miners.

Changes:
- Subscribe with the `keryx-stratum-v2` capability.
- Accept a short `mining.notify` payload with an extra `daa_score` field: `(job_id, header_hash, timestamp, daa_score)`.
- Store the DAA score in `BlockSeed::PartialBlock` and use it when selecting the PoW salt version.
- Keep the existing 3-field short notify format as a fallback for older pools.

## Why

After the SALT v2 activation, stratum miners need the actual block DAA score from the pool to choose the correct PoW salt. Direct node mining already has this value through the full block template, but the existing stratum short notify path hardcodes DAA as `0`, which keeps stratum shares on the old salt path.

## Compatibility

Older pools that do not support the new capability can continue sending the existing 3-field notify format. The fallback uses the SALT v2 activation DAA so legacy short-notify pools still mine with the post-fork salt on the current network.

## Testing

- `git diff --check`
- Attempted `cargo check --bin keryx-miner` on Windows with CUDA 13.2. The check is blocked before this patch is compiled by the current upstream dependency `cudarc v0.13.9`, which panics with: `Unsupported cuda toolkit version: 13.2`. No CUDA/dependency changes are included here to keep this PR scoped to the pool stratum protocol improvement.