### PR TITLE
fix(pom_gpu): scope uninstall() to the inference device only

### DIFF
--- a/src/pom_gpu.rs
+++ b/src/pom_gpu.rs
@@ -198,11 +198,30 @@ pub fn install(device_id: u32, m: PomGpuMiner) {
     }
 }
 
-/// Drop the GPU miner, releasing its hold on the mining model's VRAM (shared Arcs + gather) so
-/// the inference engine can load another model. Mining is paused during inference anyway.
-pub fn uninstall() {
+/// Removes only `device_id`'s entry from a `device -> miner` map, leaving every other device's
+/// entry untouched. Pulled out as a tiny generic helper (over the map's value type) purely so
+/// this scoping behavior is unit-testable without a real, CUDA-backed `PomGpuMiner` — production
+/// always calls it through `uninstall` against `HashMap<u32, Arc<PomGpuMiner>>`.
+fn remove_device_entry<T>(map: &mut HashMap<u32, T>, device_id: u32) {
+    map.remove(&device_id);
+}
+
+/// Drop the GPU miner for `device_id` only, releasing its hold on that device's mining-model VRAM
+/// (shared Arcs + gather) so the inference engine can load another model there. Mining on that
+/// device is paused during inference anyway.
+///
+/// Scoped to a single device on purpose: only the device colocated with inference (CUDA device 0
+/// — see the `Device::new_cuda(0)` call in `slm::load_and_run_inference`) ever shares VRAM with
+/// the inference engine via `load_shared`'s zero-dup path, or otherwise needs to make room for an
+/// inference model swap. Other devices in a multi-GPU rig run fully standalone `PomGpuMiner`s
+/// (`PomGpuMiner::load`) that never touch the inference engine's VRAM. A previous version of this
+/// function called `g.clear()`, dropping every device's resident miner on every inference model
+/// swap — needlessly forcing GPU1+ rigs to fully reload their GGUF from disk and rebuild the
+/// gather index (`ensure_installed_inner`'s own doc comment calls this reload "Heavy") even though
+/// nothing about them changed.
+pub fn uninstall(device_id: u32) {
     if let Ok(mut g) = miners().lock() {
-        g.clear();
+        remove_device_entry(&mut g, device_id);
     }
 }
 
@@ -334,5 +353,43 @@ fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
             log::error!("PoM[gpu{}]: device miner build failed: {}", device_id, e);
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These exercise `remove_device_entry` directly with a dummy value type, rather than going
+    // through `install`/`uninstall`, because `PomGpuMiner` can only be constructed via `load`/
+    // `load_shared`, both of which require real CUDA hardware (`Device::new_cuda`) unavailable in
+    // CI/unit-test environments. `remove_device_entry` holds the entire scoping logic that
+    // `uninstall` delegates to, so this still covers the behavior that matters: only the targeted
+    // device's entry is removed, every other device's entry survives untouched.
+
+    #[test]
+    fn remove_device_entry_only_clears_target_device() {
+        let mut map: HashMap<u32, &str> = HashMap::new();
+        map.insert(0, "gpu0-miner");
+        map.insert(1, "gpu1-miner");
+        map.insert(2, "gpu2-miner");
+
+        remove_device_entry(&mut map, 0);
+
+        assert!(!map.contains_key(&0));
+        assert_eq!(map.get(&1), Some(&"gpu1-miner"));
+        assert_eq!(map.get(&2), Some(&"gpu2-miner"));
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn remove_device_entry_on_missing_device_is_a_no_op() {
+        let mut map: HashMap<u32, &str> = HashMap::new();
+        map.insert(1, "gpu1-miner");
+
+        remove_device_entry(&mut map, 0);
+
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(&1), Some(&"gpu1-miner"));
     }
 }

--- a/src/slm.rs
+++ b/src/slm.rs
@@ -1000,8 +1000,10 @@ pub fn load_and_run_inference(model_id: &[u8; 32], prompt: &str, max_tokens: usi
                 log::info!("SlmEngine: evicting '{}' to load '{}'", old.name, spec.name);
             }
             // Inference has priority over PoW: release the GPU miner's hold on the resident mining
-            // weights so this model fits. Mining rebuilds (reloads its model) when it next runs.
-            crate::pom_gpu::uninstall();
+            // weights on this device only, so this model fits. Mining rebuilds (reloads its model)
+            // when it next runs on this device. `0` matches the CUDA device inference always loads
+            // onto below (`Device::new_cuda(0)`); other devices' resident miners are left alone.
+            crate::pom_gpu::uninstall(0);
             *guard = None;
             let device = match Device::new_cuda(0) {
                 Ok(d) => { log::info!("SlmEngine: CUDA device 0 active"); d }


### PR DESCRIPTION
## Problem

`pom_gpu::uninstall()` called `g.clear()` on the *entire* `device_id -> PomGpuMiner` map every time the inference engine needed to swap models. On a multi-GPU rig, this dropped every device's resident `PomGpuMiner`, not just the one device inference actually shares VRAM with (`Device::new_cuda(0)`, see `slm::load_and_run_inference`). The result: GPU1+ miners were forced into a full GGUF reload from disk and a gather-index rebuild (`ensure_installed_inner`'s own doc comment calls this "Heavy") on every inference model swap, even though nothing about those devices changed.

## Solution

- `uninstall()` now takes a `device_id: u32` and only removes that device's entry from the map.
- The single call site (`slm.rs`) now passes `0`, matching the CUDA device inference always loads onto.
- Other devices' resident miners are left untouched, since standalone `PomGpuMiner`s (`PomGpuMiner::load`) on other devices never touch the inference engine's VRAM.
- Pulled the actual removal into a tiny generic `remove_device_entry<T>(map: &mut HashMap<u32, T>, device_id: u32)` helper so the scoping behavior is unit-testable. `PomGpuMiner` can only be constructed via `load`/`load_shared`, both of which require real CUDA hardware (`Device::new_cuda`), so the helper is generic over the map's value type and tested with a dummy value instead.

## Tests

Added two unit tests in `pom_gpu.rs`:

- `remove_device_entry_only_clears_target_device` — inserts entries for devices 0/1/2, removes device 0, asserts only device 0 is gone and 1/2 survive untouched.
- `remove_device_entry_on_missing_device_is_a_no_op` — removing a device that was never present leaves the map unchanged.

Both verified with a full `cargo build`/`cargo test` pass against the real `cuda`-feature crate (not an isolated `rustc` check):

```
cargo test -p keryx-miner --lib pom_gpu
running 2 tests
test pom_gpu::tests::remove_device_entry_on_missing_device_is_a_no_op ... ok
test pom_gpu::tests::remove_device_entry_only_clears_target_device ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out
```

## Risks

- Behavior change is intentionally narrower than before: any *other* code path that relied on `uninstall()` clearing every device's miner (none found in this crate) would need updating to call it per-device. Searched the crate for all call sites of `pom_gpu::uninstall`; `slm.rs` is the only caller.
- No change to single-GPU rigs' behavior (device 0 is still cleared exactly as before).
