### PR TITLE
fix: reuse local models, bundle IPFS/CUDA, PoM SM by GPU gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ escrow_state.json
 
 target-hive/
 Cargo.lock
+
+# Local build/package outputs
+/dist/
+/target-linux/
+/target-windows/
+/target-cuda/

--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
     {
         let out_dir = env::var("OUT_DIR").unwrap();
-        let sm_list = env::var("POM_SM_LIST").unwrap_or_else(|_| "90,89,86,80,75,70,61".to_string());
+        // Default covers RTX 50 (120), Hopper (90), RTX 40 (89), RTX 30 (86), plus older fallbacks.
+        // sm_120 needs CUDA toolkit ≥ 12.8; older toolkits get a placeholder and runtime skips it.
+        let sm_list = env::var("POM_SM_LIST").unwrap_or_else(|_| "120,90,89,86,80,75,70,61".to_string());
         let sms: Vec<String> = sm_list
             .split(',')
             .map(str::trim)
@@ -40,14 +42,62 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .collect();
         assert!(!sms.is_empty(), "POM_SM_LIST resolved to an empty set");
 
-        for sm in sms {
+        // Always materialize every PTX slot `pom_gpu.rs` include_str!'s, even if not in POM_SM_LIST.
+        let required_sms = ["120", "90", "89", "86", "80", "75", "70", "61"];
+        let mut build_sms: Vec<String> = sms;
+        for sm in required_sms {
+            if !build_sms.iter().any(|s| s == sm) {
+                build_sms.push(sm.to_string());
+            }
+        }
+
+        // Optional: reuse prebuilt PTX (e.g. compiled under WSL) when local nvcc cannot host-compile
+        // (MSVC missing on Windows, or mismatched gcc). Expected files: pom_mine_sm{SM}.ptx
+        let prebuilt_ptx_dir = env::var("POM_PTX_DIR").ok();
+        println!("cargo:rerun-if-env-changed=POM_PTX_DIR");
+        println!("cargo:rerun-if-env-changed=NVCC_FLAGS");
+
+        for sm in build_sms {
             let ptx = format!("{out_dir}/pom_mine_sm{sm}.ptx");
-            let output = std::process::Command::new(&nvcc)
-                .args(["-ptx", "-O3", &format!("-arch=sm_{sm}"), "cuda/pom_mine.cu", "-o", &ptx])
+            if let Some(ref dir) = prebuilt_ptx_dir {
+                let src = format!("{dir}/pom_mine_sm{sm}.ptx");
+                if std::path::Path::new(&src).exists() {
+                    fs::copy(&src, &ptx).unwrap_or_else(|e| {
+                        panic!("failed copying prebuilt PTX {src} -> {ptx}: {e}")
+                    });
+                    continue;
+                }
+            }
+
+            let mut cmd = std::process::Command::new(&nvcc);
+            cmd.args(["-ptx", "-O3", &format!("-arch=sm_{sm}")]);
+            // Host gcc 15+ (Ubuntu 25+/WSL) is rejected by CUDA 12.8; allow override.
+            // Extra flags via NVCC_FLAGS (space-separated).
+            cmd.arg("-allow-unsupported-compiler");
+            if let Ok(extra) = env::var("NVCC_FLAGS") {
+                for flag in extra.split_whitespace() {
+                    cmd.arg(flag);
+                }
+            }
+            cmd.args(["cuda/pom_mine.cu", "-o", &ptx]);
+            let output = cmd
                 .output()
                 .unwrap_or_else(|e| panic!("nvcc ({nvcc}) failed to run for sm_{sm}: {e}"));
             if !output.status.success() {
                 let stderr = String::from_utf8_lossy(&output.stderr);
+                // sm_120 is optional on older toolkits (needs CUDA ≥ 12.8). Leave a stub so
+                // include_str! still resolves; runtime selection skips non-PTX stubs.
+                if sm == "120" {
+                    println!(
+                        "cargo:warning=nvcc could not emit pom_mine sm_120 PTX (need CUDA ≥ 12.8); RTX 50 will fall back to sm_89/sm_86. stderr:\n{stderr}"
+                    );
+                    fs::write(
+                        &ptx,
+                        "// pom_mine sm_120 unavailable — rebuild with CUDA toolkit ≥ 12.8\n",
+                    )
+                    .unwrap_or_else(|e| panic!("failed writing sm_120 placeholder {ptx}: {e}"));
+                    continue;
+                }
                 panic!(
                     "nvcc failed to compile cuda/pom_mine.cu for sm_{sm}:\n{}",
                     stderr
@@ -157,6 +207,8 @@ fn build_keryx_llama(nvcc: &str) -> Result<(), Box<dyn std::error::Error>> {
                 "-DGGML_CUDA_NCCL=OFF",
                 "-DCMAKE_BUILD_TYPE=Release",
                 &format!("-DCMAKE_CUDA_COMPILER={nvcc}"),
+                // CUDA 12.8 host-check rejects gcc 15+; keep builds working on current Ubuntu/WSL.
+                "-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler",
             ]),
     )?;
     let jobs = env::var("NUM_JOBS").unwrap_or_else(|_| "8".to_string());

--- a/scripts/build-linux-docker.sh
+++ b/scripts/build-linux-docker.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Build Linux/HiveOS release artifacts inside CUDA 12.8 + Ubuntu 22.04 (glibc/gcc compatible).
+set -euo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE="${KERYX_BUILD_IMAGE:-docker.io/nvidia/cuda:12.8.1-devel-ubuntu22.04}"
+TARGET_DIR="${CARGO_TARGET_DIR:-target-linux}"
+
+docker pull "${IMAGE}"
+
+docker run --rm --network host \
+  -v "${REPO}:/src" -w /src \
+  -e CARGO_TARGET_DIR="/src/${TARGET_DIR}" \
+  -e POM_SM_LIST=120,90,89,86,80,75,70,61 \
+  -e CUDA_COMPUTE_CAP=89 \
+  -e KERYX_LLAMA_ARCHS='75-real;80-real;86-real;89-real;120-real;89-virtual' \
+  -e NUM_JOBS="${NUM_JOBS:-8}" \
+  -e NVCC=/usr/local/cuda/bin/nvcc \
+  -e CUDA_PATH=/usr/local/cuda \
+  -e CUDA_HOME=/usr/local/cuda \
+  "${IMAGE}" \
+  bash -euo pipefail -c '
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y -qq curl build-essential pkg-config libssl-dev ca-certificates \
+      protobuf-compiler cmake git >/dev/null
+    if ! command -v cargo >/dev/null; then
+      curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+    fi
+    # shellcheck disable=SC1091
+    . "$HOME/.cargo/env"
+    export PATH="/usr/local/cuda/bin:$PATH"
+    echo "nvcc=$(nvcc --version | head -4 | tr "\n" " ")"
+    echo "gcc=$(gcc --version | head -1)"
+    cargo build --release --bin keryx-miner
+    cargo build --release -p keryxcuda
+    ls -lh "/src/'"${TARGET_DIR}"'/release/keryx-miner" \
+           "/src/'"${TARGET_DIR}"'/release/libkeryx-llama.so" \
+           "/src/'"${TARGET_DIR}"'/release/libkeryxcuda.so"
+  '
+
+echo "Linux build complete → ${REPO}/${TARGET_DIR}/release"

--- a/scripts/build-linux-wsl.sh
+++ b/scripts/build-linux-wsl.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Full Linux/HiveOS release build inside WSL.
+set -euo pipefail
+export PATH="/usr/local/cuda/bin:${HOME}/.local/bin:${HOME}/.cargo/bin:${PATH}"
+export PROTOC="${PROTOC:-${HOME}/.local/bin/protoc}"
+export CUDA_PATH=/usr/local/cuda
+export CUDA_HOME=/usr/local/cuda
+export NVCC=/usr/local/cuda/bin/nvcc
+export POM_SM_LIST="${POM_SM_LIST:-120,90,89,86,80,75,70,61}"
+export CUDA_COMPUTE_CAP="${CUDA_COMPUTE_CAP:-89}"
+# Include Blackwell real arch when toolkit supports it; virtual 89 remains a JIT fallback.
+export KERYX_LLAMA_ARCHS="${KERYX_LLAMA_ARCHS:-75-real;80-real;86-real;89-real;89-virtual;120-real}"
+export NUM_JOBS="${NUM_JOBS:-8}"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target-linux}"
+# CUDA 12.8 rejects host gcc > 14 (Ubuntu 25+/WSL often ships 15).
+export NVCC_FLAGS="${NVCC_FLAGS:--allow-unsupported-compiler}"
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO}"
+
+echo "protoc=$(${PROTOC} --version)"
+echo "nvcc=$(${NVCC} --version | head -1)"
+echo "gcc=$(gcc --version | head -1)"
+echo "Starting Linux build at $(date) → ${CARGO_TARGET_DIR}"
+
+# llama.cpp/nvcc also needs the unsupported-compiler escape on gcc 15+.
+export CMAKE_CUDA_FLAGS="-allow-unsupported-compiler ${CMAKE_CUDA_FLAGS:-}"
+export CUDAFLAGS="-allow-unsupported-compiler ${CUDAFLAGS:-}"
+
+cargo build --release --bin keryx-miner
+echo "BIN_OK $(date)"
+cargo build --release -p keryxcuda
+echo "DONE $(date)"
+ls -lh "${CARGO_TARGET_DIR}/release/keryx-miner" \
+       "${CARGO_TARGET_DIR}/release/libkeryx-llama.so" \
+       "${CARGO_TARGET_DIR}/release/libkeryxcuda.so"

--- a/scripts/build-ptx-wsl.sh
+++ b/scripts/build-ptx-wsl.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH="/usr/local/cuda/bin:${PATH}"
+NVCC="${NVCC:-/usr/local/cuda/bin/nvcc}"
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="${REPO}/dist/ptx"
+mkdir -p "${OUT}"
+cd "${REPO}"
+for sm in 120 90 89 86 80 75 70 61; do
+  echo "=== sm_${sm} ==="
+  if "${NVCC}" -ptx -O3 -allow-unsupported-compiler -arch="sm_${sm}" \
+      cuda/pom_mine.cu -o "${OUT}/pom_mine_sm${sm}.ptx"; then
+    ls -lh "${OUT}/pom_mine_sm${sm}.ptx"
+  else
+    echo "FAILED sm_${sm}"
+    if [ "${sm}" = "120" ]; then
+      echo "// pom_mine sm_120 unavailable" > "${OUT}/pom_mine_sm${sm}.ptx"
+    else
+      exit 1
+    fi
+  fi
+done
+ls -lh "${OUT}"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Build release archives with runtime deps bundled (CUDA libs + Kubo IPFS).
+#
+# Usage:
+#   ./scripts/package-release.sh windows   # from MSYS/Git Bash on Windows (binaries already built)
+#   ./scripts/package-release.sh hiveos    # from Linux/WSL (binaries already built)
+#   ./scripts/package-release.sh all       # package whatever local artifacts exist
+#
+# Env:
+#   VERSION          default: Cargo.toml version + -OPoI
+#   DIST_DIR         default: dist
+#   WIN_TARGET_DIR   default: target/release
+#   LINUX_TARGET_DIR default: target/release  (or target-cuda/release)
+#   CUDA_WIN_BIN     Windows CUDA bin dir (auto-detect 12.x)
+#   KUBO_VERSION     default: 0.41.0
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+VERSION="${VERSION:-$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)-OPoI}"
+DIST_DIR="${DIST_DIR:-$REPO/dist}"
+WIN_TARGET_DIR="${WIN_TARGET_DIR:-$REPO/target/release}"
+LINUX_TARGET_DIR="${LINUX_TARGET_DIR:-$REPO/target/release}"
+if [[ ! -x "$LINUX_TARGET_DIR/keryx-miner" && -x "$REPO/target-cuda/release/keryx-miner" ]]; then
+  LINUX_TARGET_DIR="$REPO/target-cuda/release"
+fi
+KUBO_VERSION="${KUBO_VERSION:-0.41.0}"
+DEPS_CACHE="${DEPS_CACHE:-$REPO/dist/deps-cache}"
+mkdir -p "$DIST_DIR" "$DEPS_CACHE"
+
+log() { echo "==> $*"; }
+
+fetch() {
+  local url="$1" out="$2"
+  if [[ -f "$out" ]]; then
+    return 0
+  fi
+  log "Downloading $(basename "$out")"
+  curl -fsSL --retry 5 --retry-delay 2 -o "$out.partial" "$url"
+  mv "$out.partial" "$out"
+}
+
+ensure_kubo() {
+  local os="$1" # windows|linux
+  local arch="amd64"
+  local ext archive bin
+  if [[ "$os" == "windows" ]]; then
+    ext="zip"
+    archive="$DEPS_CACHE/kubo_v${KUBO_VERSION}_windows-${arch}.zip"
+    bin="ipfs.exe"
+  else
+    ext="tar.gz"
+    archive="$DEPS_CACHE/kubo_v${KUBO_VERSION}_linux-${arch}.tar.gz"
+    bin="ipfs"
+  fi
+  fetch "https://dist.ipfs.tech/kubo/v${KUBO_VERSION}/kubo_v${KUBO_VERSION}_${os}-${arch}.${ext}" "$archive"
+  local extract_dir="$DEPS_CACHE/kubo-${os}"
+  rm -rf "$extract_dir"
+  mkdir -p "$extract_dir"
+  if [[ "$ext" == "zip" ]]; then
+    unzip -qo "$archive" -d "$extract_dir"
+  else
+    tar -xzf "$archive" -C "$extract_dir"
+  fi
+  local found
+  found="$(find "$extract_dir" -type f -name "$bin" | head -1)"
+  [[ -n "$found" ]] || { echo "ERROR: $bin not found in kubo archive"; exit 1; }
+  chmod a+rx "$found" 2>/dev/null || true
+  echo "$found"
+}
+
+copy_win_cuda() {
+  local dest="$1"
+  local cuda_bin="${CUDA_WIN_BIN:-}"
+  if [[ -z "$cuda_bin" ]]; then
+    for v in v12.8 v12.6 v12.5 v12.4 v12.2 v12.1 v12.0; do
+      local candidate="/c/Program Files/NVIDIA GPU Computing Toolkit/CUDA/${v}/bin"
+      if [[ -f "$candidate/cublas64_12.dll" ]]; then
+        cuda_bin="$candidate"
+        break
+      fi
+    done
+  fi
+  [[ -n "$cuda_bin" && -f "$cuda_bin/cublas64_12.dll" ]] || {
+    echo "ERROR: Windows CUDA 12 bin dir with cublas64_12.dll not found (set CUDA_WIN_BIN)"
+    exit 1
+  }
+  log "Bundling Windows CUDA libs from $cuda_bin"
+  cp -f "$cuda_bin/cublas64_12.dll" "$dest/"
+  cp -f "$cuda_bin/cublasLt64_12.dll" "$dest/"
+  # Optional helpers some hosts still dlopen
+  [[ -f "$cuda_bin/cudart64_12.dll" ]] && cp -f "$cuda_bin/cudart64_12.dll" "$dest/" || true
+  [[ -f "$cuda_bin/curand64_10.dll" ]] && cp -f "$cuda_bin/curand64_10.dll" "$dest/" || true
+}
+
+ensure_linux_cuda_libs() {
+  local dest="$1"
+  local stamp="$DEPS_CACHE/cuda12.2-libs"
+  mkdir -p "$stamp"
+  if [[ ! -f "$stamp/libcublas.so.12" ]]; then
+    log "Fetching CUDA 12.2 runtime debs (Ubuntu 22.04)"
+    local base="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64"
+    # Pin known 12.2 package filenames; refresh via Packages index if missing.
+    local pkgs=(
+      "libcublas-12-2_12.2.5.6-1_amd64.deb"
+      "cuda-cudart-12-2_12.2.140-1_amd64.deb"
+      "libcurand-12-2_10.3.3.141-1_amd64.deb"
+    )
+    local tmp="$DEPS_CACHE/cuda-debs"
+    mkdir -p "$tmp"
+    for pkg in "${pkgs[@]}"; do
+      fetch "$base/$pkg" "$tmp/$pkg"
+      rm -rf "$tmp/extract"
+      mkdir -p "$tmp/extract"
+      if command -v dpkg-deb >/dev/null 2>&1; then
+        dpkg-deb -x "$tmp/$pkg" "$tmp/extract"
+      else
+        (
+          cd "$tmp/extract"
+          ar x "$tmp/$pkg"
+          tar -xf data.tar.* 2>/dev/null || tar -xf data.tar
+        )
+      fi
+      # Collect versioned shared objects.
+      find "$tmp/extract" -type f \( -name 'libcublas.so.12*' -o -name 'libcublasLt.so.12*' \
+        -o -name 'libcudart.so.12*' -o -name 'libcurand.so.10*' \) -exec cp -a {} "$stamp/" \;
+    done
+    # Normalize unversioned soname symlinks expected by dlopen.
+    (
+      cd "$stamp"
+      [[ -e libcublas.so.12 ]] || ln -sf "$(ls libcublas.so.12.* 2>/dev/null | head -1)" libcublas.so.12
+      [[ -e libcublasLt.so.12 ]] || ln -sf "$(ls libcublasLt.so.12.* 2>/dev/null | head -1)" libcublasLt.so.12
+      [[ -e libcudart.so.12 ]] || ln -sf "$(ls libcudart.so.12.* 2>/dev/null | head -1)" libcudart.so.12
+      [[ -e libcurand.so.10 ]] || ln -sf "$(ls libcurand.so.10.* 2>/dev/null | head -1)" libcurand.so.10
+    )
+  fi
+  log "Bundling Linux CUDA 12.2 runtime libs"
+  cp -a "$stamp"/. "$dest/"
+}
+
+package_windows() {
+  local out_name="keryx-miner-v${VERSION}-win64-amd64"
+  local stage="$DIST_DIR/$out_name"
+  rm -rf "$stage"
+  mkdir -p "$stage"
+
+  [[ -f "$WIN_TARGET_DIR/keryx-miner.exe" ]] || { echo "ERROR: missing $WIN_TARGET_DIR/keryx-miner.exe"; exit 1; }
+  [[ -f "$WIN_TARGET_DIR/keryx-llama.dll" ]] || { echo "ERROR: missing $WIN_TARGET_DIR/keryx-llama.dll"; exit 1; }
+
+  cp -f "$WIN_TARGET_DIR/keryx-miner.exe" "$stage/"
+  cp -f "$WIN_TARGET_DIR/keryx-llama.dll" "$stage/"
+  if [[ -f "$WIN_TARGET_DIR/keryxcuda.dll" ]]; then
+    cp -f "$WIN_TARGET_DIR/keryxcuda.dll" "$stage/"
+  elif [[ -f "$WIN_TARGET_DIR/keryxcuda.dll" ]]; then
+    cp -f "$WIN_TARGET_DIR/keryxcuda.dll" "$stage/"
+  else
+    # plugin may live under plugins target
+    local plug
+    plug="$(find "$REPO/target" -name 'keryxcuda.dll' 2>/dev/null | head -1 || true)"
+    [[ -n "$plug" ]] && cp -f "$plug" "$stage/" || echo "WARN: keryxcuda.dll not found"
+  fi
+
+  copy_win_cuda "$stage"
+  local ipfs
+  ipfs="$(ensure_kubo windows)"
+  cp -f "$ipfs" "$stage/ipfs.exe"
+
+  # Convenience launcher
+  cat > "$stage/mine.bat" <<'EOF'
+@echo off
+echo ============================================================
+echo = Edit this file and set your keryx: address / pool host  =
+echo ============================================================
+:start
+keryx-miner.exe --mining-address keryx:YOUR_ADDRESS
+goto start
+EOF
+
+  local zip_path="$DIST_DIR/${out_name}.zip"
+  rm -f "$zip_path"
+  (
+    cd "$DIST_DIR"
+    if command -v 7z >/dev/null 2>&1; then
+      7z a -tzip -mx=9 "${out_name}.zip" "$out_name" >/dev/null
+    else
+      powershell.exe -NoProfile -Command "Compress-Archive -Path '$out_name' -DestinationPath '${out_name}.zip' -Force"
+    fi
+  )
+  log "Windows package: $zip_path"
+  ls -lh "$zip_path"
+}
+
+package_hiveos() {
+  local out_name="keryx-miner"
+  local stage="$DIST_DIR/$out_name"
+  rm -rf "$stage"
+  mkdir -p "$stage"
+
+  [[ -x "$LINUX_TARGET_DIR/keryx-miner" || -f "$LINUX_TARGET_DIR/keryx-miner" ]] \
+    || { echo "ERROR: missing $LINUX_TARGET_DIR/keryx-miner"; exit 1; }
+
+  cp -f "$LINUX_TARGET_DIR/keryx-miner" "$stage/keryx-miner"
+  chmod a+rx "$stage/keryx-miner"
+  if [[ -f "$LINUX_TARGET_DIR/libkeryx-llama.so" ]]; then
+    cp -f "$LINUX_TARGET_DIR/libkeryx-llama.so" "$stage/"
+  else
+    echo "ERROR: missing libkeryx-llama.so next to linux binary"; exit 1
+  fi
+  local cuda_plugin
+  cuda_plugin="$(find "$LINUX_TARGET_DIR" "$REPO/target" -name 'libkeryxcuda.so' 2>/dev/null | head -1 || true)"
+  [[ -n "$cuda_plugin" ]] && cp -f "$cuda_plugin" "$stage/" || echo "WARN: libkeryxcuda.so not found"
+
+  ensure_linux_cuda_libs "$stage"
+  local ipfs
+  ipfs="$(ensure_kubo linux)"
+  cp -f "$ipfs" "$stage/ipfs"
+  chmod a+rx "$stage/ipfs"
+
+  # HiveOS scripts + stable shared-models manifest (keeps CUSTOM_MINER_DIR resolution).
+  local ver_tag="$VERSION"
+  ver_tag="${ver_tag%-OPoI}"
+  sed "s/^CUSTOM_VERSION=.*/CUSTOM_VERSION=${ver_tag}-OPoI/" \
+    "$REPO/integrations/hiveos/h-manifest.conf" > "$stage/h-manifest.conf"
+  cp -f "$REPO/integrations/hiveos/"h-*.sh "$stage/"
+  chmod a+rx "$stage/"h-*.sh
+
+  # HIVEOS_README: keryx-miner-v<version>_OPoI_hiveos.tar.gz
+  local tarball="$DIST_DIR/keryx-miner-v${ver_tag}_OPoI_hiveos.tar.gz"
+  rm -f "$tarball"
+  tar -czf "$tarball" -C "$DIST_DIR" "$out_name"
+
+  # Also ship a plain linux zip with the same payload (non-HiveOS)
+  local linux_name="keryx-miner-v${VERSION}-linux-gnu-amd64"
+  rm -rf "$DIST_DIR/$linux_name"
+  mkdir -p "$DIST_DIR/$linux_name"
+  cp -a "$stage"/. "$DIST_DIR/$linux_name/"
+  # Hive helper scripts are harmless for bare linux; keep binary deps identical.
+  local linux_zip="$DIST_DIR/${linux_name}.zip"
+  rm -f "$linux_zip" "$DIST_DIR/${linux_name}.tar.gz"
+  tar -czf "$DIST_DIR/${linux_name}.tar.gz" -C "$DIST_DIR" "$linux_name"
+  (
+    cd "$DIST_DIR"
+    if command -v zip >/dev/null 2>&1; then
+      zip -qr "${linux_name}.zip" "$linux_name"
+    elif command -v 7z >/dev/null 2>&1; then
+      7z a -tzip -mx=9 "${linux_name}.zip" "$linux_name" >/dev/null
+    else
+      echo "WARN: zip/7z unavailable — skipped ${linux_name}.zip"
+    fi
+  )
+
+  log "HiveOS package: $tarball"
+  ls -lh "$tarball" "$DIST_DIR/${linux_name}.tar.gz" 2>/dev/null || true
+}
+
+cmd="${1:-all}"
+case "$cmd" in
+  windows) package_windows ;;
+  hiveos|linux) package_hiveos ;;
+  all)
+    if [[ -f "$WIN_TARGET_DIR/keryx-miner.exe" ]]; then package_windows; fi
+    if [[ -f "$LINUX_TARGET_DIR/keryx-miner" ]]; then package_hiveos; fi
+    if [[ ! -f "$WIN_TARGET_DIR/keryx-miner.exe" && ! -f "$LINUX_TARGET_DIR/keryx-miner" ]]; then
+      echo "ERROR: no built binaries found under $WIN_TARGET_DIR or $LINUX_TARGET_DIR"
+      exit 1
+    fi
+    ;;
+  *)
+    echo "usage: $0 {windows|hiveos|all}"
+    exit 1
+    ;;
+esac
+
+log "Done. Artifacts in $DIST_DIR"
+ls -lh "$DIST_DIR"/*.{zip,tar.gz} 2>/dev/null || ls -lh "$DIST_DIR"

--- a/scripts/remote-install-deps.sh
+++ b/scripts/remote-install-deps.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Permanent compile deps for keryx-miner on Ubuntu 22.04 / HiveOS.
+set -euo pipefail
+
+echo "==> apt packages"
+sudo apt-get update -qq
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades -qq \
+  build-essential pkg-config libssl-dev ca-certificates curl git \
+  cmake ninja-build protobuf-compiler ocl-icd-opencl-dev \
+  wget xz-utils unzip zip tar gcc g++ make python3 || \
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+  build-essential pkg-config libssl-dev ca-certificates curl git \
+  cmake ninja-build protobuf-compiler \
+  wget xz-utils unzip zip tar gcc g++ make python3
+
+echo "==> rustup (stable)"
+if ! command -v rustc >/dev/null 2>&1; then
+  if [ -f "$HOME/.cargo/env" ]; then
+    # shellcheck disable=SC1091
+    . "$HOME/.cargo/env"
+  fi
+fi
+if ! command -v rustc >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+fi
+# shellcheck disable=SC1091
+. "$HOME/.cargo/env"
+rustup default stable
+grep -q 'cargo/env' "$HOME/.bashrc" 2>/dev/null || echo '. "$HOME/.cargo/env"' >> "$HOME/.bashrc"
+
+echo "==> CUDA toolkit 12.8 (nvcc) if missing"
+if [ ! -x /usr/local/cuda/bin/nvcc ] && [ ! -x /usr/local/cuda-12.8/bin/nvcc ]; then
+  cd /tmp
+  # apt toolkit from NVIDIA repo — keeps driver untouched (HiveOS already has 595)
+  if [ ! -f /etc/apt/sources.list.d/cuda-ubuntu2204-x86_64.list ] && [ ! -f /usr/share/keyrings/cuda-archive-keyring.gpg ]; then
+    wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb -O cuda-keyring.deb
+    sudo dpkg -i cuda-keyring.deb
+    rm -f cuda-keyring.deb
+  fi
+  sudo apt-get update -qq
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq cuda-toolkit-12-8
+  sudo ln -sfn /usr/local/cuda-12.8 /usr/local/cuda
+fi
+
+# Permanent env for all shells
+sudo tee /etc/profile.d/keryx-build.sh >/dev/null <<'EOF'
+export CUDA_HOME=/usr/local/cuda
+export CUDA_PATH=/usr/local/cuda
+export PATH="/usr/local/cuda/bin:$HOME/.cargo/bin:$PATH"
+export LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}"
+export POM_SM_LIST=120,90,89,86,80,75,70,61
+export CUDA_COMPUTE_CAP=89
+export KERYX_LLAMA_ARCHS='75-real;80-real;86-real;89-real;120-real;89-virtual'
+EOF
+sudo chmod 644 /etc/profile.d/keryx-build.sh
+
+# shellcheck disable=SC1091
+. /etc/profile.d/keryx-build.sh
+. "$HOME/.cargo/env"
+
+echo "==> versions"
+rustc --version
+cargo --version
+gcc --version | head -1
+cmake --version | head -1
+protoc --version
+nvcc --version | sed -n '4p'
+nvidia-smi -L | head -3
+echo "DEPS_OK"

--- a/scripts/setup-gcc13-wsl.sh
+++ b/scripts/setup-gcc13-wsl.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DEBDIR="${HOME}/opt/gcc13-debs"
+ROOT="${HOME}/opt/gcc13"
+mkdir -p "${DEBDIR}" "${ROOT}"
+cd "${DEBDIR}"
+apt-get download \
+  gcc-13 g++-13 cpp-13 gcc-13-base \
+  gcc-13-x86-64-linux-gnu g++-13-x86-64-linux-gnu cpp-13-x86-64-linux-gnu \
+  libgcc-13-dev libstdc++-13-dev \
+  libasan8 libtsan2 liblsan0 libubsan1 libitm1 libatomic1 libcc1-0 libgomp1
+
+rm -rf "${ROOT}"
+mkdir -p "${ROOT}"
+shopt -s nullglob
+for deb in "${DEBDIR}"/*.deb; do
+  echo "extract ${deb}"
+  dpkg-deb -x "${deb}" "${ROOT}"
+done
+
+GXX="${ROOT}/usr/bin/x86_64-linux-gnu-g++-13"
+GCC="${ROOT}/usr/bin/x86_64-linux-gnu-gcc-13"
+"${GXX}" --version | head -1
+
+export PATH="/usr/local/cuda/bin:${PATH}"
+REPO="/mnt/h/Dev/Mining/KERYX-LABS/keryx-miner"
+mkdir -p "${REPO}/dist/ptx"
+cd "${REPO}"
+for sm in 120 90 89 86 80 75 70 61; do
+  echo "=== sm_${sm} ==="
+  if nvcc -ptx -O3 -allow-unsupported-compiler -ccbin "${GXX}" \
+      -arch="sm_${sm}" cuda/pom_mine.cu -o "dist/ptx/pom_mine_sm${sm}.ptx"; then
+    ls -lh "dist/ptx/pom_mine_sm${sm}.ptx"
+  else
+    if [ "${sm}" = "120" ]; then
+      echo "// unavailable" > "dist/ptx/pom_mine_sm${sm}.ptx"
+    else
+      exit 1
+    fi
+  fi
+done
+ls -lh "${REPO}/dist/ptx"
+echo "GCC13=${GCC}"
+echo "GXX13=${GXX}"

--- a/src/gguf.rs
+++ b/src/gguf.rs
@@ -198,6 +198,33 @@ impl GgufMeta {
         names.sort();
         names
     }
+
+    /// Minimum on-disk byte length required for every tensor's data to be present.
+    pub fn required_file_len(&self) -> u64 {
+        self.tensors
+            .values()
+            .map(|t| self.tensor_data_offset.saturating_add(t.offset).saturating_add(t.nbytes))
+            .max()
+            .unwrap_or(self.tensor_data_offset)
+    }
+}
+
+/// True when `path` is a parseable GGUF whose on-disk size covers every tensor.
+/// Used to reuse already-downloaded models without hitting the network again.
+pub fn is_complete_file(path: &std::path::Path) -> bool {
+    let mut f = match File::open(path) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+    let meta = match GgufMeta::read(&mut f) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    let file_len = match f.metadata() {
+        Ok(m) => m.len(),
+        Err(_) => return false,
+    };
+    file_len >= meta.required_file_len()
 }
 
 #[cfg(test)]

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -1,7 +1,43 @@
 /// IPFS integration — upload inference results and auto-manage kubo daemon.
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const KUBO_VERSION_FALLBACK: &str = "0.41.0";
+
+fn home_dir() -> PathBuf {
+    if let Ok(h) = std::env::var("HOME") {
+        if !h.is_empty() {
+            return PathBuf::from(h);
+        }
+    }
+    if let Ok(h) = std::env::var("USERPROFILE") {
+        if !h.is_empty() {
+            return PathBuf::from(h);
+        }
+    }
+    PathBuf::from(".")
+}
+
+fn miner_exe_dir() -> PathBuf {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn bundled_ipfs_bin(exe_dir: &Path) -> Option<PathBuf> {
+    #[cfg(windows)]
+    let names: [&str; 2] = ["ipfs.exe", "ipfs"];
+    #[cfg(not(windows))]
+    let names: [&str; 1] = ["ipfs"];
+    for name in names {
+        let p = exe_dir.join(name);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    None
+}
 
 /// Upload `text` to the IPFS node at `api_url` and return the raw 34-byte multihash.
 /// The multihash format is: [0x12, 0x20, <32-byte sha2-256 digest>].
@@ -102,8 +138,8 @@ pub fn ensure_daemon(api_url: &str) {
     };
 
     // Init repo if first run.
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    let ipfs_repo = std::path::PathBuf::from(&home).join(".ipfs");
+    let home = home_dir();
+    let ipfs_repo = home.join(".ipfs");
     if !ipfs_repo.exists() {
         log::info!("Initialising IPFS repo...");
         let _ = std::process::Command::new(&ipfs_bin)
@@ -117,7 +153,7 @@ pub fn ensure_daemon(api_url: &str) {
     // mDNS/discovery noise does not pollute the miner terminal while
     // keeping Kubo logs accessible for inference debugging.
     log::info!("Starting IPFS daemon...");
-    let log_dir = std::path::PathBuf::from(&home).join(".keryx");
+    let log_dir = home.join(".keryx");
     let _ = std::fs::create_dir_all(&log_dir);
     let kubo_log = log_dir.join("kubo.log");
     let (stdout, stderr) = match std::fs::OpenOptions::new().create(true).append(true).open(&kubo_log) {
@@ -151,25 +187,23 @@ pub fn ensure_daemon(api_url: &str) {
     }
 }
 
-fn find_or_download_kubo() -> anyhow::Result<std::path::PathBuf> {
-    // 1. Check PATH.
+fn find_or_download_kubo() -> anyhow::Result<PathBuf> {
+    let exe_dir = miner_exe_dir();
+
+    // 1. Prefer the Kubo binary shipped next to the miner (release packages).
+    if let Some(local) = bundled_ipfs_bin(&exe_dir) {
+        log::info!("Using bundled IPFS at {}", local.display());
+        return Ok(local);
+    }
+
+    // 2. Check PATH.
     if let Ok(out) = std::process::Command::new("ipfs").arg("version").output() {
         if out.status.success() {
-            return Ok(std::path::PathBuf::from("ipfs"));
+            return Ok(PathBuf::from("ipfs"));
         }
     }
 
-    // 2. Check next to the miner executable.
-    let exe_dir = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
-        .unwrap_or_else(|| std::path::PathBuf::from("."));
-    let local_bin = exe_dir.join("ipfs");
-    if local_bin.exists() {
-        return Ok(local_bin);
-    }
-
-    // 3. Download kubo for the current platform.
+    // 3. Download kubo for the current platform into the miner directory.
     let version = fetch_latest_kubo_version();
     let (os, arch) = detect_platform()?;
     let archive_ext = if cfg!(target_os = "windows") { "zip" } else { "tar.gz" };
@@ -183,7 +217,9 @@ fn find_or_download_kubo() -> anyhow::Result<std::path::PathBuf> {
     extract_ipfs_binary(&archive_path, &exe_dir)?;
     std::fs::remove_file(&archive_path).ok();
 
-    let bin = exe_dir.join(if cfg!(target_os = "windows") { "ipfs.exe" } else { "ipfs" });
+    let bin = bundled_ipfs_bin(&exe_dir).ok_or_else(|| {
+        anyhow::anyhow!("ipfs binary missing after extracting {}", archive_name)
+    })?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -462,11 +462,48 @@ fn main() -> Result<(), Error> {
     rt.block_on(run())
 }
 
+/// Prefer CUDA / bundled runtime libs that ship next to the miner binary so packages are
+/// self-contained (HiveOS/Windows zips include cuBLAS + friends + IPFS).
+fn prepend_exe_dir_to_library_path() {
+    let mut exe_dir = current_exe().unwrap_or_default();
+    if !exe_dir.pop() {
+        return;
+    }
+    #[cfg(unix)]
+    {
+        let exe = exe_dir.to_string_lossy().into_owned();
+        match std::env::var("LD_LIBRARY_PATH") {
+            Ok(cur) if !cur.is_empty() => {
+                if !cur.split(':').any(|p| p == exe) {
+                    std::env::set_var("LD_LIBRARY_PATH", format!("{exe}:{cur}"));
+                }
+            }
+            _ => std::env::set_var("LD_LIBRARY_PATH", &exe),
+        }
+    }
+    #[cfg(windows)]
+    {
+        // Windows already searches the executable directory for DLL loads; also prepend PATH
+        // so child processes (and some CRT loaders) see bundled CUDA/IPFS deps.
+        let exe = exe_dir.to_string_lossy().into_owned();
+        match std::env::var("PATH") {
+            Ok(cur) if !cur.is_empty() => {
+                let sep = ';';
+                if !cur.split(sep).any(|p| p.eq_ignore_ascii_case(&exe)) {
+                    std::env::set_var("PATH", format!("{exe}{sep}{cur}"));
+                }
+            }
+            _ => std::env::set_var("PATH", &exe),
+        }
+    }
+}
+
 async fn run() -> Result<(), Error> {
     #[cfg(target_os = "windows")]
     adjust_console().unwrap_or_else(|e| {
         eprintln!("WARNING: Failed to protect console ({}). Any selection in console will freeze the miner.", e)
     });
+    prepend_exe_dir_to_library_path();
     let mut path = current_exe().unwrap_or_default();
     path.pop(); // Getting the parent directory
     let plugins = filter_plugins(path.to_str().unwrap_or("."));

--- a/src/models.rs
+++ b/src/models.rs
@@ -127,7 +127,9 @@ pub const KIMI_LINEAR_48B: ModelSpec = ModelSpec {
 /// `crate::pom::h5_activation_daa()`, it raises the tier-0 VRAM floor to ~6 GB (closes the "any 2 GB
 /// card mines tier 0" gap). `model_id` = CIDv0[2..34] of the pinned GGUF; `weight_cids` points at the
 /// same GGUF the node's `POM_TIERS_H5[0]` R_T was built over, so the miner's runtime R_T matches.
-/// tokenizer.json is the shared Qwen3 tokenizer (same CID as Qwen3-32B tier 3).
+/// `tokenizer_cid` is empty: llama uses the tokenizer embedded in the GGUF (same as the rest of the
+/// lineup). A non-empty CID previously forced a separate tokenizer.json download and, when that
+/// file was missing, re-entered the GGUF download path and could wipe an already-complete model.
 pub const QWEN3_8B_ABLITERATED: ModelSpec = ModelSpec {
     name: "qwen3-8b-abliterated",
     model_id: [
@@ -137,7 +139,7 @@ pub const QWEN3_8B_ABLITERATED: ModelSpec = ModelSpec {
         0x57, 0x4a, 0x72, 0x87, 0x4c, 0x35, 0x0d, 0x24,
     ],
     format: ModelFormat::GgufQwen35,
-    tokenizer_cid: "QmcuGkJvR343ry3b4jy7u5L9ior3ujas3yGAFMSyZdACb5",
+    tokenizer_cid: "",
     weight_cids: &["QmccwHVeZYVzEq6A5ofk76MxrnwzMnSjAVt9PaUQ7zfLXm"],
     dir_name: "Qwen3-8B-abliterated",
     // ~4.6 GB Q4_K_S weights + ~1.2 GB KV/workspace → fits a 6 GB card (measured 5,409 MiB @ ctx 4096).

--- a/src/pom_gpu.rs
+++ b/src/pom_gpu.rs
@@ -20,6 +20,7 @@ use log::{info, warn};
 
 use cudarc::driver::{result, sys, CudaContext, CudaSlice, CudaStream, DevicePtr, LaunchConfig};
 
+const PTX_SM120: &str = include_str!(concat!(env!("OUT_DIR"), "/pom_mine_sm120.ptx"));
 const PTX_SM90: &str = include_str!(concat!(env!("OUT_DIR"), "/pom_mine_sm90.ptx"));
 const PTX_SM89: &str = include_str!(concat!(env!("OUT_DIR"), "/pom_mine_sm89.ptx"));
 const PTX_SM86: &str = include_str!(concat!(env!("OUT_DIR"), "/pom_mine_sm86.ptx"));
@@ -32,15 +33,77 @@ const FATBIN_NEXTGEN: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/pom_mine
 const CHUNK_BYTES: usize = 32;
 const POM_KERNEL_NAME: &str = "pom_mine";
 
-const POM_PTX_CANDIDATES: [(&str, &str, &str); 7] = [
-    ("pom_mine_mod_sm90", "sm_90", PTX_SM90),
-    ("pom_mine_mod_sm89", "sm_89", PTX_SM89),
-    ("pom_mine_mod_sm86", "sm_86", PTX_SM86),
-    ("pom_mine_mod_sm80", "sm_80", PTX_SM80),
-    ("pom_mine_mod_sm75", "sm_75", PTX_SM75),
-    ("pom_mine_mod_sm70", "sm_70", PTX_SM70),
-    ("pom_mine_mod_sm61", "sm_61", PTX_SM61),
-];
+/// Ordered PTX images to try for a GPU's compute capability.
+///
+/// Primary targets (by GeForce generation):
+/// - RTX 50 / consumer Blackwell (`sm_120`) → native `sm_120`, then Ada/Ampere fallbacks
+/// - RTX 40 / Ada (`sm_89`) → `sm_89`, then `sm_86`
+/// - RTX 30 / Ampere (`sm_86`) → `sm_86`, then `sm_80`
+fn ptx_candidates_for_cc(major: i32, minor: i32) -> Vec<(&'static str, &'static str, &'static str)> {
+    if major >= 12 {
+        // Consumer Blackwell (RTX 5090/5080/5070…): must prefer sm_120. sm_100 is a different
+        // datacenter arch and fails on GeForce; without sm_120 the card used to land on JIT'd
+        // sm_86 at roughly half throughput.
+        vec![
+            ("pom_mine_mod_sm120", "sm_120", PTX_SM120),
+            ("pom_mine_mod_sm89", "sm_89", PTX_SM89),
+            ("pom_mine_mod_sm86", "sm_86", PTX_SM86),
+        ]
+    } else if major >= 10 {
+        // Datacenter Blackwell — no dedicated sm_100 PoM image yet; Ada PTX JITs forward.
+        vec![
+            ("pom_mine_mod_sm89", "sm_89", PTX_SM89),
+            ("pom_mine_mod_sm86", "sm_86", PTX_SM86),
+        ]
+    } else if major == 9 {
+        vec![
+            ("pom_mine_mod_sm90", "sm_90", PTX_SM90),
+            ("pom_mine_mod_sm89", "sm_89", PTX_SM89),
+            ("pom_mine_mod_sm86", "sm_86", PTX_SM86),
+        ]
+    } else if major == 8 && minor >= 9 {
+        // RTX 40 (Ada Lovelace)
+        vec![
+            ("pom_mine_mod_sm89", "sm_89", PTX_SM89),
+            ("pom_mine_mod_sm86", "sm_86", PTX_SM86),
+        ]
+    } else if major == 8 && minor >= 6 {
+        // RTX 30 (Ampere GA102/GA104…)
+        vec![
+            ("pom_mine_mod_sm86", "sm_86", PTX_SM86),
+            ("pom_mine_mod_sm80", "sm_80", PTX_SM80),
+        ]
+    } else if major == 8 {
+        // GA100 / early Ampere
+        vec![
+            ("pom_mine_mod_sm80", "sm_80", PTX_SM80),
+            ("pom_mine_mod_sm75", "sm_75", PTX_SM75),
+        ]
+    } else if major == 7 && minor >= 5 {
+        vec![
+            ("pom_mine_mod_sm75", "sm_75", PTX_SM75),
+            ("pom_mine_mod_sm70", "sm_70", PTX_SM70),
+        ]
+    } else if major == 7 {
+        vec![
+            ("pom_mine_mod_sm70", "sm_70", PTX_SM70),
+            ("pom_mine_mod_sm61", "sm_61", PTX_SM61),
+        ]
+    } else {
+        vec![
+            ("pom_mine_mod_sm61", "sm_61", PTX_SM61),
+            ("pom_mine_mod_sm70", "sm_70", PTX_SM70),
+            ("pom_mine_mod_sm75", "sm_75", PTX_SM75),
+            ("pom_mine_mod_sm80", "sm_80", PTX_SM80),
+            ("pom_mine_mod_sm86", "sm_86", PTX_SM86),
+        ]
+    }
+}
+
+fn ptx_image_usable(ptx: &str) -> bool {
+    let trimmed = ptx.trim_start();
+    !trimmed.is_empty() && !trimmed.starts_with("//") && trimmed.contains(".version")
+}
 
 #[derive(Clone, Debug)]
 pub struct GpuKernelInfo {
@@ -279,26 +342,28 @@ fn select_pom_kernel(device_id: usize) -> Result<LoadedPomKernel> {
         }
     }
 
-    for (module_name, label, ptx) in POM_PTX_CANDIDATES {
+    let cc = gpu_compute_capability(device_id);
+    let (major, minor) = cc.unwrap_or((0, 0));
+    let candidates = ptx_candidates_for_cc(major, minor);
+
+    for (module_name, label, ptx) in candidates {
+        if !ptx_image_usable(ptx) {
+            warn!(
+                "PoM[gpu{}]: {} PTX unavailable in this build (rebuild with CUDA ≥ 12.8 for sm_120)",
+                device_id, label
+            );
+            continue;
+        }
         match LoadedPomKernel::from_ptx(label, ptx) {
             Ok(kernel) => {
-                let cc = gpu_compute_capability(device_id);
-                if let Some((major, minor)) = cc {
-                    info!(
-                        "PoM[gpu{} cc{}.{}]: startup loaded {} PTX fallback via {}",
-                        device_id,
-                        major,
-                        minor,
-                        label,
-                        module_name,
-                    );
-                } else {
-                    info!("PoM[gpu{}]: startup loaded {} PTX fallback via {}", device_id, label, module_name);
-                }
+                info!(
+                    "PoM[gpu{} cc{}.{}]: startup loaded {} PTX via {} (RTX30=sm_86, RTX40=sm_89, RTX50=sm_120)",
+                    device_id, major, minor, label, module_name,
+                );
                 set_gpu_kernel_info(
                     device_id,
                     cc,
-                    &format!("{} PTX fallback", label),
+                    &format!("{} PTX", label),
                     module_name,
                 );
                 return Ok(kernel);
@@ -309,7 +374,11 @@ fn select_pom_kernel(device_id: usize) -> Result<LoadedPomKernel> {
         }
     }
 
-    Err(anyhow!("PoM GPU: no compatible PTX image for this device/driver"))
+    Err(anyhow!(
+        "PoM GPU: no compatible PTX image for device cc{}.{} (want sm_120/sm_89/sm_86 by generation)",
+        major,
+        minor
+    ))
 }
 
 fn words4(b: &[u8; 32]) -> [u64; 4] {

--- a/src/slm.rs
+++ b/src/slm.rs
@@ -104,8 +104,45 @@ fn download_file(url: &str, dest: &std::path::Path) -> Result<()> {
                 }
                 return Ok(());
             } else {
-                // 200, or the server ignored Range ⇒ (re)start from scratch.
+                // 200, or the server ignored Range. Never wipe a local file that already matches
+                // the remote size — IPFS gateways often ignore Range and answer 200 + full
+                // Content-Length, which previously truncated multi-GB GGUFs back to zero.
                 let total = response.header("Content-Length").and_then(|s| s.parse::<u64>().ok());
+                if resume_from > 0 {
+                    if let Some(t) = total {
+                        if resume_from >= t {
+                            if ui_progress_to_stderr() {
+                                eprintln!("\r  already complete ({} MB).            ", resume_from / 1_000_000);
+                            } else {
+                                ui_download_info(&format!(
+                                    "[keryx-miner] already complete ({} MB).",
+                                    resume_from / 1_000_000
+                                ));
+                            }
+                            return Ok(());
+                        }
+                    }
+                    // Partial local file + no Range support: keep the bytes and resume via a
+                    // fresh request without Range only when we have nothing useful; otherwise
+                    // refuse to truncate and retry later (gateway may regain Range support).
+                    if resume_from > 1_000_000 {
+                        drop(response);
+                        attempt += 1;
+                        if attempt >= MAX_ATTEMPTS {
+                            return Err(anyhow!(
+                                "download {} cannot resume: server ignored Range and local partial is {} MB",
+                                url,
+                                resume_from / 1_000_000
+                            ));
+                        }
+                        ui_download_warn(&format!(
+                            "[keryx-miner] server ignored Range (HTTP {status}); keeping local {} MB, retry {attempt}/{MAX_ATTEMPTS} in {BACKOFF_SECS}s…",
+                            resume_from / 1_000_000
+                        ));
+                        std::thread::sleep(std::time::Duration::from_secs(BACKOFF_SECS));
+                        continue;
+                    }
+                }
                 let f = std::fs::File::create(dest)
                     .with_context(|| format!("create {}", dest.display()))?;
                 (f, 0u64, total)
@@ -208,18 +245,51 @@ fn ensure_gguf(spec: &ModelSpec) -> Result<(std::path::PathBuf, std::path::PathB
     let gguf = dir.join("model.gguf");
     let ok_flag = dir.join(".ok");
 
-    // H4 models pin no separate tokenizer.json (llama uses the one embedded in the GGUF).
+    // Separate tokenizer.json is optional for the lineup — llama uses the GGUF-embedded one.
     let tok_needed = !spec.tokenizer_cid.is_empty();
-    // .ok sentinel written only after a complete download — guards against truncated files
-    if (!tok_needed || tok.exists()) && gguf.exists() && ok_flag.exists() {
-        log::debug!("SlmEngine: found local model '{}' at {}", spec.name, dir.display());
+    let gguf_ready = crate::gguf::is_complete_file(&gguf);
+    let tok_ready = !tok_needed || tok.exists();
+
+    // Reuse a complete on-disk GGUF even when `.ok` was lost (HiveOS upgrades, manual copies,
+    // interrupted flag write). Never re-download a model that already parses as complete.
+    if gguf_ready && tok_ready {
+        if !ok_flag.exists() {
+            let _ = std::fs::write(&ok_flag, b"");
+        }
+        log::info!("SlmEngine: reusing local model '{}' at {}", spec.name, dir.display());
         return Ok((tok, gguf));
     }
+
     std::fs::create_dir_all(&dir)?;
-    let _ = std::fs::remove_file(&ok_flag); // clear stale flag before re-downloading
-    ui_download_info(&format!("[keryx-miner] Downloading model '{}' via IPFS. This happens once.", spec.name));
-    if tok_needed && !tok.exists() { download_file(&ipfs_url(spec.tokenizer_cid), &tok)?; }
-    download_file(&ipfs_url(spec.weight_cids[0]), &gguf)?;
+    if ok_flag.exists() && !gguf_ready {
+        let _ = std::fs::remove_file(&ok_flag); // clear stale flag before repairing
+    }
+
+    if !gguf_ready {
+        ui_download_info(&format!(
+            "[keryx-miner] Downloading model '{}' via IPFS. This happens once.",
+            spec.name
+        ));
+        download_file(&ipfs_url(spec.weight_cids[0]), &gguf)?;
+        if !crate::gguf::is_complete_file(&gguf) {
+            return Err(anyhow!(
+                "model '{}' download finished but GGUF is incomplete at {}",
+                spec.name,
+                gguf.display()
+            ));
+        }
+    } else {
+        ui_download_info(&format!(
+            "[keryx-miner] Reusing existing GGUF for '{}' at {}",
+            spec.name,
+            gguf.display()
+        ));
+    }
+
+    if tok_needed && !tok.exists() {
+        download_file(&ipfs_url(spec.tokenizer_cid), &tok)?;
+    }
+
     std::fs::write(&ok_flag, b"").with_context(|| format!("write .ok flag {}", ok_flag.display()))?;
     ui_download_info(&format!("[keryx-miner] Model '{}' ready.", spec.name));
     Ok((tok, gguf))
@@ -296,7 +366,18 @@ pub fn probe_gpu_inference() -> GpuProbe {
     // Windows nvcc links cudart statically into keryx-llama.dll, so only cuBLAS is probed.
     // Each probe Library is dropped immediately — we only care that it CAN load; the
     // engine (re-)loads it for real later, and the OS loader refcounts it.
-    let loads = |candidates: &[&str]| candidates.iter().any(|so| unsafe { libloading::Library::new(so) }.is_ok());
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let loads = |candidates: &[&str]| {
+        candidates.iter().any(|name| {
+            let bundled = exe_dir.join(name);
+            unsafe {
+                libloading::Library::new(&bundled).is_ok() || libloading::Library::new(name).is_ok()
+            }
+        })
+    };
     #[cfg(windows)]
     let ok = loads(&["cublas64_12.dll"]);
     #[cfg(not(windows))]


### PR DESCRIPTION
## Summary
- **Model reuse:** treat a parseable complete GGUF as ready even without `.ok`; never truncate large partials when the IPFS gateway ignores `Range` (was forcing multi‑GB re-downloads).
- **Bundled runtime deps:** prefer `ipfs` / CUDA libs next to the binary (`LD_LIBRARY_PATH` / `PATH`); packaging script ships Kubo + cuBLAS/cudart/curand in HiveOS/Windows archives.
- **PoM PTX selection:** RTX 30 → `sm_86`, RTX 40 → `sm_89`, RTX 50 → `sm_120` (with fallbacks). Build emits `sm_120` when toolkit ≥ 12.8.
- **Scripts:** `scripts/package-release.sh` + Docker/WSL helpers for reproducible Linux builds.

## Packages
Draft release (fork): https://github.com/fearke85/keryx-miner/releases/tag/untagged-5bc1a147ec525125bdd3

- [keryx-miner-v0.4.0_OPoI_hiveos.tar.gz](https://github.com/fearke85/keryx-miner/releases/download/untagged-5bc1a147ec525125bdd3/keryx-miner-v0.4.0_OPoI_hiveos.tar.gz)
- [keryx-miner-v0.4.0-OPoI-linux-gnu-amd64.zip](https://github.com/fearke85/keryx-miner/releases/download/untagged-5bc1a147ec525125bdd3/keryx-miner-v0.4.0-OPoI-linux-gnu-amd64.zip)
- [keryx-miner-v0.4.0-OPoI-win64-amd64.zip](https://github.com/fearke85/keryx-miner/releases/download/untagged-5bc1a147ec525125bdd3/keryx-miner-v0.4.0-OPoI-win64-amd64.zip)

> Draft assets may require GitHub login. Publish the fork release for anonymous downloads.

## Test plan
- [ ] Fresh HiveOS install: package extracts, `ipfs` + `libcublas.so.12` present next to binary, miner starts without apt CUDA install
- [ ] Restart with existing `/hive/miners/custom/models/.../model.gguf`: logs show reuse, no full re-download
- [ ] Windows zip: `ipfs.exe` + `cublas64_12.dll` / `cublasLt64_12.dll` co-located; miner probes cuBLAS OK
- [ ] RTX 50: log shows `sm_120` PTX; RTX 40 → `sm_89`; RTX 30 → `sm_86`