### PR TITLE
Transient GPU fault fix per GPU

### DIFF
--- a/src/llama_engine.rs
+++ b/src/llama_engine.rs
@@ -84,7 +84,12 @@ pub fn ensure_loaded(gguf: &str, gpu: usize) -> bool {
         Err(p) => p.into_inner(),
     };
     if let Some(e) = g.as_ref() {
-        return e.gguf == gguf && e.gpu == gpu;
+        if e.gguf == gguf && e.gpu == gpu {
+            return true;
+        }
+        if let Some(e) = g.take() {
+            unsafe { (e.free)(e.model) };
+        }
     }
     let Some(so) = so_path() else { return false };
     // Never unloaded (the old dlopen path never dlclosed either): the Engine keeps raw fn
@@ -157,6 +162,19 @@ pub fn available() -> bool {
 /// the caller walks a raw canonical upload instead.
 pub fn unload() {
     if let Ok(mut g) = engine().lock() {
+        if let Some(e) = g.take() {
+            unsafe { (e.free)(e.model) };
+        }
+    }
+}
+
+/// Free the resident model and disable the engine only if the given GPU currently hosts it.
+/// This is used for stale-GPU recovery after a transient fault on that specific device.
+pub fn unload_for_gpu(gpu: usize) {
+    if let Ok(mut g) = engine().lock() {
+        if g.as_ref().is_some_and(|e| e.gpu != gpu) {
+            return;
+        }
         if let Some(e) = g.take() {
             unsafe { (e.free)(e.model) };
         }

--- a/src/pom_gpu.rs
+++ b/src/pom_gpu.rs
@@ -825,7 +825,7 @@ fn is_transient_gpu_runtime_fault(err: &str) -> bool {
 
 fn reset_stale_gpu_state(device_id: u32, use_llama: bool) {
     if use_llama {
-        crate::llama_engine::unload();
+        crate::llama_engine::unload_for_gpu(device_id as usize);
     }
     uninstall(device_id);
 }

--- a/src/pom_gpu.rs
+++ b/src/pom_gpu.rs
@@ -814,6 +814,22 @@ fn classify_miner_load_error(err: &str) -> MinerLoadFailureKind {
     MinerLoadFailureKind::Other
 }
 
+fn is_transient_gpu_runtime_fault(err: &str) -> bool {
+    let s = err.to_ascii_lowercase();
+    s.contains("illegal address")
+        || s.contains("illegal memory")
+        || s.contains("cuda_error_illegal_address")
+        || s.contains("invalid device pointer")
+        || s.contains("misaligned address")
+}
+
+fn reset_stale_gpu_state(device_id: u32, use_llama: bool) {
+    if use_llama {
+        crate::llama_engine::unload();
+    }
+    uninstall(device_id);
+}
+
 fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
     let (model_id, gguf) = match mining_tiers().lock().ok().and_then(|g| g.get(&device_id).cloned()) {
         Some(x) => x,
@@ -896,6 +912,15 @@ fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
         Ok(Ok(gm)) => gm,
         Ok(Err(e)) => {
             let e_msg = e.to_string();
+            if is_transient_gpu_runtime_fault(&e_msg) {
+                log::warn!(
+                    "PoM[gpu{}]: transient GPU runtime fault while loading miner ({}); dropping stale miner state and forcing a rebuild on the next cycle.",
+                    device_id,
+                    e_msg
+                );
+                reset_stale_gpu_state(device_id, use_llama);
+                return false;
+            }
             match classify_miner_load_error(&e_msg) {
                 MinerLoadFailureKind::PtxIncompatible => {
                     log::error!(
@@ -979,5 +1004,12 @@ mod tests {
 
         assert_eq!(map.len(), 1);
         assert_eq!(map.get(&1), Some(&"gpu1-miner"));
+    }
+
+    #[test]
+    fn detects_transient_illegal_address_faults() {
+        assert!(is_transient_gpu_runtime_fault("CUDA_ERROR_ILLEGAL_ADDRESS"));
+        assert!(is_transient_gpu_runtime_fault("illegal memory access was encountered"));
+        assert!(!is_transient_gpu_runtime_fault("out of memory"));
     }
 }


### PR DESCRIPTION
This PR improves resilience to transient GPU runtime faults by changing how inference state is recovered after a device failure.

Previously, recovery was handled by reloading the broader runtime stack, which was heavier and less targeted. That approach could disrupt unrelated state and was not specific to the GPU that actually faulted. With this change, recovery is now scoped to the affected GPU’s inference engine state, so the runtime can be reset more precisely and with less collateral impact.

### What changed
- Added GPU-specific recovery for the in-process llama inference engine.
- The engine now unloads and reloads only when the affected GPU is the one hosting the active runtime state.
- This avoids unnecessary full-stack resets and makes transient fault handling more deterministic.

### Why
Transient GPU faults can leave the inference runtime in a stale or invalid state. Handling recovery per GPU makes the system more robust, reduces churn, and preserves the rest of the runtime stack instead of forcing a broad reload.