### PR TITLE
build(llama): add "no-avx" line for CPUs without AVX2/FMA

### DIFF
--- a/hiveos/build-keryx-llama.sh
+++ b/hiveos/build-keryx-llama.sh
@@ -20,8 +20,11 @@ case "$LINE" in
   modern) ARCHS="75;80;86;89;90;120"; CUDAMOUNT=(); KCUDA=/usr/local/cuda ;;
   legacy) ARCHS="70;75;80;86;89;90";  CUDAMOUNT=(-v /tmp/cuda124:/opt/cuda:ro); KCUDA=/opt/cuda ;;
   pascal) ARCHS="60;61";              CUDAMOUNT=(-v /tmp/cuda124:/opt/cuda:ro); KCUDA=/opt/cuda ;;
-  *) echo "usage: $0 <modern|legacy|pascal> [JOBS]"; exit 1 ;;
+  no-avx) ARCHS="70;75;80;86;89;90";  CUDAMOUNT=(-v /tmp/cuda124:/opt/cuda:ro); KCUDA=/opt/cuda
+          CPUFLAGS="-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF" ;;
+  *) echo "usage: $0 <modern|legacy|pascal|no-avx> [JOBS]"; exit 1 ;;
 esac
+: "${CPUFLAGS:=}"
 OUT="$REPO/hiveos/dist-$LINE"
 mkdir -p "$OUT"
 SRC=/tmp/llama-src-$TAG
@@ -31,7 +34,7 @@ fi
 
 docker run --rm --network host \
   -v "$SRC":/llama -v "$REPO":/repo:ro -v "$OUT":/out "${CUDAMOUNT[@]}" \
-  -e KCUDA="$KCUDA" -e ARCHS="$ARCHS" -e JOBS="$JOBS" -e KERYX_SPIKE="${KERYX_SPIKE:-0}" \
+  -e KCUDA="$KCUDA" -e ARCHS="$ARCHS" -e JOBS="$JOBS" -e CPUFLAGS="$CPUFLAGS" -e KERYX_SPIKE="${KERYX_SPIKE:-0}" \
   keryx-build:offline bash -euo pipefail -c '
     if [ ! -x /tmp/cmk/bin/cmake ]; then
       curl -sL https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-linux-x86_64.tar.gz \
@@ -42,7 +45,7 @@ docker run --rm --network host \
     /tmp/cmk/bin/cmake -S /llama -B $B -DGGML_CUDA=ON \
       -DCMAKE_CUDA_ARCHITECTURES="$ARCHS" -DBUILD_SHARED_LIBS=OFF \
       -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-      -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF -DGGML_CUDA_NCCL=OFF -DCMAKE_BUILD_TYPE=Release \
+      -DLLAMA_CURL=OFF -DGGML_NATIVE=OFF $CPUFLAGS -DGGML_CUDA_NCCL=OFF -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_CUDA_COMPILER=$KCUDA/bin/nvcc
     /tmp/cmk/bin/cmake --build $B --target llama -j "$JOBS"
     g++ -O2 -std=c++17 -shared -fPIC -fopenmp /repo/tools/keryx-llama/keryx_llama.cpp \


### PR DESCRIPTION
## Summary
Adds a `no-avx` build line to `hiveos/build-keryx-llama.sh` so `libkeryx-llama.so`
can be produced for CPUs that lack AVX2/FMA. Existing `modern`/`legacy`/`pascal`
lines are unchanged.

## Problem
On older CPUs the miner dies at startup with `Illegal instruction` (SIGILL),
e.g. Intel G3930, and Celeron 847 / Pentium G2030 (Intel fuses AVX off on many
Celeron/Pentium parts, so they have no AVX at all).

Root cause: the cmake call passes `-DGGML_NATIVE=OFF`, but in llama.cpp that only
disables `-march=native` — `GGML_AVX2`, `GGML_FMA` and `GGML_F16C` still default
to ON. The shipped `libkeryx-llama.so` therefore contains AVX2/FMA and SIGILLs at
load on any CPU without them. The Rust binary itself is fine (no `target-cpu=native`),
so only the llama lib is affected.

## Fix
New `no-avx` line reusing legacy's CUDA/archs, with a `CPUFLAGS` var that adds
`-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF` for that line only
(empty for the others). Pure-SSE ggml baseline.

## Testing
Built the `no-avx` variant and ran it on the worst case — Celeron 847 and Pentium
G2030 (no AVX at all). Miner starts, `Illegal instruction` is gone, hashrate and
accepted blocks are normal.

## Impact
CPU-inference baseline only. GPU rigs are unaffected: PoM/inference runs on CUDA,
so mining throughput is unchanged — this just stops the load-time SIGILL.

Discussed on Discord with @Slash / @Dragonkeepr (old-CPU crash thread).