### PR TITLE
fix(pom): add VRAM headroom to tier floors so 8/12 GB cards keep their tier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -241,10 +241,10 @@ fn check_gpu_power_limit(needs_high: bool, needs_very_high: bool) {
 /// for the smallest tiers (never gated out of `ai:cap`) and so can't rank tier 0 vs 1 by VRAM.
 /// Largest tier first, so a device picks the biggest tier it can hold.
 const POM_TIER_LADDER: &[(keryx_miner::models::Tier, u64)] = &[
-    (keryx_miner::models::Tier::VeryHigh, 30_000),
-    (keryx_miner::models::Tier::High, 24_000),
-    (keryx_miner::models::Tier::Default, 12_000),
-    (keryx_miner::models::Tier::Light, 8_000),
+    (keryx_miner::models::Tier::VeryHigh, 28_000),
+    (keryx_miner::models::Tier::High, 22_000),
+    (keryx_miner::models::Tier::Default, 11_000),
+    (keryx_miner::models::Tier::Light, 7_000),
     (keryx_miner::models::Tier::VeryLight, 2_000),
 ];
 


### PR DESCRIPTION
## Summary
Lowers the `POM_TIER_LADDER` floors by ~1 GB each so a GPU whose reported VRAM
sits just below a nominal boundary still gets its intended tier. Fixes 8 GB and
12 GB cards silently dropping one tier.

## Problem
On 8 GB cards with no flag, the miner correctly rejects GLM-4-9B (Default, ≥12 GB)
but then drops **two** tiers to EXAONE instead of landing on Light (Mistral-7B).
Same on a 12 GB 3080 Ti: it lands on Mistral instead of GLM. Every card is one
tier too low. Reproduced on a plain desktop RTX 3070 FE (8192 MiB), so it isn't a
laptop/carve-out artifact.

Root cause: the floors sit exactly at nominal VRAM (Light 8000, Default 12000),
but tier assignment uses `cuDeviceTotalMem` (`query_all_gpus_vram`), which reports
slightly under nominal — more so on newer CUDA drivers (13.3 here). A 3070 reads
~7900 (<8000 → EXAONE); a 3080 Ti reads ~11950 (<12000 → Mistral). Miners on older
drivers (report closer to nominal) get the right tier — matching the "works for
them, not me" reports.

## Fix
Give each floor ~1 GB headroom: Light 8000→7000, Default 12000→11000,
High 24000→22000, VeryHigh 30000→28000. Real 6 GB cards still read ~5800 < 7000,
so the deliberate Q6_K gating noted in the Mistral spec ("6 GB stays on tier 0,
8 GB serves tier 1") is preserved.

## Testing
Not verified on hardware — rebuilding just the binary crashes with a TypeId
mismatch against the shipped `libkeryxcuda.so` plugin (my rustc/deps differ from
the build env), so I couldn't run my own build. Code-analysis-backed only. My
8 GB / 12 GB rigs are available to confirm once there's a build from the canonical
environment. Discussed with @Slash on Discord.