### PR TITLE
fix(cli): correct model tier conflicts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ pub struct Opt {
         long = "very-light",
         help = "Model tier: Qwen3-8B-abliterated — 6GB+ GPU, smallest tier",
         help_heading = "OPoI / Inference",
-        conflicts_with_all = &["light", "high", "very_high"]
+        conflicts_with_all = &["light", "high", "very-high"]
     )]
     pub very_light: bool,
 
@@ -20,7 +20,7 @@ pub struct Opt {
         long = "light",
         help = "Model tier: Mistral-7B-v0.3 — 8GB+ VRAM",
         help_heading = "OPoI / Inference",
-        conflicts_with_all = &["very_light", "high", "very_high"]
+        conflicts_with_all = &["very-light", "high", "very-high"]
     )]
     pub light: bool,
 
@@ -28,7 +28,7 @@ pub struct Opt {
         long = "high",
         help = "Model tier: Qwen3.6-27B (Q4_K_M) — 24GB+ VRAM",
         help_heading = "OPoI / Inference",
-        conflicts_with_all = &["very_light", "light", "very_high"]
+        conflicts_with_all = &["very-light", "light", "very-high"]
     )]
     pub high: bool,
 
@@ -36,7 +36,7 @@ pub struct Opt {
         long = "very-high",
         help = "Model tier: Kimi-Linear-48B (Q4_K_M) — 32GB+ VRAM",
         help_heading = "OPoI / Inference",
-        conflicts_with_all = &["very_light", "light", "high"]
+        conflicts_with_all = &["very-light", "light", "high"]
     )]
     pub very_high: bool,
 
@@ -251,5 +251,17 @@ impl Opt {
         } else {
             LevelFilter::Info
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn model_tier_conflicts_reference_valid_arguments() {
+        Opt::command().debug_assert();
+        assert!(Opt::try_parse_from(["keryx-miner", "--very-light", "--very-high"]).is_err());
     }
 }


### PR DESCRIPTION
# fix(cli): correct model tier conflicts

Intended base: `Keryx-Labs/keryx-miner:main`.

## Summary

The model-tier flags declared conflicts using Rust field names such as `very_high`, but Clap registered the corresponding argument IDs as `very-high`. Debug builds therefore panicked during command construction before logging, model setup, or network startup.

This PR uses the registered kebab-case argument IDs and adds a parser regression test so every conflict reference is validated by Clap.

## Changes

- Replace `very_light` and `very_high` conflict references with `very-light` and `very-high`.
- Run Clap's command-level `debug_assert` in a focused test.
- Verify that `--very-light --very-high` returns normal conflict usage output.

## Scope

Only `src/cli.rs` changes. Model selection, mining, Stratum behavior, and release configuration are unchanged.

## Verification

- `model_tier_conflicts_reference_valid_arguments`: 1 passed, 0 failed.
- A real debug binary accepted `--very-light --help` without panicking.
- The same debug binary rejected `--very-light --very-high` with normal Clap conflict output.
- Native build used CUDA 12.2 and MSVC 19.36 with all required PoM targets.
- Cached diff check passed.

## Additional fixes discovered

This defect was found while practically testing the Stratum PR. The previous release-binary check was insufficient because Clap's command-construction assertions are disabled outside debug builds.

## Residual risk

The command-level debug assertion validates all declared conflict references, while the executable smoke explicitly exercises the multiword tier pair that caused the panic. No other CLI behavior changes.

This PR was made by AI
