### PR TITLE
fix(llama): ship forward-compatible CUDA kernels

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -138,9 +138,10 @@ fn build_keryx_llama(nvcc: &str) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let build_dir = target_root.join(format!("llama-build-{LLAMA_TAG}"));
-    // "native" targets the GPU(s) present at build time; headless builders must pass
-    // an explicit list, e.g. KERYX_LLAMA_ARCHS="75;80;86;89;90".
-    let archs = env::var("KERYX_LLAMA_ARCHS").unwrap_or_else(|_| "native".to_string());
+    // Ship real kernels for common GPUs plus compute_89 PTX, which drivers JIT-forward
+    // to newer architectures such as Blackwell. Override for machine-specific builds.
+    let archs = env::var("KERYX_LLAMA_ARCHS")
+        .unwrap_or_else(|_| "75-real;80-real;86-real;89-real;89-virtual".to_string());
     run(
         "cmake configure of llama.cpp (if it cannot detect a GPU, set KERYX_LLAMA_ARCHS explicitly)",
         std::process::Command::new("cmake")


### PR DESCRIPTION
## Summary

Changes the default llama.cpp CUDA architecture list from `native` to explicit
device kernels for common NVIDIA GPUs plus `compute_89` PTX for newer GPUs.
`KERYX_LLAMA_ARCHS` still overrides the default for machine-specific builds.

## Problem

The official v0.3.7 Windows `keryx-llama.dll` contains CUDA images for `sm_52`
and `sm_86`, with no PTX fallback. On an RTX 5070 Ti (`sm_120`), OPoI inference
fails in `egml_cuda_kernel_can_use_pdl` with:

```text
CUDA error: no kernel image is available for execution on the device
```

PoW mining is unaffected because it uses a separate CUDA plugin that already
ships compatible Blackwell code.

The llama build currently defaults `CMAKE_CUDA_ARCHITECTURES` to `native`, so a
release built without `KERYX_LLAMA_ARCHS` only contains kernels for the GPU in
the build machine.

## Fix

The default architecture list now includes native kernels for `sm_75`, `sm_80`,
`sm_86`, and `sm_89`, plus `compute_89` PTX. NVIDIA drivers can JIT the PTX for
newer architectures such as Blackwell without requiring the build machine to
have an RTX 50-series GPU.

## Testing

- Built the pinned llama.cpp CUDA targets with CUDA 13.3.
- Linked and inspected the resulting Windows DLL with `cuobjdump`.
- Confirmed 553 native cubins across `sm_75`, `sm_80`, `sm_86`, and `sm_89`.
- Confirmed 138 `sm_89` PTX entries for forward JIT compilation.
- Confirmed `git diff --check` passes.

The DLL has not been run on an RTX 50-series card because one is not available
locally. Binary inspection confirms that the missing compatible kernel image is
addressed, but runtime testing on Blackwell is still requested.

This PR was made with AI.
