### PR TITLE
perf(runtime): reduce idle CPU usage on multi-core rigs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 
 [dependencies]
 tonic = "0.8"
-tokio = { version = "1.17", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.17", features = ["rt-multi-thread", "time", "sync", "net"] }
 prost = "0.11"
 futures-util = "0.3"
 tokio-stream = {version = "0.1", features = ["net"]}

--- a/src/client/grpc.rs
+++ b/src/client/grpc.rs
@@ -15,6 +15,7 @@ use rand::{thread_rng, RngCore};
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{mpsc::{self, error::SendError, Sender}, oneshot};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
@@ -90,32 +91,50 @@ impl Client for KeryxdHandler {
 
     async fn listen(&mut self, miner: &mut MinerManager) -> Result<(), Error> {
         self.opoi_challenge_active = Some(miner.opoi_challenge_flag());
-        // Harvest in-flight inference on a timer, independently of node notifications.
-        // On a sole-producer node, pausing mining for inference stops block production,
-        // so the node stops sending NewBlockTemplate notifications — without this timer
-        // the finished inference would never be collected and mining would deadlock.
-        let mut tick = tokio::time::interval(tokio::time::Duration::from_millis(200));
-        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        const CHALLENGE_KEEPALIVE: Duration = Duration::from_secs(2);
         loop {
-            let maybe_msg = tokio::select! {
-                msg = self.stream.message() => Some(msg?),
-                _ = tick.tick() => None,
-            };
-            match maybe_msg {
-                Some(Some(m)) => match m.payload {
-                    Some(payload) => self.handle_message(payload, miner).await?,
-                    None => warn!("keryxd message payload is empty"),
-                },
-                Some(None) => break, // stream closed by node
-                None => {
-                    // Timer tick: if a regular inference just finished, get a fresh template.
-                    if self.inference_rx.is_some() && self.poll_inference().await {
-                        self.client_get_block_template().await?;
-                    // If a challenge is in flight, keep pinging the node so the result is
-                    // delivered as soon as the inference task completes. This is critical on
-                    // sole-producer nodes where mining suspension stops NewBlockTemplate
-                    // notifications and the response would otherwise never be sent.
-                    } else if self.challenge_inference_rx.is_some() {
+            if self.inference_rx.is_none() && self.challenge_inference_rx.is_none() {
+                match self.stream.message().await? {
+                    Some(m) => match m.payload {
+                        Some(payload) => self.handle_message(payload, miner).await?,
+                        None => warn!("keryxd message payload is empty"),
+                    },
+                    None => break,
+                }
+                continue;
+            }
+
+            if self.inference_rx.is_some() {
+                tokio::select! {
+                    msg = self.stream.message() => {
+                        match msg? {
+                            Some(m) => match m.payload {
+                                Some(payload) => self.handle_message(payload, miner).await?,
+                                None => warn!("keryxd message payload is empty"),
+                            },
+                            None => break,
+                        }
+                    }
+                    finished = self.await_regular_inference() => {
+                        if finished {
+                            self.client_get_block_template().await?;
+                        }
+                    }
+                }
+            } else {
+                // Challenge in flight: slow keepalive for sole-producer nodes where mining
+                // suspension stops NewBlockTemplate notifications.
+                tokio::select! {
+                    msg = self.stream.message() => {
+                        match msg? {
+                            Some(m) => match m.payload {
+                                Some(payload) => self.handle_message(payload, miner).await?,
+                                None => warn!("keryxd message payload is empty"),
+                            },
+                            None => break,
+                        }
+                    }
+                    _ = tokio::time::sleep(CHALLENGE_KEEPALIVE) => {
                         self.client_get_block_template().await?;
                     }
                 }
@@ -453,6 +472,22 @@ impl KeryxdHandler {
         }
     }
 
+    /// Awaits in-flight regular inference, then uploads to IPFS and submits AiResponse.
+    /// Returns `true` when inference finished (regardless of tx success).
+    async fn await_regular_inference(&mut self) -> bool {
+        let Some((raw, rx)) = self.inference_rx.take() else {
+            return false;
+        };
+        let result_opt = match rx.await {
+            Ok(v) => v,
+            Err(_) => {
+                info!("OPoI: inference task dropped — AiResponse skipped");
+                return true;
+            }
+        };
+        self.complete_inference(raw, result_opt).await
+    }
+
     /// Polls the in-flight inference task. When complete, uploads the result to
     /// IPFS and submits a zero-input/zero-output AiResponse transaction.
     /// Returns `true` if inference just finished (regardless of tx success).
@@ -464,6 +499,10 @@ impl KeryxdHandler {
             self.inference_rx = Some((raw, rx));
             return false;
         };
+        self.complete_inference(raw, result_opt).await
+    }
+
+    async fn complete_inference(&mut self, raw: Vec<u8>, result_opt: Option<String>) -> bool {
         let Some(result) = result_opt else {
             // Inference returned None: model not ready or think block exhausted max_tokens.
             // Do NOT upload anything to IPFS — skip this AiResponse entirely.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use rand::{thread_rng, RngCore};
 use std::fs;
 use std::sync::atomic::AtomicU16;
 use std::sync::Arc;
-use std::thread::sleep;
 use std::time::Duration;
 
 use crate::cli::Opt;
@@ -300,8 +299,35 @@ async fn client_main(
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> Result<(), Error> {
+/// Tokio async worker count. Async workload is minimal (gRPC/stratum + a few tasks);
+/// default 2 avoids spawning one worker per logical CPU on large rigs.
+fn tokio_worker_threads() -> usize {
+    std::env::var("KERYX_ASYNC_WORKERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2)
+        .clamp(1, 4)
+}
+
+/// Cap for `spawn_blocking` (inference, IPFS, model prefetch). Override with KERYX_BLOCKING_THREADS.
+fn tokio_blocking_threads() -> usize {
+    std::env::var("KERYX_BLOCKING_THREADS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4)
+        .clamp(2, 16)
+}
+
+fn main() -> Result<(), Error> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(tokio_worker_threads())
+        .max_blocking_threads(tokio_blocking_threads())
+        .enable_all()
+        .build()?;
+    rt.block_on(run())
+}
+
+async fn run() -> Result<(), Error> {
     #[cfg(target_os = "windows")]
     adjust_console().unwrap_or_else(|e| {
         eprintln!("WARNING: Failed to protect console ({}). Any selection in console will freeze the miner.", e)
@@ -558,6 +584,6 @@ async fn main() -> Result<(), Error> {
             Err(e) => error!("Client closed with error {:?}", e),
         }
         info!("Client closed, reconnecting");
-        sleep(Duration::from_millis(100));
+        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -2,15 +2,13 @@ use std::collections::HashMap;
 use std::num::Wrapping;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::thread::sleep;
-use std::time::Duration;
+use std::thread::{self, JoinHandle as ThreadJoinHandle};
+use std::time::{Duration, Instant};
 
 use crate::{pow, watch, Error};
 use log::{error, info, warn};
 use rand::{thread_rng, RngCore};
 use tokio::sync::mpsc::Sender;
-use tokio::task::{self, JoinHandle};
-use tokio::time::MissedTickBehavior;
 
 use crate::pow::BlockSeed;
 use keryx_miner::{PluginManager, WorkerSpec};
@@ -35,7 +33,7 @@ fn trigger_freeze_handler(kill_switch: Arc<AtomicBool>, handle: &MinerHandler) -
     use std::os::unix::thread::JoinHandleExt;
     let pthread_handle = handle.as_pthread_t();
     std::thread::spawn(move || {
-        sleep(Duration::from_millis(1000));
+        thread::sleep(Duration::from_millis(1000));
         if kill_switch.load(Ordering::SeqCst) {
             match nix::sys::pthread::pthread_kill(pthread_handle, nix::sys::signal::Signal::SIGUSR1) {
                 Ok(()) => {
@@ -65,7 +63,7 @@ fn trigger_freeze_handler(kill_switch: Arc<AtomicBool>, handle: &MinerHandler) -
 
     std::thread::spawn(move || unsafe {
         let ensure_full_move = raw_handle;
-        sleep(Duration::from_millis(1000));
+        thread::sleep(Duration::from_millis(1000));
         if kill_switch.load(Ordering::SeqCst) {
             kernel32::TerminateThread(ensure_full_move.0, 0);
         }
@@ -93,7 +91,8 @@ pub struct MinerManager {
     handles: Vec<MinerHandler>,
     block_channel: watch::Sender<Option<WorkerCommand>>,
     send_channel: Sender<BlockSeed>,
-    logger_handle: JoinHandle<()>,
+    logger_handle: ThreadJoinHandle<()>,
+    logger_stop: Arc<AtomicBool>,
     is_synced: bool,
     hashes_tried: Arc<AtomicU64>,
     hashes_by_worker: Arc<Mutex<HashMap<String, Arc<AtomicU64>>>>,
@@ -104,7 +103,10 @@ pub struct MinerManager {
 impl Drop for MinerManager {
     fn drop(&mut self) {
         info!("Closing miner");
-        self.logger_handle.abort();
+        self.logger_stop.store(true, Ordering::Release);
+        if let Err(e) = self.logger_handle.join() {
+            error!("Hashrate logger failed to join: {:?}", e);
+        }
         match self.block_channel.send(Some(WorkerCommand::Close)) {
             Ok(_) => {}
             Err(_) => warn!("All workers are already dead"),
@@ -157,15 +159,21 @@ impl MinerManager {
                 hashes_by_worker.clone(),
             ));
         }
+        let logger_stop = Arc::new(AtomicBool::new(false));
+        let logger_stop_spawn = Arc::clone(&logger_stop);
         Self {
             handles,
             block_channel: send,
             send_channel,
-            logger_handle: task::spawn(Self::log_hashrate(
-                Arc::clone(&hashes_tried),
-                hashes_by_worker.clone(),
-                Arc::clone(&opoi_challenge_active),
-            )),
+            logger_handle: thread::spawn(move || {
+                Self::log_hashrate(
+                    Arc::clone(&hashes_tried),
+                    hashes_by_worker.clone(),
+                    Arc::clone(&opoi_challenge_active),
+                    logger_stop_spawn,
+                )
+            }),
+            logger_stop,
             is_synced: true,
             hashes_tried,
             current_state_id: AtomicUsize::new(0),
@@ -498,27 +506,26 @@ impl MinerManager {
         })
     }
 
-    async fn log_hashrate(
+    fn log_hashrate(
         hashes_tried: Arc<AtomicU64>,
         hashes_by_worker: Arc<Mutex<HashMap<String, Arc<AtomicU64>>>>,
         opoi_challenge_active: Arc<AtomicBool>,
+        stop: Arc<AtomicBool>,
     ) {
-        let mut ticker = tokio::time::interval(LOG_RATE);
-        ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
-        let mut last_instant = ticker.tick().await;
-        // Consecutive all-zero ticks while NOT in an OPoI inference pause.
+        let mut last_instant = Instant::now();
         let mut zero_streak: u32 = 0;
-        loop {
-            let now = ticker.tick().await;
-            let duration = (now - last_instant).as_secs_f64();
-            last_instant = now;
-            // PoM model (re)load also intentionally pauses PoW — treat it like an inference pause.
+        while !stop.load(Ordering::Acquire) {
+            thread::sleep(LOG_RATE);
+            if stop.load(Ordering::Acquire) {
+                break;
+            }
+            let duration = last_instant.elapsed().as_secs_f64();
+            last_instant = Instant::now();
             let challenge_active = opoi_challenge_active.load(Ordering::Relaxed)
                 || keryx_miner::pom_gpu::is_loading();
             let total = hashes_tried.swap(0, Ordering::AcqRel);
 
             if total > 0 {
-                // Mining normally: report aggregate + per-device rates.
                 zero_streak = 0;
                 let (rate, suffix) = Self::hash_suffix(total as f64 / duration);
                 info!("Current hashrate is {:.2} {}", rate, suffix);
@@ -530,25 +537,21 @@ impl MinerManager {
                 continue;
             }
 
-            // No hashes this tick — keep the per-device counters drained for the next window.
             for (_device, counter) in &*hashes_by_worker.lock().unwrap() {
                 counter.store(0, Ordering::Release);
             }
 
             if challenge_active {
-                // PoW is intentionally paused while the GPU runs inference / loads a model.
                 zero_streak = 0;
                 info!("OPoI inference in progress — PoW paused, stand by");
             } else {
                 zero_streak = zero_streak.saturating_add(1);
                 if zero_streak >= STALL_GRACE_TICKS {
-                    // Sustained zeros outside an inference pause — this is a real problem.
                     warn!("Workers stalled or crashed. Consider reducing workload and check that your node is synced");
                     for (device, _) in &*hashes_by_worker.lock().unwrap() {
                         warn!("Device {}: 0 hash/s", device);
                     }
                 } else {
-                    // Transient pause (model load/eviction or template gap) — not a crash yet.
                     info!("PoW paused (OPoI inference / model load) — stand by");
                 }
             }


### PR DESCRIPTION
## Problem

#[tokio::main] with 
t-multi-thread spawns one Tokio worker per logical CPU. On large rigs (HiveOS, many-core hosts) the miner’s async workload is tiny — a single gRPC or stratum connection, a few spawned tasks, and periodic timers — so dozens of idle executor threads sit around consuming scheduler overhead and memory.

Two additional sources of unnecessary wakeups:

- The gRPC listen loop used a fixed 200 ms interval tick even when no OPoI inference was in flight, waking the runtime 5×/s while mining normally.
- The reconnect loop called std::thread::sleep(100 ms), blocking a Tokio worker thread on every disconnect.
- Hashrate logging ran as a 	okio::spawn task on the same runtime, competing for one of the few workers that actually matter.

The default spawn_blocking pool (up to 512 threads) was also uncapped relative to the miner’s real blocking needs (model prefetch, SLM inference, IPFS upload).

## Solution

- Replace #[tokio::main] with a manually built multi-thread runtime: **2 async workers** and **4 blocking threads** by default, overridable via KERYX_ASYNC_WORKERS and KERYX_BLOCKING_THREADS.
- Use 	okio::time::sleep in the reconnect loop so workers are yielded instead of blocked.
- Refactor gRPC listen:
  - **Idle** (no inference in flight): block only on stream.message().await — zero artificial polling.
  - **Regular inference**: select! between stream messages and wait on the inference oneshot (wait_regular_inference).
  - **Challenge inference** (sole-producer keepalive): slow 2 s sleep + GetBlockTemplate ping instead of a 200 ms timer.
- Move hashrate logging to a dedicated std::thread with 	hread::sleep, freeing Tokio workers from periodic housekeeping.
- Trim Tokio crate features to 
t-multi-thread, 	ime, sync, 
et (drop macros).

## Tests

Not run in CI on this machine — local cargo check requires CUDA toolkit access (Windows host without NVIDIA admin permissions). Changes are confined to the async/control plane; mining hot paths (GPU PoW / PoM kernels) are untouched.

Manual verification checklist:

- [ ] Miner connects to keryxd and receives block templates on a synced node.
- [ ] Hashrate log lines still appear every ~10 s during mining.
- [ ] OPoI inference completes and submits AiResponse after an AiRequest block.
- [ ] Node-issued inference challenge response is delivered on a sole-producer setup.
- [ ] Reconnect after keryxd restart does not hang.
- [ ] 	op / htop shows far fewer idle Tokio threads on a 32+ core rig vs main.

## Risks

- Challenge keepalive is slower (2 s vs 200 ms) on sole-producer nodes; response delivery may lag slightly, but should still avoid the mining deadlock the original timer guarded against.
- max_blocking_threads(4) may bottleneck parallel prefetch on very slow networks; raise via KERYX_BLOCKING_THREADS=8 if boot-time model download contends.
- Any external tooling that assumed 
um_cpus Tokio workers will see a behavior change (intentional).
