### PR TITLE
perf(runtime): reduce RAM usage on multi-core rigs and long OPoI sessions

### DIFF
--- a/src/client/grpc.rs
+++ b/src/client/grpc.rs
@@ -8,6 +8,12 @@ use crate::proto::{
     NotifyBlockAddedRequestMessage, NotifyNewBlockTemplateRequestMessage,
 };
 use crate::{miner::MinerManager, Error};
+
+/// Max AiRequest queue size — drop oldest when full to prevent unbounded memory growth.
+const MAX_AI_QUEUE_SIZE: usize = 64;
+/// Max unique stable-ids tracked for deduplication — evict when full.
+const MAX_AI_SEEN_IDS: usize = 10_000;
+
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use log::{error, info, warn};
@@ -343,6 +349,16 @@ impl KeryxdHandler {
                     info!("OPoI: queued AiRequest id={}", stable_id);
                     self.ai_seen_prefixes.insert(stable_id.clone());
                     self.ai_request_queue.push_back((stable_id.clone(), raw, model_id, prompt, max_tokens));
+                    while self.ai_request_queue.len() > MAX_AI_QUEUE_SIZE {
+                        self.ai_request_queue.pop_front();
+                    }
+                    while self.ai_seen_prefixes.len() > MAX_AI_SEEN_IDS {
+                        self.ai_seen_prefixes.clear();
+                        self.ai_seen_prefixes.shrink_to_fit();
+                        for (sid, _, _, _, _) in &self.ai_request_queue {
+                            self.ai_seen_prefixes.insert(sid.clone());
+                        }
+                    }
                 }
                 // Track txid for escrow claims. Prefer verbose_data.transaction_id when
                 // present, fall back to computing the txid from the transaction fields —
@@ -522,7 +538,7 @@ impl KeryxdHandler {
                 if let Some(block) = notif.block {
                     if !block.transactions.is_empty() {
                         // Full block — scan directly.
-                        self.scan_txs_for_ai_requests(&block.transactions.clone());
+                        self.scan_txs_for_ai_requests(&block.transactions);
                         self.try_start_inference();
                         // Escrow: check for new escrow UTXOs and mature claims.
                         let claim_tx = self.escrow_watcher.as_mut().and_then(|w| w.handle_block(&block));
@@ -610,7 +626,7 @@ impl KeryxdHandler {
                     return Ok(());
                 }
                 if let Some(ref block) = template.block {
-                    self.scan_txs_for_ai_requests(&block.transactions.clone());
+                    self.scan_txs_for_ai_requests(&block.transactions);
                 }
                 self.try_start_inference();
                 // Pause GPU mining while any inference is in flight (GPU is occupied by the model).
@@ -637,7 +653,7 @@ impl KeryxdHandler {
                 if let Some(e) = msg.error {
                     warn!("GetBlockResponse error: {}", e.message);
                 } else if let Some(block) = msg.block {
-                    self.scan_txs_for_ai_requests(&block.transactions.clone());
+                    self.scan_txs_for_ai_requests(&block.transactions);
                     self.try_start_inference();
                     let claim_tx = self.escrow_watcher.as_mut().and_then(|w| w.handle_block(&block));
                     if let Some(tx) = claim_tx {

--- a/src/client/stratum.rs
+++ b/src/client/stratum.rs
@@ -64,6 +64,10 @@ struct CurrentTask {
 /// Shared inference result cache — persists across block changes so that if the
 /// same AiRequest is included in multiple consecutive job templates the miner can
 /// immediately submit with a CID once inference completed for the first occurrence.
+
+/// Max cached inference results — evict when full to prevent unbounded growth.
+const MAX_INFERENCE_CACHE_SIZE: usize = 1_000;
+
 struct InferenceCacheInner {
     /// stable_id → base58 CIDv0 string returned by IPFS after upload.
     results: HashMap<String, String>,
@@ -773,6 +777,10 @@ fn run_inference_and_upload(
     let mut guard = cache.blocking_lock();
     guard.in_progress.remove(&stable_id);
     if let Some(cid) = cid_opt {
+        if guard.results.len() >= MAX_INFERENCE_CACHE_SIZE {
+            guard.results.clear();
+            guard.results.shrink_to_fit();
+        }
         guard.results.insert(stable_id, cid);
     }
 }

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -425,7 +425,10 @@ impl MinerManager {
         let mut nonce = Wrapping(thread_rng().next_u64());
         let mut mask = Wrapping(0);
         let mut fixed = Wrapping(0);
-        std::thread::spawn(move || {
+        std::thread::Builder::new()
+            .name("cpu-miner".into())
+            .stack_size(256 * 1024)
+            .spawn(move || {
             (|| {
                 let mut state = None;
 
@@ -495,7 +498,7 @@ impl MinerManager {
                 error!("CPU thread crashed: {}", e.to_string());
                 e
             })
-        })
+        }).expect("failed to spawn cpu-miner thread")
     }
 
     async fn log_hashrate(


### PR DESCRIPTION
## Problem

On large rigs the miner allocates far more memory than its control-plane and mining loops require:

- Each CPU mining thread uses the Rust default stack size (~8 MB virtual per thread). On a 128-core host that is ~1 GB of virtual memory for stacks alone, with no benefit to the tight PoW/PoM loop.
- The gRPC handler clones the full block transaction list on every `BlockAdded`, block template, and `GetBlockResponse` scan (`block.transactions.clone()`), allocating ~200–300 KB per event even though `scan_txs_for_ai_requests` only needs a reference.
- OPoI backpressure can grow `ai_request_queue` and `ai_seen_prefixes` without bound when inference lags behind block production; each entry carries raw payload bytes and prompt strings.
- Stratum pool mode keeps a persistent `inference_cache` (`stable_id → CID`) that never evicts entries, so long sessions with many distinct AiRequests accumulate unbounded `HashMap` growth.

## Solution

- CPU miner threads: `thread::Builder` with **256 KB** stack (`stack_size(256 * 1024)`) instead of the ~8 MB default.
- gRPC: pass `&block.transactions` directly to `scan_txs_for_ai_requests` — remove three redundant `.clone()` calls per block/template path.
- gRPC: cap `ai_request_queue` at **64** (drop oldest) and `ai_seen_prefixes` at **10 000** (clear + rebuild from queue when full).
- Stratum: cap inference result cache at **1 000** entries (clear + `shrink_to_fit` before insert when full).

Mining hot paths (GPU PoW / PoM kernels, SLM inference logic) are untouched.

## Tests

Not run in CI on this machine — local `cargo check` requires CUDA toolkit access (Windows host without NVIDIA admin permissions). Changes are confined to memory bounds and reference passing; hashing and submission paths are unchanged.

Manual verification checklist:

- [ ] Miner connects to keryxd and receives block templates on a synced node.
- [ ] CPU mining threads spawn and report hashrate on a multi-core host.
- [ ] OPoI inference completes and submits AiResponse after an AiRequest block.
- [ ] Stratum pool mode reuses cached CIDs for repeated AiRequests in consecutive jobs.
- [ ] `top` / `htop` shows lower virtual memory vs main on a 32+ core rig (stacks dominate).
- [ ] Long OPoI-heavy session does not show unbounded RSS growth from queues/cache.

## Risks

- **256 KB stack** is sufficient for the current CPU miner loop but would need revisiting if deep recursion or large stack frames are added to that thread.
- **Queue eviction** drops the oldest pending AiRequest when the queue exceeds 64 — under extreme inference backpressure a request may never be served (same trade-off as bounding memory).
- **`ai_seen_prefixes` clear** briefly allows re-queuing of IDs already evicted from the queue; dedup is restored from the surviving queue contents.
- **Inference cache clear** forces a re-inference if an evicted `stable_id` reappears in a later job template (rare for pool workloads with rolling jobs).