### PR TITLE
fix(build): wrap libloading::Library::new calls in unsafe blocks

### DIFF
--- a/src/llama_engine.rs
+++ b/src/llama_engine.rs
@@ -89,7 +89,7 @@ pub fn ensure_loaded(gguf: &str, gpu: usize) -> bool {
     let Some(so) = so_path() else { return false };
     // Never unloaded (the old dlopen path never dlclosed either): the Engine keeps raw fn
     // pointers into the library for the life of the process, so leak it deliberately.
-    let lib: &'static libloading::Library = match libloading::Library::new(&so) {
+    let lib: &'static libloading::Library = match unsafe { libloading::Library::new(&so) } {
         Ok(l) => Box::leak(Box::new(l)),
         Err(e) => {
             log::warn!("llama engine: load({}) failed: {} — inference unavailable.", so.display(), e);

--- a/src/slm.rs
+++ b/src/slm.rs
@@ -301,7 +301,7 @@ pub fn probe_gpu_inference() -> GpuProbe {
     // Windows nvcc links cudart statically into keryx-llama.dll, so only cuBLAS is probed.
     // Each probe Library is dropped immediately — we only care that it CAN load; the
     // engine (re-)loads it for real later, and the OS loader refcounts it.
-    let loads = |candidates: &[&str]| candidates.iter().any(|so| libloading::Library::new(so).is_ok());
+    let loads = |candidates: &[&str]| candidates.iter().any(|so| unsafe { libloading::Library::new(so) }.is_ok());
     #[cfg(windows)]
     let ok = loads(&["cublas64_12.dll"]);
     #[cfg(not(windows))]


### PR DESCRIPTION
## Summary
- `src/llama_engine.rs` and `src/slm.rs` called the `unsafe fn libloading::Library::new` outside an `unsafe` block, left over from the Windows llama engine port (6dbf35b). This fails to compile under rustc 1.97 (E0133).
- Wrapped both call sites in `unsafe { ... }`.

## Test plan
- [x] `cargo build --release --bin keryx-miner` succeeds (Linux, CUDA 12.2, sm_86)
- [x] `keryx-miner --version` reports 0.3.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)