### PR TITLE
fix(escrow): make state persistence durable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ include = [
 
 [dependencies]
 memmap2 = "0.9"
+tempfile = "3"
 tonic = "0.8"
 tokio = { version = "1.17", features = ["macros", "rt-multi-thread", "signal"] }
 prost = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ no-asm = ["keccak"]
 keccak = "0.1"
 kernel32-sys = "0.2"
 win32console = "0.1"
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ models/
 
 If the miner still downloads a model although the folder is there, check your tier flag before anything else: the flag decides **which** model is requested, `--models-dir` only says **where** to look.
 
+### Escrow state durability
+
+Escrow keys and claim state are written through a same-directory temporary file, synced, and atomically installed. An unreadable key or malformed state file stops escrow initialization without replacing the existing bytes. Recovery output uses the same atomic write path.
+
+On HiveOS, the durable files live outside the replaceable miner package at `/hive/miners/custom/keryx-miner-state/escrow.key` and `/hive/miners/custom/keryx-miner-state/escrow_state.json`, with directory mode `0700` and file mode `0600`. Back up both files together before an upgrade or manual recovery. Never delete an invalid key to generate another one: restore the original backup because it controls existing rewards. See [`integrations/hiveos/HIVEOS_README.md`](integrations/hiveos/HIVEOS_README.md) for verified migration and rollback steps.
+
 ### All options
 
 ```bash

--- a/integrations/hiveos/HIVEOS_README.md
+++ b/integrations/hiveos/HIVEOS_README.md
@@ -1,28 +1,47 @@
+# HiveOS integration
 
-## What the run script now does
+## Persistent paths
 
-Before the miner starts, `h-run.sh` checks for a previously preserved shared `models` directory and moves it back into the current miner directory if needed.
+HiveOS replaces the complete miner package during an upgrade or rollback. Keryx therefore stores funds-critical mutable data outside that package:
 
-This restores the model files after HiveOS has unpacked the new miner package.
+```text
+/hive/miners/custom/keryx-miner-state/escrow.key
+/hive/miners/custom/keryx-miner-state/escrow_state.json
+```
 
-## Tarball naming
+The directory is mode `0700`; both files are mode `0600`. `h-run.sh` validates and migrates package-local files before starting the miner. A valid existing durable file takes precedence, making migration idempotent. Invalid durable or legacy data stops migration without replacing either copy.
 
-Naming it like this with only 2 hyphens keeps the folder name that hive creates, short.  It creates a single folder each time named keryx-miner.  Every space after the second
-hyphen should be an underscore.
-The HiveOS release tarball should be named in this format:
+Back up both durable files together before an upgrade or recovery. If validation fails, restore the matching pair from backup. Do not delete `escrow.key` to regenerate it because the original key controls existing rewards.
+
+## Rollback-safe upgrade
+
+An old Keryx package understands the escrow path flags but defaults to files in its replaceable working directory. Before changing the Install URL, persist these exact flags in the HiveOS Flight Sheet **Extra config**:
+
+```text
+--escrow-key-file /hive/miners/custom/keryx-miner-state/escrow.key --escrow-state-file /hive/miners/custom/keryx-miner-state/escrow_state.json
+```
+
+Use the `pre-hive-upgrade.sh` bundled with the exact target release. Do not pipe a separately downloaded script into a shell. Copy the bundled script to a temporary path, then run it with the current package directory explicitly:
+
+```bash
+install -m 0700 /path/to/unpacked-target-release/pre-hive-upgrade.sh /tmp/keryx-pre-hive-upgrade.sh
+CURRENT_KERYX_DIR=/hive/miners/custom/name-of-currently-installed-keryx-package
+test -f "$CURRENT_KERYX_DIR/h-manifest.conf" || exit 1
+bash /tmp/keryx-pre-hive-upgrade.sh --install-dir "$CURRENT_KERYX_DIR"
+```
+
+Replace `name-of-currently-installed-keryx-package` with the directory containing the currently running package, not the unpacked target release. The first run stops the current miner and performs verified migration. It cannot report the upgrade safe unless a valid durable key exists. If persistent flags are missing, it prints the exact Extra config and exits without declaring the upgrade safe. Add those flags, apply the Flight Sheet while the old package is still installed, then run the command again. The second run must report that migration and rollback flags are verified. It sources `/hive-config/wallet.conf` in an isolated Bash process for verification and never edits it.
+
+After verification, change only the Install URL and preserve Extra config. The new package and an unchanged old rollback package will then read and write the same durable files. If HiveOS reports `Already installed` instead of replacing the package, force the requested install through the normal HiveOS custom-miner controls.
+
+Custom `--escrow-key-file` and `--escrow-state-file` values remain authoritative in `h-config.sh`, using either `--flag path` or `--flag=path`. Rollback is guaranteed only when both persistent values point outside the package and are retained across the Flight Sheet change.
+
+## Package naming
+
+Use the release archive format:
 
 ```text
 keryx-miner-v<version>_OPoI_hiveos.tar.gz
 ```
 
-Use that naming pattern so HiveOS creates only one miner folder instead of creating a new folder for every version change. That keeps the install layout stable across updates and makes the model directory move logic work as intended.
-
-## Summary
-
-- The tarball name should remain stable in structure across releases so HiveOS does not create multiple version folders.
-- The first time going from current naming format to the new format, a user( from a hiveos shell ) will have to run the following command to get the shell script that 
-    will run `h-stop.sh` and move the models folder up one directory level before changing the Install URL to the new version in their custom config screen so that it will preserve their models.  Commands are as follows:
-    ```bash 
-    cd /hive/miners/custom/keryx-miner-v0.3.6-OPoI/ \
-    wget -O - https://keryx-labs.com/pre-hive-upgrade.sh | bash
-    ```
+This gives HiveOS the stable miner name `keryx-miner`. Models remain in `/hive/miners/custom/models`; escrow data must remain in the separate state directory above.

--- a/integrations/hiveos/createmanifest.sh
+++ b/integrations/hiveos/createmanifest.sh
@@ -1,7 +1,8 @@
-if [ "$#" -ne "2" ]
-  then
-    echo "No arguments supplied. Call using createmanifest.sh <VERSION_NUMBER> <MINER BINARY NAME>"
-    exit
+#!/usr/bin/env bash
+
+if [ "$#" -ne 2 ]; then
+  echo "No arguments supplied. Call using createmanifest.sh <VERSION_NUMBER> <MINER BINARY NAME>"
+  exit 1
 fi
 cat > h-manifest.conf << EOF
 # The name of the miner
@@ -12,11 +13,17 @@ CUSTOM_VERSION=$1
 CUSTOM_BUILD=0
 CUSTOM_MINERBIN=$2
 
+# Resolve the actual versioned package directory from this manifest.
+CUSTOM_MINER_DIR="\$(cd "\$(dirname "\$(readlink -f "\${BASH_SOURCE[0]:-\$0}")")" && pwd)"
+
 # Full path to miner config file
-CUSTOM_CONFIG_FILENAME=/hive/miners/custom/\$CUSTOM_NAME/config.ini
+CUSTOM_CONFIG_FILENAME="\$CUSTOM_MINER_DIR/config.ini"
 
 # Full path to log file basename (without .log extension)
 CUSTOM_LOG_BASENAME=/var/log/miner/\$CUSTOM_NAME
 
 WEB_PORT=3338
+
+# Funds-critical mutable state must survive package replacement.
+KERYX_STATE_DIR="\${KERYX_STATE_DIR:-/hive/miners/custom/keryx-miner-state}"
 EOF

--- a/integrations/hiveos/h-config.sh
+++ b/integrations/hiveos/h-config.sh
@@ -10,7 +10,45 @@ conf=""
 conf+=" -s $CUSTOM_URL --mining-address $CUSTOM_TEMPLATE"
 conf+=" --plain-log-file $CUSTOM_LOG_BASENAME.log"
 
-[[ ! -z $CUSTOM_USER_CONFIG ]] && conf+=" $CUSTOM_USER_CONFIG"
+parse_custom_flag() {
+  local config="${CUSTOM_USER_CONFIG//$'\n'/ }" flag="$1" word index
+  local -a words=()
+  CUSTOM_FLAG_COUNT=0
+  CUSTOM_FLAG_VALUE=""
+  read -r -a words <<< "$config"
+  for ((index = 0; index < ${#words[@]}; index++)); do
+    word="${words[index]}"
+    if [[ "$word" == "$flag" ]]; then
+      ((CUSTOM_FLAG_COUNT += 1))
+      ((index += 1))
+      (( index < ${#words[@]} )) || return 1
+      CUSTOM_FLAG_VALUE="${words[index]}"
+      [[ "$CUSTOM_FLAG_VALUE" != --* ]] || return 1
+    elif [[ "$word" == "$flag="* ]]; then
+      ((CUSTOM_FLAG_COUNT += 1))
+      CUSTOM_FLAG_VALUE="${word#*=}"
+      [[ -n "$CUSTOM_FLAG_VALUE" ]] || return 1
+    fi
+  done
+  (( CUSTOM_FLAG_COUNT <= 1 ))
+}
+
+append_escrow_default() {
+  local flag="$1" value="$2"
+  if ! parse_custom_flag "$flag"; then
+    echo "Invalid CUSTOM_USER_CONFIG: $flag must have one value and may appear at most once." >&2
+    return 1
+  fi
+  (( CUSTOM_FLAG_COUNT == 1 )) || conf+=" $flag $value"
+}
+
+if ! append_escrow_default --escrow-key-file "$KERYX_STATE_DIR/escrow.key" ||
+  ! append_escrow_default --escrow-state-file "$KERYX_STATE_DIR/escrow_state.json"; then
+  [[ "${BASH_SOURCE[0]}" != "$0" ]] && return 1
+  exit 1
+fi
+
+[[ -n ${CUSTOM_USER_CONFIG:-} ]] && conf+=" $CUSTOM_USER_CONFIG"
 
 echo "$conf"
-echo "$conf" > $CUSTOM_CONFIG_FILENAME
+echo "$conf" > "$CUSTOM_CONFIG_FILENAME"

--- a/integrations/hiveos/h-manifest.conf
+++ b/integrations/hiveos/h-manifest.conf
@@ -18,3 +18,6 @@ CUSTOM_CONFIG_FILENAME="$CUSTOM_MINER_DIR/config.ini"
 CUSTOM_LOG_BASENAME=/var/log/miner/$CUSTOM_NAME
 
 WEB_PORT=3338
+
+# Funds-critical mutable state must survive package replacement.
+KERYX_STATE_DIR="${KERYX_STATE_DIR:-/hive/miners/custom/keryx-miner-state}"

--- a/integrations/hiveos/h-run.sh
+++ b/integrations/hiveos/h-run.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-cd `dirname $0`
+cd "$(dirname "$0")" || exit 1
 
 [ -t 1 ] && . colors
 
 . h-manifest.conf
+. "$CUSTOM_MINER_DIR/pre-hive-upgrade.sh"
 
 [[ -z $CUSTOM_LOG_BASENAME ]] && echo -e "${RED}No CUSTOM_LOG_BASENAME is set${NOCOLOR}" && exit 1
 [[ -z $CUSTOM_CONFIG_FILENAME ]] && echo -e "${RED}No CUSTOM_CONFIG_FILENAME is set${NOCOLOR}" && exit 1
@@ -63,5 +64,9 @@ cleanup_legacy_models() {
 # One-time migration from old local-per-install cache into the shared cache.
 mkdir -p "$KERYX_MODELS_DIR"
 cleanup_legacy_models
+prepare_keryx_state "$CUSTOM_MINER_DIR" || exit 1
 
-./$CUSTOM_MINERBIN $(< $CUSTOM_CONFIG_FILENAME) --hiveos --stats-bind 127.0.0.1 --stats-port "$WEB_PORT" $@
+config="$(< "$CUSTOM_CONFIG_FILENAME")"
+config="${config//$'\n'/ }"
+read -r -a miner_args <<< "$config"
+"./$CUSTOM_MINERBIN" "${miner_args[@]}" --hiveos --stats-bind 127.0.0.1 --stats-port "$WEB_PORT" "$@"

--- a/integrations/hiveos/h-stop.sh
+++ b/integrations/hiveos/h-stop.sh
@@ -11,8 +11,30 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # This script is executed by HiveOS when stopping the custom miner.
 
-# If Hive launched this miner in a screen session, close that session too so a
-# parent shell/wrapper cannot relaunch the binary.
+miner_pids() {
+	{
+		pgrep -x "${CUSTOM_MINERBIN}" || true
+		pgrep -f -- "${CUSTOM_MINER_DIR}/${CUSTOM_MINERBIN}" || true
+	} | sort -un
+}
+
+signal_miner() {
+	local signal="$1"
+	local -a pids=()
+	mapfile -t pids < <(miner_pids)
+	(( ${#pids[@]} == 0 )) || kill "-$signal" "${pids[@]}" || true
+}
+
+# Give the miner time to flush escrow state before stopping wrappers or screen.
+signal_miner TERM
+for ((i = 0; i < 15; i++)); do
+	[[ -n "$(miner_pids)" ]] || break
+	sleep 1
+done
+
+# Force-stop only after the complete graceful shutdown window.
+signal_miner KILL
+
 if command -v screen >/dev/null 2>&1; then
 	screen -S "miner" -X quit || true
 	screen -S "${CUSTOM_NAME}" -X quit || true
@@ -21,14 +43,3 @@ fi
 pkill -f "${CUSTOM_MINER_DIR}/h-run.sh" || true
 pkill -f "screen.*${CUSTOM_MINERBIN}" || true
 pkill -f "screen.*${CUSTOM_NAME}" || true
-
-# Kill by the exact installed binary path first, then by common invocation patterns.
-pkill -f "${CUSTOM_MINER_DIR}/${CUSTOM_MINERBIN}" || true
-pkill -x "${CUSTOM_MINERBIN}" || true
-pkill -f "./${CUSTOM_MINERBIN}" || true
-pkill -f "/${CUSTOM_NAME}/${CUSTOM_MINERBIN}" || true
-
-# Some wrappers ignore TERM briefly; force-stop if still alive.
-sleep 1
-pkill -9 -f "${CUSTOM_MINER_DIR}/${CUSTOM_MINERBIN}" || true
-pkill -9 -x "${CUSTOM_MINERBIN}" || true

--- a/integrations/hiveos/pre-hive-upgrade.sh
+++ b/integrations/hiveos/pre-hive-upgrade.sh
@@ -1,52 +1,251 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-. "$SCRIPT_DIR/h-manifest.conf"
+KERYX_STATE_DIR="${KERYX_STATE_DIR:-/hive/miners/custom/keryx-miner-state}"
+KERYX_ESCROW_FLAGS="--escrow-key-file $KERYX_STATE_DIR/escrow.key --escrow-state-file $KERYX_STATE_DIR/escrow_state.json"
+
+keryx_validate_key() {
+    local path="$1" key order LC_ALL=C
+    [[ -f "$path" && ! -L "$path" ]] || return 1
+    key="$(< "$path")"
+    key="${key#"${key%%[![:space:]]*}"}"
+    key="${key%"${key##*[![:space:]]}"}"
+    key="${key,,}"
+    order="fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"
+    [[ "$key" =~ ^[0-9a-f]{64}$ ]] && [[ "$key" != "$(printf '%064d' 0)" ]] && [[ "$key" < "$order" ]]
+}
+
+keryx_validate_state() {
+    local path="$1"
+    [[ -f "$path" && ! -L "$path" ]] || return 1
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -I - "$path" <<'PY'
+import json, sys
+
+U8, U32, U64 = 2**8 - 1, 2**32 - 1, 2**64 - 1
+value = json.load(open(sys.argv[1], encoding="utf-8"))
+assert isinstance(value, dict) and isinstance(value.get("entries"), list)
+
+def integer(value, maximum):
+    return type(value) is int and 0 <= value <= maximum
+
+for entry in value["entries"]:
+    assert isinstance(entry, dict)
+    assert isinstance(entry.get("coinbase_txid"), str)
+    assert integer(entry.get("confirm_daa"), U64)
+    assert integer(entry.get("amount_sompi"), U64)
+    assert type(entry.get("claimed")) is bool and type(entry.get("slashed")) is bool
+    assert "block_hash" not in entry or isinstance(entry["block_hash"], str)
+    assert "output_index" not in entry or integer(entry["output_index"], U32)
+    assert "orphan_slashed" not in entry or type(entry["orphan_slashed"]) is bool
+    assert "orphan_retries" not in entry or integer(entry["orphan_retries"], U8)
+    assert "orphan_retry_after_daa" not in entry or entry["orphan_retry_after_daa"] is None or integer(entry["orphan_retry_after_daa"], U64)
+    assert "submit_retries" not in entry or integer(entry["submit_retries"], U8)
+    assert "batch_cap" not in entry or integer(entry["batch_cap"], U8)
+    assert "cap_set_daa" not in entry or integer(entry["cap_set_daa"], U64)
+    assert "is_inference" not in entry or type(entry["is_inference"]) is bool
+PY
+    elif command -v jq >/dev/null 2>&1; then
+        # jq numbers cannot represent every u64 exactly, so its fallback is deliberately conservative.
+        jq -e 'def uint($max): type == "number" and floor == . and . >= 0 and . <= $max;
+            type == "object" and (.entries | type == "array") and all(.entries[];
+                type == "object" and (.coinbase_txid | type == "string") and
+                (.confirm_daa | uint(9007199254740991)) and (.amount_sompi | uint(9007199254740991)) and
+                (.claimed | type == "boolean") and (.slashed | type == "boolean") and
+                (has("block_hash") | not or (.block_hash | type == "string")) and
+                (has("output_index") | not or (.output_index | uint(4294967295))) and
+                (has("orphan_slashed") | not or (.orphan_slashed | type == "boolean")) and
+                (has("orphan_retries") | not or (.orphan_retries | uint(255))) and
+                (has("orphan_retry_after_daa") | not or .orphan_retry_after_daa == null or (.orphan_retry_after_daa | uint(9007199254740991))) and
+                (has("submit_retries") | not or (.submit_retries | uint(255))) and
+                (has("batch_cap") | not or (.batch_cap | uint(255))) and
+                (has("cap_set_daa") | not or (.cap_set_daa | uint(9007199254740991))) and
+                (has("is_inference") | not or (.is_inference | type == "boolean")))' "$path" >/dev/null
+    else
+        echo "[keryx] ERROR: jq or python3 is required to validate escrow state." >&2
+        return 1
+    fi
+}
+
+keryx_validate_escrow_file() {
+    case "${2:-$(basename "$1")}" in
+        escrow.key) keryx_validate_key "$1" ;;
+        escrow_state.json) keryx_validate_state "$1" ;;
+        *) return 1 ;;
+    esac
+}
+
+keryx_sync_path() {
+    if [[ -n "${KERYX_SYNC_COMMAND:-}" ]]; then
+        "$KERYX_SYNC_COMMAND" "$1"
+    else
+        sync -f "$1"
+    fi
+}
+
+prepare_keryx_state() (
+    set -euo pipefail
+    umask 077
+
+    local install_dir="$1" state_dir="${KERYX_STATE_DIR}" name source destination temporary="" lock_file
+    local state_dir_existed=0
+    [[ ! -L "$state_dir" ]] || {
+        echo "[keryx] ERROR: durable escrow directory must not be a symlink: $state_dir" >&2
+        return 1
+    }
+    [[ -d "$state_dir" ]] && state_dir_existed=1
+    mkdir -p "$state_dir" || return 1
+    [[ -d "$state_dir" && ! -L "$state_dir" ]] || return 1
+    chmod 700 "$state_dir" || return 1
+    if (( ! state_dir_existed )); then
+        keryx_sync_path "$(dirname "$state_dir")" || return 1
+    fi
+
+    lock_file="$state_dir/.migration.lock"
+    [[ ! -L "$lock_file" ]] || {
+        echo "[keryx] ERROR: migration lock must not be a symlink: $lock_file" >&2
+        return 1
+    }
+    command -v flock >/dev/null 2>&1 || {
+        echo "[keryx] ERROR: flock is required for escrow migration." >&2
+        return 1
+    }
+    exec 9>"$lock_file" || return 1
+    flock 9 || return 1
+
+    trap '[[ -n "$temporary" ]] && rm -f -- "$temporary"' EXIT
+    for name in escrow.key escrow_state.json; do
+        source="$install_dir/$name"
+        destination="$state_dir/$name"
+
+        if [[ -L "$destination" ]]; then
+            echo "[keryx] ERROR: durable escrow file must not be a symlink: $destination" >&2
+            return 1
+        elif [[ -e "$destination" ]]; then
+            if ! keryx_validate_escrow_file "$destination" "$name"; then
+                echo "[keryx] ERROR: durable escrow file is invalid: $destination" >&2
+                return 1
+            fi
+            chmod 600 "$destination" || return 1
+            keryx_sync_path "$destination" || return 1
+            continue
+        fi
+        if [[ -L "$source" ]]; then
+            echo "[keryx] ERROR: legacy escrow file must not be a symlink: $source" >&2
+            return 1
+        fi
+        [[ ! -e "$source" ]] && continue
+        if ! keryx_validate_escrow_file "$source" "$name"; then
+            echo "[keryx] ERROR: legacy escrow file is invalid: $source" >&2
+            return 1
+        fi
+
+        temporary="$(mktemp "$state_dir/.${name}.migrate.XXXXXX")" || return 1
+        "${KERYX_COPY_COMMAND:-cp}" -- "$source" "$temporary" || return 1
+        cmp -s -- "$source" "$temporary" || return 1
+        keryx_validate_escrow_file "$temporary" "$name" || return 1
+        chmod 600 "$temporary" || return 1
+        keryx_sync_path "$temporary" || return 1
+
+        if ! "${KERYX_INSTALL_COMMAND:-ln}" -- "$temporary" "$destination"; then
+            if [[ -L "$destination" ]] || [[ ! -e "$destination" ]] || ! keryx_validate_escrow_file "$destination" "$name"; then
+                echo "[keryx] ERROR: failed to install durable escrow file: $destination" >&2
+                return 1
+            fi
+        fi
+        rm -f -- "$temporary" || return 1
+        temporary=""
+        chmod 600 "$destination" || return 1
+        keryx_sync_path "$state_dir" || return 1
+    done
+
+    keryx_sync_path "$state_dir" || return 1
+)
+
+keryx_flag_value_once() {
+    local config="${1//$'\n'/ }" flag="$2" expected="$3" value="" word
+    local -a words=()
+    local count=0 index
+    read -r -a words <<< "$config"
+    for ((index = 0; index < ${#words[@]}; index++)); do
+        word="${words[index]}"
+        if [[ "$word" == "$flag" ]]; then
+            ((count += 1))
+            ((index += 1))
+            (( index < ${#words[@]} )) || return 1
+            value="${words[index]}"
+            [[ "$value" != --* ]] || return 1
+        elif [[ "$word" == "$flag="* ]]; then
+            ((count += 1))
+            value="${word#*=}"
+            [[ -n "$value" ]] || return 1
+        fi
+    done
+    [[ "$count" -eq 1 && "$value" == "$expected" ]]
+}
+
+verify_keryx_rollback_config() {
+    local wallet_conf="${KERYX_WALLET_CONF:-/hive-config/wallet.conf}" config
+    [[ -r "$wallet_conf" ]] || {
+        echo "[keryx] ERROR: cannot read HiveOS wallet config: $wallet_conf" >&2
+        return 1
+    }
+    config="$(bash -c 'set +u; . "$1"; printf "%s" "${CUSTOM_USER_CONFIG:-}"' _ "$wallet_conf")" || return 1
+    keryx_flag_value_once "$config" --escrow-key-file "$KERYX_STATE_DIR/escrow.key" &&
+        keryx_flag_value_once "$config" --escrow-state-file "$KERYX_STATE_DIR/escrow_state.json"
+}
 
 cleanup_legacy_models() {
-    local legacy_dir="$CUSTOM_MINER_DIR/models"
-    local shared_dir="/hive/miners/custom/models"
-
-    [[ ! -d "$legacy_dir" ]] && return 0
-    [[ "$legacy_dir" == "$shared_dir" ]] && return 0
-
+    local install_dir="$1" legacy_dir="$1/models" shared_dir="/hive/miners/custom/models"
+    [[ ! -d "$legacy_dir" || "$legacy_dir" == "$shared_dir" ]] && return 0
     if [[ ! -d "$shared_dir" ]]; then
         mv "$legacy_dir" "$shared_dir" || true
         return 0
     fi
-
-    # Merge only entries that do not yet exist in the shared cache.
+    local entry name
     for entry in "$legacy_dir"/*; do
         [[ -e "$entry" ]] || break
-        local name
         name="$(basename "$entry")"
-        [[ -e "$shared_dir/$name" ]] && continue
-        mv "$entry" "$shared_dir/$name" || true
+        [[ -e "$shared_dir/$name" ]] || mv "$entry" "$shared_dir/$name" || true
     done
-
-    # Remove empty directories left behind after merge.
     find "$legacy_dir" -depth -type d -empty -delete 2>/dev/null || true
-
-    if rmdir "$legacy_dir" 2>/dev/null; then
-        echo "[keryx] Legacy model cache cleaned up: $legacy_dir" >&2
-        return 0
-    fi
-
-    if [[ "${KERYX_PURGE_LEGACY_MODELS:-0}" == "1" ]]; then
-        rm -rf "$legacy_dir" || true
-        echo "[keryx] WARNING: force-purged legacy model cache at $legacy_dir (KERYX_PURGE_LEGACY_MODELS=1)." >&2
-    else
-        echo "[keryx] WARNING: legacy model cache still exists at $legacy_dir while $shared_dir already exists (possible duplicate disk usage). Set KERYX_PURGE_LEGACY_MODELS=1 to remove it automatically." >&2
-    fi
+    rmdir "$legacy_dir" 2>/dev/null || true
 }
 
-# Run the current stop hook first so its preservation logic executes before
-# any pre-upgrade migration done here.
-if [[ -x "$SCRIPT_DIR/h-stop.sh" ]]; then
-    "$SCRIPT_DIR/h-stop.sh" || true
+pre_hive_upgrade_main() {
+    set -euo pipefail
+    if [[ "$#" -ne 2 || "$1" != "--install-dir" ]]; then
+        echo "Usage: $0 --install-dir /hive/miners/custom/<installed-keryx-directory>" >&2
+        return 2
+    fi
+
+    local install_dir
+    install_dir="$(readlink -f "$2")"
+    [[ -d "$install_dir" && -f "$install_dir/h-manifest.conf" ]] || {
+        echo "[keryx] ERROR: invalid Keryx install directory: $2" >&2
+        return 1
+    }
+
+    if [[ -x "$install_dir/h-stop.sh" ]]; then
+        "$install_dir/h-stop.sh" || true
+    fi
+    prepare_keryx_state "$install_dir"
+    if ! keryx_validate_key "$KERYX_STATE_DIR/escrow.key"; then
+        echo "[keryx] ERROR: no valid durable escrow key was found after migration; upgrade is not safe." >&2
+        return 1
+    fi
+
+    if ! verify_keryx_rollback_config; then
+        echo "[keryx] Escrow files are preserved, but rollback is not configured." >&2
+        echo "[keryx] Add this exact text to HiveOS Flight Sheet Extra config, apply it, then run this script again:" >&2
+        echo "$KERYX_ESCROW_FLAGS" >&2
+        return 2
+    fi
+
+    cleanup_legacy_models "$install_dir"
+    echo "[keryx] Escrow migration and persistent rollback flags verified."
+    echo "[keryx] It is safe to change only the Install URL while preserving Extra config."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    pre_hive_upgrade_main "$@"
 fi
-
-cleanup_legacy_models
-
-echo "[keryx] HiveOS Pre-upgrade preparation complete."
-echo "[keryx] It is now safe to change the Install URL in the HiveOS custom miner config screen and apply changes."

--- a/integrations/hiveos/tests/state-migration.sh
+++ b/integrations/hiveos/tests/state-migration.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+UPGRADE_SCRIPT="$ROOT/integrations/hiveos/pre-hive-upgrade.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+export KERYX_SYNC_COMMAND=true
+. "$UPGRADE_SCRIPT"
+
+fail() {
+    echo "state-migration: $*" >&2
+    exit 1
+}
+
+write_key() {
+    printf '11%.0s' {1..32} > "$1"
+}
+
+write_other_key() {
+    printf '22%.0s' {1..32} > "$1"
+}
+
+write_state() {
+    printf '{"entries":[],"marker":"%s"}\n' "$2" > "$1"
+}
+
+assert_mode() {
+    [[ "$(stat -c '%a' "$1")" == "$2" ]] || fail "expected mode $2 for $1"
+}
+
+case_dir() {
+    local name="$1"
+    rm -rf "$WORK/$name"
+    mkdir -p "$WORK/$name/install"
+    printf '%s\n' "$WORK/$name"
+}
+
+# Fresh install creates only the protected durable directory.
+base="$(case_dir fresh)"
+KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install"
+[[ -d "$base/state" && ! -e "$base/state/escrow.key" ]] || fail "fresh install"
+assert_mode "$base/state" 700
+
+# First migration copies, validates, syncs, and protects both files.
+base="$(case_dir first)"
+write_key "$base/install/escrow.key"
+write_state "$base/install/escrow_state.json" first
+KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install"
+cmp -s "$base/install/escrow.key" "$base/state/escrow.key" || fail "key copy"
+cmp -s "$base/install/escrow_state.json" "$base/state/escrow_state.json" || fail "state copy"
+assert_mode "$base/state/escrow.key" 600
+assert_mode "$base/state/escrow_state.json" 600
+
+# Repeated migration keeps an existing valid durable destination.
+write_other_key "$base/install/escrow.key"
+write_state "$base/install/escrow_state.json" legacy-newer
+KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install"
+[[ "$(cat "$base/state/escrow.key")" == "$(printf '11%.0s' {1..32})" ]] || fail "idempotent key precedence"
+grep -q '"marker":"first"' "$base/state/escrow_state.json" || fail "idempotent state precedence"
+
+# A valid durable destination also takes precedence over stale invalid legacy data.
+printf 'broken' > "$base/install/escrow.key"
+printf '{broken' > "$base/install/escrow_state.json"
+KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install"
+keryx_validate_key "$base/state/escrow.key" || fail "valid durable key lost precedence"
+keryx_validate_state "$base/state/escrow_state.json" || fail "valid durable state lost precedence"
+
+# Partial migration preserves an existing valid key and fills the missing state.
+base="$(case_dir partial)"
+mkdir -p "$base/state"
+write_key "$base/state/escrow.key"
+write_other_key "$base/install/escrow.key"
+write_state "$base/install/escrow_state.json" partial
+KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install"
+[[ "$(cat "$base/state/escrow.key")" == "$(printf '11%.0s' {1..32})" ]] || fail "partial key precedence"
+grep -q '"marker":"partial"' "$base/state/escrow_state.json" || fail "partial state copy"
+
+# Invalid durable or legacy data fails without replacing either side.
+base="$(case_dir invalid-durable)"
+mkdir -p "$base/state"
+printf 'broken' > "$base/state/escrow.key"
+write_key "$base/install/escrow.key"
+if KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install" 2>/dev/null; then
+    fail "invalid durable key accepted"
+fi
+[[ "$(cat "$base/state/escrow.key")" == broken ]] || fail "invalid durable key changed"
+
+base="$(case_dir invalid-legacy)"
+printf '{broken' > "$base/install/escrow_state.json"
+if KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install" 2>/dev/null; then
+    fail "invalid legacy state accepted"
+fi
+[[ "$(cat "$base/install/escrow_state.json")" == '{broken' ]] || fail "invalid legacy state changed"
+
+base="$(case_dir invalid-entry)"
+printf '{"entries":[{}]}\n' > "$base/install/escrow_state.json"
+if KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install" 2>/dev/null; then
+    fail "state with an invalid entry accepted"
+fi
+
+# Validation matches Rust trimming, integer ranges, and optional field types.
+base="$(case_dir invalid-key-newline)"
+{ printf '11%.0s' {1..16}; printf '\n'; printf '11%.0s' {1..16}; } > "$base/install/escrow.key"
+if KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install" 2>/dev/null; then
+    fail "key with embedded newline accepted"
+fi
+
+for case in oversized optional-type; do
+    base="$(case_dir "invalid-$case")"
+    if [[ "$case" == oversized ]]; then
+        printf '{"entries":[{"coinbase_txid":"x","confirm_daa":18446744073709551616,"amount_sompi":1,"claimed":false,"slashed":false}]}\n' > "$base/install/escrow_state.json"
+    else
+        printf '{"entries":[{"coinbase_txid":"x","confirm_daa":1,"amount_sompi":1,"claimed":false,"slashed":false,"output_index":"1"}]}\n' > "$base/install/escrow_state.json"
+    fi
+    if KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install" 2>/dev/null; then
+        fail "$case state accepted"
+    fi
+done
+
+# Durable paths and legacy sources must be real directories/files, not symlinks.
+base="$(case_dir symlink-state-dir)"
+mkdir -p "$base/linked-state"
+ln -s "$base/linked-state" "$base/state"
+if KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install" 2>/dev/null; then
+    fail "symlink state directory accepted"
+fi
+
+base="$(case_dir symlink-source)"
+write_key "$base/real.key"
+ln -s "$base/real.key" "$base/install/escrow.key"
+if KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install" 2>/dev/null; then
+    fail "symlink legacy key accepted"
+fi
+
+base="$(case_dir symlink-destination)"
+mkdir -p "$base/state"
+write_key "$base/real.key"
+ln -s "$base/real.key" "$base/state/escrow.key"
+if KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install" 2>/dev/null; then
+    fail "symlink durable key accepted"
+fi
+
+# One lock covers the complete key/state migration.
+base="$(case_dir concurrent-lock)"
+mkdir -p "$base/state"
+write_key "$base/install/escrow.key"
+write_state "$base/install/escrow_state.json" locked
+exec 8>"$base/state/.migration.lock"
+flock 8
+(KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install") &
+migration_pid=$!
+sleep 0.2
+[[ ! -e "$base/state/escrow.key" ]] || fail "migration ignored held lock"
+flock -u 8
+wait "$migration_pid"
+keryx_validate_key "$base/state/escrow.key" || fail "locked migration did not complete"
+
+# Injected copy and install failures leave no destination or live temporary file.
+for stage in copy install; do
+    base="$(case_dir "fail-$stage")"
+    write_key "$base/install/escrow.key"
+    if [[ "$stage" == copy ]]; then
+        if KERYX_STATE_DIR="$base/state" KERYX_COPY_COMMAND=false prepare_keryx_state "$base/install" 2>/dev/null; then
+            fail "copy failure accepted"
+        fi
+    else
+        if KERYX_STATE_DIR="$base/state" KERYX_INSTALL_COMMAND=false prepare_keryx_state "$base/install" 2>/dev/null; then
+            fail "install failure accepted"
+        fi
+    fi
+    [[ ! -e "$base/state/escrow.key" ]] || fail "$stage failure installed destination"
+    [[ -z "$(find "$base/state" -name '*.migrate.*' -print -quit)" ]] || fail "$stage failure left temporary file"
+done
+
+# A residue from an interrupted older invocation is ignored and never promoted.
+base="$(case_dir residue)"
+mkdir -p "$base/state"
+printf 'partial' > "$base/state/.escrow.key.migrate.abandoned"
+write_key "$base/install/escrow.key"
+KERYX_STATE_DIR="$base/state" prepare_keryx_state "$base/install"
+keryx_validate_key "$base/state/escrow.key" || fail "residue blocked migration"
+[[ -e "$base/state/.escrow.key.migrate.abandoned" ]] || fail "unowned residue was removed"
+
+# Simulate HiveOS deleting the package for upgrade and rollback. Persistent Extra
+# flags make the unchanged old h-config and the new h-config select the same files.
+base="$(case_dir rollback)"
+state_dir="$base/keryx-miner-state"
+flags="--escrow-key-file $state_dir/escrow.key --escrow-state-file $state_dir/escrow_state.json"
+wallet="$base/wallet.conf"
+printf "CUSTOM_USER_CONFIG='%s'\n" "$flags" > "$wallet"
+
+make_old_package() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cat > "$dir/h-manifest.conf" <<EOF
+CUSTOM_NAME=keryx-miner
+CUSTOM_MINERBIN=keryx-miner
+CUSTOM_MINER_DIR="$dir"
+CUSTOM_CONFIG_FILENAME="$dir/config.ini"
+CUSTOM_LOG_BASENAME=/tmp/keryx-miner
+EOF
+    cat > "$dir/h-config.sh" <<'EOF'
+. "$(dirname "${BASH_SOURCE[0]}")/h-manifest.conf"
+conf=" -s $CUSTOM_URL --mining-address $CUSTOM_TEMPLATE --plain-log-file $CUSTOM_LOG_BASENAME.log"
+[[ -z ${CUSTOM_USER_CONFIG:-} ]] || conf+=" $CUSTOM_USER_CONFIG"
+printf '%s\n' "$conf" > "$CUSTOM_CONFIG_FILENAME"
+EOF
+}
+
+old="$base/keryx-miner"
+make_old_package "$old"
+write_key "$old/escrow.key"
+write_state "$old/escrow_state.json" old
+KERYX_STATE_DIR="$state_dir" prepare_keryx_state "$old"
+
+CUSTOM_URL=grpc://node CUSTOM_TEMPLATE=wallet CUSTOM_USER_CONFIG="$flags" bash -c ". '$old/h-config.sh'"
+grep -Fq -- "$flags" "$old/config.ini" || fail "old package did not use persistent flags"
+rm -rf "$old"
+
+new="$base/keryx-miner"
+mkdir -p "$new"
+cp "$ROOT/integrations/hiveos/h-config.sh" "$new/h-config.sh"
+cp "$ROOT/integrations/hiveos/h-manifest.conf" "$new/h-manifest.conf"
+CUSTOM_URL=grpc://node CUSTOM_TEMPLATE=wallet CUSTOM_USER_CONFIG="$flags" KERYX_STATE_DIR="$state_dir" bash -c ". '$new/h-config.sh'" >/dev/null
+grep -Fq -- "$flags" "$new/config.ini" || fail "new package did not preserve persistent flags"
+if CUSTOM_URL=grpc://node CUSTOM_TEMPLATE=wallet CUSTOM_USER_CONFIG="$flags --escrow-key-file=$state_dir/other.key" KERYX_STATE_DIR="$state_dir" bash -c ". '$new/h-config.sh'" >/dev/null 2>&1; then
+    fail "h-config accepted duplicate escrow key flags"
+fi
+if CUSTOM_URL=grpc://node CUSTOM_TEMPLATE=wallet CUSTOM_USER_CONFIG="--escrow-key-file --escrow-state-file $state_dir/escrow_state.json" KERYX_STATE_DIR="$state_dir" bash -c ". '$new/h-config.sh'" >/dev/null 2>&1; then
+    fail "h-config accepted missing escrow key value"
+fi
+write_state "$state_dir/escrow_state.json" new
+rm -rf "$new"
+
+make_old_package "$old"
+CUSTOM_URL=grpc://node CUSTOM_TEMPLATE=wallet CUSTOM_USER_CONFIG="$flags" bash -c ". '$old/h-config.sh'"
+grep -Fq -- "$flags" "$old/config.ini" || fail "rollback package did not use durable state"
+grep -q '"marker":"new"' "$state_dir/escrow_state.json" || fail "rollback lost new-package state"
+
+# The standalone script requires an explicit install directory and verifies,
+# but never edits, the persistent wallet configuration.
+if KERYX_STATE_DIR="$state_dir" KERYX_WALLET_CONF="$wallet" bash "$UPGRADE_SCRIPT" >/dev/null 2>&1; then
+    fail "standalone script accepted no install directory"
+fi
+wallet_before="$(cat "$wallet")"
+KERYX_STATE_DIR="$state_dir" KERYX_WALLET_CONF="$wallet" KERYX_SYNC_COMMAND=true \
+    bash "$UPGRADE_SCRIPT" --install-dir "$old" >/dev/null
+[[ "$(cat "$wallet")" == "$wallet_before" ]] || fail "standalone script edited wallet.conf"
+
+for bad_flags in \
+    "$flags --escrow-key-file=$state_dir/other.key" \
+    "--escrow-key-file --escrow-state-file $state_dir/escrow_state.json" \
+    "--escrow-key-file=$state_dir/other.key --escrow-state-file $state_dir/escrow_state.json"; do
+    printf "CUSTOM_USER_CONFIG='%s'\n" "$bad_flags" > "$wallet"
+    if KERYX_STATE_DIR="$state_dir" KERYX_WALLET_CONF="$wallet" verify_keryx_rollback_config >/dev/null 2>&1; then
+        fail "rollback verification accepted malformed/conflicting flags"
+    fi
+done
+
+# A valid manifest without a migrated durable key is never upgrade-safe.
+base="$(case_dir standalone-no-key)"
+make_old_package "$base/install"
+flags="--escrow-key-file $base/state/escrow.key --escrow-state-file $base/state/escrow_state.json"
+printf "CUSTOM_USER_CONFIG='%s'\n" "$flags" > "$base/wallet.conf"
+if KERYX_STATE_DIR="$base/state" KERYX_WALLET_CONF="$base/wallet.conf" KERYX_SYNC_COMMAND=true \
+    bash "$UPGRADE_SCRIPT" --install-dir "$base/install" >/dev/null 2>&1; then
+    fail "standalone script reported safe without a durable key"
+fi
+
+echo "state-migration: all focused cases passed"

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,4 +13,7 @@ pub trait Client {
     async fn register(&mut self) -> Result<(), Error>;
     async fn listen(&mut self, miner: &mut MinerManager) -> Result<(), Error>;
     fn get_block_channel(&self) -> Sender<BlockSeed>;
+    fn flush_escrow_state(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
 }

--- a/src/client/grpc.rs
+++ b/src/client/grpc.rs
@@ -147,6 +147,10 @@ impl Client for KeryxdHandler {
     fn get_block_channel(&self) -> Sender<BlockSeed> {
         self.block_channel.clone()
     }
+
+    fn flush_escrow_state(&mut self) -> Result<(), Error> {
+        self.escrow_watcher.as_mut().map_or(Ok(()), |watcher| watcher.flush_state().map_err(Into::into))
+    }
 }
 
 impl KeryxdHandler {

--- a/src/escrow.rs
+++ b/src/escrow.rs
@@ -9,13 +9,13 @@ use blake2b_simd::Params as Blake2bParams;
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use std::{fs, io};
+use tempfile::NamedTempFile;
 
-use crate::proto::{
-    RpcOutpoint, RpcScriptPublicKey, RpcTransaction, RpcTransactionInput, RpcTransactionOutput,
-};
+use crate::proto::{RpcOutpoint, RpcScriptPublicKey, RpcTransaction, RpcTransactionInput, RpcTransactionOutput};
 
 const CHALLENGE_WINDOW_BLOCKS: u64 = 36_000;
 const CLAIM_FEE_SOMPI: u64 = 30_000_000;
@@ -202,15 +202,14 @@ struct InFlightClaim {
 
 impl EscrowWatcher {
     pub fn new(privkey_hex: &str, mining_address: &str, state_path: PathBuf) -> Result<Self, String> {
-        let privkey_bytes = hex::decode(privkey_hex)
-            .map_err(|e| format!("Invalid --mining-privkey hex: {}", e))?;
+        let privkey_bytes = hex::decode(privkey_hex).map_err(|e| format!("Invalid --mining-privkey hex: {}", e))?;
         if privkey_bytes.len() != 32 {
             return Err(format!("--mining-privkey must be 32 bytes (64 hex chars), got {}", privkey_bytes.len()));
         }
 
         let secp = secp256k1::Secp256k1::new();
-        let secret_key = secp256k1::SecretKey::from_slice(&privkey_bytes)
-            .map_err(|e| format!("Invalid private key: {}", e))?;
+        let secret_key =
+            secp256k1::SecretKey::from_slice(&privkey_bytes).map_err(|e| format!("Invalid private key: {}", e))?;
         let keypair = secp256k1::Keypair::from_secret_key(&secp, &secret_key);
         let (xonly, _parity) = keypair.x_only_public_key();
         let pubkey_bytes: [u8; 32] = xonly.serialize();
@@ -222,7 +221,7 @@ impl EscrowWatcher {
         let payout_spk_script = build_p2pk_script(&payout_spk_bytes);
         let payout_spk_script_hex = hex::encode(&payout_spk_script);
 
-        let state = load_state(&state_path);
+        let state = load_state(&state_path)?;
 
         info!("EscrowWatcher ready: pubkey={}", hex::encode(pubkey_bytes));
 
@@ -286,8 +285,11 @@ impl EscrowWatcher {
     /// which is re-derived from the chain on the next blocks.
     fn maybe_flush(&mut self) {
         if self.dirty && self.last_save.elapsed() >= STATE_SAVE_INTERVAL {
-            self.save_state();
-            self.dirty = false;
+            if let Err(e) = self.save_state() {
+                warn!("EscrowWatcher: failed to save state: {}", e);
+            } else {
+                self.dirty = false;
+            }
             self.last_save = Instant::now();
         }
     }
@@ -758,11 +760,7 @@ impl EscrowWatcher {
                 // dead ones converge to solo claims and get slashed there.
                 let halved_cap = ((n_outputs / 2).max(1)).min(u8::MAX as usize) as u8;
                 for (t, i) in &claim.outpoints {
-                    let e = match self
-                        .state
-                        .entries
-                        .iter_mut()
-                        .find(|e| e.coinbase_txid == *t && e.output_index == *i)
+                    let e = match self.state.entries.iter_mut().find(|e| e.coinbase_txid == *t && e.output_index == *i)
                     {
                         Some(e) => e,
                         None => continue,
@@ -830,12 +828,7 @@ impl EscrowWatcher {
     fn mark_entries_claimed(&mut self, outpoints: &[(String, u32)]) -> u64 {
         let mut total_sompi = 0u64;
         for (t, i) in outpoints {
-            if let Some(e) = self
-                .state
-                .entries
-                .iter_mut()
-                .find(|e| e.coinbase_txid == *t && e.output_index == *i)
-            {
+            if let Some(e) = self.state.entries.iter_mut().find(|e| e.coinbase_txid == *t && e.output_index == *i) {
                 if !e.claimed {
                     total_sompi += e.amount_sompi;
                 }
@@ -868,19 +861,14 @@ impl EscrowWatcher {
             inputs_meta.push((txid_bytes, entry.output_index, entry.amount_sompi));
         }
 
-        let reused = SighashReused::new(
-            &inputs_meta,
-            amount_out,
-            self.payout_spk_version,
-            &self.payout_spk_script,
-        );
+        let reused = SighashReused::new(&inputs_meta, amount_out, self.payout_spk_version, &self.payout_spk_script);
         let keypair = secp256k1::Keypair::from_secret_key(&self.secp, &self.secret_key);
 
         let mut inputs: Vec<RpcTransactionInput> = Vec::with_capacity(entries.len());
         for (entry, meta) in entries.iter().zip(&inputs_meta) {
             let sighash = compute_sighash(meta, &self.escrow_script, &reused);
-            let msg = secp256k1::Message::from_digest_slice(&sighash)
-                .map_err(|e| format!("sighash message error: {}", e))?;
+            let msg =
+                secp256k1::Message::from_digest_slice(&sighash).map_err(|e| format!("sighash message error: {}", e))?;
             let sig = self.secp.sign_schnorr_no_aux_rand(&msg, &keypair);
 
             // signature_script: OpData65 (0x41) | 64-byte sig | SIG_HASH_ALL (0x01)
@@ -901,12 +889,7 @@ impl EscrowWatcher {
             });
         }
 
-        let claim_txid = compute_claim_txid(
-            &inputs_meta,
-            amount_out,
-            self.payout_spk_version,
-            &self.payout_spk_script,
-        );
+        let claim_txid = compute_claim_txid(&inputs_meta, amount_out, self.payout_spk_version, &self.payout_spk_script);
 
         Ok((
             claim_txid,
@@ -968,16 +951,156 @@ impl EscrowWatcher {
         self.maybe_flush();
     }
 
-    fn save_state(&self) {
-        match serde_json::to_string_pretty(&self.state) {
-            Ok(json) => {
-                if let Err(e) = fs::write(&self.state_path, &json) {
-                    warn!("EscrowWatcher: failed to save state: {}", e);
-                }
-            }
-            Err(e) => warn!("EscrowWatcher: failed to serialize state: {}", e),
+    fn save_state(&self) -> Result<(), String> {
+        save_state_atomic(&self.state_path, &self.state)
+    }
+
+    pub fn flush_state(&mut self) -> Result<(), String> {
+        if self.dirty {
+            self.save_state()?;
+            self.dirty = false;
+            self.last_save = Instant::now();
+        }
+        Ok(())
+    }
+}
+
+impl Drop for EscrowWatcher {
+    fn drop(&mut self) {
+        if let Err(e) = self.flush_state() {
+            warn!("EscrowWatcher: final state flush failed: {}", e);
         }
     }
+}
+
+fn ensure_parent(path: &Path) -> io::Result<&Path> {
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty()).unwrap_or_else(|| Path::new("."));
+    create_parent_dirs(parent)?;
+    Ok(parent)
+}
+
+#[cfg(unix)]
+fn create_parent_dirs(parent: &Path) -> io::Result<()> {
+    let mut missing = Vec::new();
+    let mut cursor = parent;
+    while !cursor.exists() {
+        missing.push(cursor.to_path_buf());
+        cursor = cursor.parent().filter(|p| !p.as_os_str().is_empty()).unwrap_or_else(|| Path::new("."));
+    }
+    if !cursor.is_dir() {
+        return Err(io::Error::new(io::ErrorKind::NotADirectory, format!("'{}' is not a directory", cursor.display())));
+    }
+    for directory in missing.into_iter().rev() {
+        match fs::create_dir(&directory) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists && directory.is_dir() => {}
+            Err(e) => return Err(e),
+        }
+        sync_parent(directory.parent().unwrap_or_else(|| Path::new(".")))?;
+        sync_parent(&directory)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn create_parent_dirs(parent: &Path) -> io::Result<()> {
+    fs::create_dir_all(parent)
+}
+
+#[cfg(unix)]
+fn sync_parent(parent: &Path) -> io::Result<()> {
+    fs::File::open(parent)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_parent(_parent: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn harden_key_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)?.permissions();
+    if permissions.mode() & 0o077 != 0 {
+        permissions.set_mode(0o600);
+        fs::set_permissions(path, permissions)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn harden_key_permissions(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+thread_local! {
+    static ATOMIC_REPLACE_FAILURE_STAGE: std::cell::Cell<u8> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn inject_atomic_replace_failure(stage: u8) -> io::Result<()> {
+    ATOMIC_REPLACE_FAILURE_STAGE.with(|configured| {
+        if configured.get() == stage {
+            Err(io::Error::new(io::ErrorKind::Other, format!("injected atomic replacement failure at stage {stage}")))
+        } else {
+            Ok(())
+        }
+    })
+}
+
+#[cfg(windows)]
+fn move_file_write_through(source: &Path, destination: &Path, replace: bool) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH};
+
+    let source: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
+    let destination: Vec<u16> = destination.as_os_str().encode_wide().chain(Some(0)).collect();
+    let flags = MOVEFILE_WRITE_THROUGH | if replace { MOVEFILE_REPLACE_EXISTING } else { 0 };
+    if unsafe { MoveFileExW(source.as_ptr(), destination.as_ptr(), flags) } == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+fn install_temp_noclobber(temporary: NamedTempFile, path: &Path) -> io::Result<()> {
+    #[cfg(windows)]
+    {
+        move_file_write_through(temporary.path(), path, false)
+    }
+    #[cfg(not(windows))]
+    {
+        temporary.persist_noclobber(path).map(|_| ()).map_err(|e| e.error)
+    }
+}
+
+fn atomic_replace(path: &Path, contents: &[u8]) -> io::Result<()> {
+    let parent = ensure_parent(path)?;
+    let mut temporary = NamedTempFile::new_in(parent)?;
+    #[cfg(test)]
+    inject_atomic_replace_failure(1)?;
+    temporary.write_all(contents)?;
+    #[cfg(test)]
+    inject_atomic_replace_failure(2)?;
+    temporary.as_file().sync_all()?;
+    #[cfg(test)]
+    inject_atomic_replace_failure(3)?;
+    #[cfg(windows)]
+    move_file_write_through(temporary.path(), path, true)?;
+    #[cfg(not(windows))]
+    temporary.persist(path).map_err(|e| e.error)?;
+    #[cfg(test)]
+    inject_atomic_replace_failure(4)?;
+    sync_parent(parent)
+}
+
+/// Persist escrow state without exposing a partially-written JSON file.
+pub fn save_state_atomic(path: &Path, state: &EscrowState) -> Result<(), String> {
+    let json = serde_json::to_vec_pretty(state).map_err(|e| format!("Failed to serialize escrow state: {}", e))?;
+    atomic_replace(path, &json)
+        .map_err(|e| format!("Failed to atomically write escrow state '{}': {}", path.display(), e))
 }
 
 /// Load the OPoI escrow private key from `path`. Fails if the file does not exist.
@@ -990,14 +1113,11 @@ pub fn load_key(path: &str) -> Result<String, String> {
             path
         ));
     }
-    let s = fs::read_to_string(p)
-        .map_err(|e| format!("Failed to read escrow key file '{}': {}", path, e))?;
+    harden_key_permissions(p).map_err(|e| format!("Failed to secure escrow key file '{}': {}", path, e))?;
+    let s = fs::read_to_string(p).map_err(|e| format!("Failed to read escrow key file '{}': {}", path, e))?;
     let privkey = s.trim().to_string();
     if privkey.len() != 64 || !privkey.bytes().all(|b| b.is_ascii_hexdigit()) {
-        return Err(format!(
-            "Escrow key file '{}' must contain exactly 64 hex chars",
-            path
-        ));
+        return Err(format!("Escrow key file '{}' must contain exactly 64 hex chars", path));
     }
     Ok(privkey)
 }
@@ -1008,16 +1128,8 @@ pub fn load_or_generate_key(path: &str) -> Result<String, String> {
     use rand::RngCore;
     let p = std::path::Path::new(path);
     if p.exists() {
-        let s = fs::read_to_string(p)
-            .map_err(|e| format!("Failed to read escrow key file '{}': {}", path, e))?;
-        let privkey = s.trim().to_string();
-        if privkey.len() != 64 || !privkey.bytes().all(|b| b.is_ascii_hexdigit()) {
-            return Err(format!(
-                "Escrow key file '{}' must contain exactly 64 hex chars — delete it to regenerate",
-                path
-            ));
-        }
-        return Ok(privkey);
+        return load_key(path)
+            .map_err(|e| format!("{}. Restore the correct key; do not delete a key that may control rewards.", e));
     }
 
     let mut privkey_bytes = [0u8; 32];
@@ -1035,8 +1147,21 @@ pub fn load_or_generate_key(path: &str) -> Result<String, String> {
     let (xonly, _) = kp.x_only_public_key();
     let pubkey_hex = hex::encode(xonly.serialize());
 
-    fs::write(p, &privkey_hex)
+    let parent =
+        ensure_parent(p).map_err(|e| format!("Failed to create escrow key directory for '{}': {}", path, e))?;
+    let mut temporary = NamedTempFile::new_in(parent)
+        .map_err(|e| format!("Failed to create temporary escrow key file for '{}': {}", path, e))?;
+    temporary
+        .write_all(privkey_hex.as_bytes())
+        .and_then(|_| temporary.as_file().sync_all())
         .map_err(|e| format!("Failed to write escrow key file '{}': {}", path, e))?;
+
+    match install_temp_noclobber(temporary, p) {
+        Ok(()) => sync_parent(parent)
+            .map_err(|e| format!("Failed to sync escrow key directory '{}': {}", parent.display(), e))?,
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => return load_key(path),
+        Err(e) => return Err(format!("Failed to install escrow key file '{}': {}", path, e)),
+    }
 
     info!("OPoI escrow keypair generated — saved to '{}'", path);
     info!("  Escrow pubkey : {}", pubkey_hex);
@@ -1046,30 +1171,22 @@ pub fn load_or_generate_key(path: &str) -> Result<String, String> {
 
 /// Derive the x-only public key hex (64 hex chars) from a hex-encoded private key.
 pub fn pubkey_hex_from_privkey(privkey_hex: &str) -> Result<String, String> {
-    let privkey_bytes = hex::decode(privkey_hex)
-        .map_err(|e| format!("Invalid privkey hex: {}", e))?;
+    let privkey_bytes = hex::decode(privkey_hex).map_err(|e| format!("Invalid privkey hex: {}", e))?;
     let secp = secp256k1::Secp256k1::new();
-    let sk = secp256k1::SecretKey::from_slice(&privkey_bytes)
-        .map_err(|e| format!("Invalid private key: {}", e))?;
+    let sk = secp256k1::SecretKey::from_slice(&privkey_bytes).map_err(|e| format!("Invalid private key: {}", e))?;
     let kp = secp256k1::Keypair::from_secret_key(&secp, &sk);
     let (xonly, _) = kp.x_only_public_key();
     Ok(hex::encode(xonly.serialize()))
 }
 
-fn load_state(path: &PathBuf) -> EscrowState {
-    let state = match fs::read_to_string(path) {
-        Ok(s) => serde_json::from_str(&s).unwrap_or_else(|e| {
-            warn!("EscrowWatcher: could not parse {}: {} — starting fresh", path.display(), e);
-            EscrowState::default()
+fn load_state(path: &Path) -> Result<EscrowState, String> {
+    match fs::read_to_string(path) {
+        Ok(s) => serde_json::from_str(&s).map_err(|e| {
+            format!("Escrow state '{}' is corrupt: {}. Restore it or run --recover-escrow.", path.display(), e)
         }),
-        Err(e) if e.kind() == io::ErrorKind::NotFound => EscrowState::default(),
-        Err(e) => {
-            warn!("EscrowWatcher: could not read {}: {} — starting fresh", path.display(), e);
-            EscrowState::default()
-        }
-    };
-
-    state
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(EscrowState::default()),
+        Err(e) => Err(format!("Failed to read escrow state '{}': {}", path.display(), e)),
+    }
 }
 
 // ── Script builders ───────────────────────────────────────────────────────────
@@ -1277,4 +1394,170 @@ fn decode_address(addr: &str) -> Result<(u16, [u8; 32]), String> {
     let mut spk = [0u8; 32];
     spk.copy_from_slice(&bytes[1..33]);
     Ok((version, spk))
+}
+
+#[cfg(test)]
+mod persistence_tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+
+    fn state(confirm_daa: u64) -> EscrowState {
+        EscrowState {
+            entries: vec![EscrowEntry {
+                coinbase_txid: "01".repeat(32),
+                block_hash: "02".repeat(32),
+                confirm_daa,
+                amount_sompi: 100,
+                output_index: 1,
+                claimed: false,
+                slashed: false,
+                orphan_slashed: false,
+                orphan_retries: 0,
+                orphan_retry_after_daa: None,
+                submit_retries: 0,
+                batch_cap: 0,
+                cap_set_daa: 0,
+                is_inference: false,
+            }],
+        }
+    }
+
+    fn fail_at(stage: u8) {
+        ATOMIC_REPLACE_FAILURE_STAGE.with(|configured| configured.set(stage));
+    }
+
+    #[test]
+    fn state_replacement_is_complete_and_parseable() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("escrow_state.json");
+        save_state_atomic(&path, &EscrowState::default()).unwrap();
+        save_state_atomic(&path, &state(42)).unwrap();
+
+        let loaded: EscrowState = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].confirm_daa, 42);
+    }
+
+    #[test]
+    fn failures_before_replace_preserve_previous_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("escrow_state.json");
+        save_state_atomic(&path, &state(1)).unwrap();
+        let original = fs::read(&path).unwrap();
+
+        for stage in 1..=3 {
+            fail_at(stage);
+            assert!(save_state_atomic(&path, &state(2)).is_err());
+            fail_at(0);
+            assert_eq!(fs::read(&path).unwrap(), original, "failure stage {stage}");
+        }
+    }
+
+    #[test]
+    fn failure_after_replace_leaves_complete_state_and_allows_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("escrow_state.json");
+        save_state_atomic(&path, &state(1)).unwrap();
+
+        fail_at(4);
+        assert!(save_state_atomic(&path, &state(2)).is_err());
+        fail_at(0);
+        let loaded: EscrowState = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(loaded.entries[0].confirm_daa, 2);
+
+        save_state_atomic(&path, &state(3)).unwrap();
+        let retried: EscrowState = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+        assert_eq!(retried.entries[0].confirm_daa, 3);
+    }
+
+    #[test]
+    fn concurrent_key_creation_returns_one_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = Arc::new(dir.path().join("escrow.key"));
+        let barrier = Arc::new(Barrier::new(8));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let path = Arc::clone(&path);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    load_or_generate_key(path.to_str().unwrap()).unwrap()
+                })
+            })
+            .collect();
+        let keys: Vec<_> = handles.into_iter().map(|handle| handle.join().unwrap()).collect();
+
+        assert!(keys.iter().all(|key| key == &keys[0]));
+        assert_eq!(fs::read_to_string(path.as_ref()).unwrap(), keys[0]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generated_key_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("escrow.key");
+        load_or_generate_key(path.to_str().unwrap()).unwrap();
+        assert_eq!(fs::metadata(path).unwrap().permissions().mode() & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_key_permissions_are_hardened() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("escrow.key");
+        fs::write(&path, "11".repeat(32)).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        load_or_generate_key(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(fs::metadata(path).unwrap().permissions().mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn invalid_key_fails_without_changing_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("escrow.key");
+        let invalid = b"not-a-private-key";
+        fs::write(&path, invalid).unwrap();
+
+        assert!(load_or_generate_key(path.to_str().unwrap()).is_err());
+        assert_eq!(fs::read(path).unwrap(), invalid);
+    }
+
+    #[test]
+    fn corrupt_state_fails_closed_without_changing_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("escrow_state.json");
+        let invalid = b"{not-json";
+        fs::write(&path, invalid).unwrap();
+
+        let error = load_state(&path).unwrap_err();
+        assert!(error.contains("corrupt"));
+        assert!(error.contains("--recover-escrow"));
+        assert_eq!(fs::read(path).unwrap(), invalid);
+    }
+
+    #[test]
+    fn explicit_flush_keeps_dirty_state_until_retry_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("state").join("escrow_state.json");
+        let address = format!("keryx:{}", "q".repeat(61));
+        let mut watcher = EscrowWatcher::new(&"11".repeat(32), &address, path.clone()).unwrap();
+        watcher.state = state(77);
+        watcher.dirty = true;
+
+        fail_at(1);
+        assert!(watcher.flush_state().is_err());
+        assert!(watcher.dirty);
+        fail_at(0);
+        watcher.flush_state().unwrap();
+
+        assert!(!watcher.dirty);
+        let loaded: EscrowState = serde_json::from_slice(&fs::read(path).unwrap()).unwrap();
+        assert_eq!(loaded.entries[0].confirm_daa, 77);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,11 +73,7 @@ type Hash = Uint256;
 fn install_cuda_libs() -> bool {
     use std::process::Command;
     // Only meaningful where apt-get exists (Debian/Ubuntu, incl. HiveOS).
-    let has_apt = Command::new("sh")
-        .args(["-c", "command -v apt-get"])
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
+    let has_apt = Command::new("sh").args(["-c", "command -v apt-get"]).status().map(|s| s.success()).unwrap_or(false);
     if !has_apt {
         error!("CUDA lib auto-install needs apt-get (Debian/Ubuntu) — not found on this system.");
         return false;
@@ -141,6 +137,46 @@ fn adjust_console() -> Result<(), Error> {
     Ok(())
 }
 
+#[cfg(test)]
+mod recovery_tests {
+    use super::*;
+
+    fn api_entry() -> ApiEscrowEntry {
+        ApiEscrowEntry {
+            coinbase_txid: "AB".repeat(32),
+            block_hash: "CD".repeat(32),
+            confirm_daa: 10,
+            amount_sompi: 20,
+            output_index: 1,
+        }
+    }
+
+    #[test]
+    fn recovery_validates_and_normalizes_entries() {
+        let (state, total) = recovered_escrow_state(vec![api_entry()]).unwrap();
+        assert_eq!(total, 20);
+        assert_eq!(state.entries[0].coinbase_txid, "ab".repeat(32));
+        assert_eq!(state.entries[0].block_hash, "cd".repeat(32));
+    }
+
+    #[test]
+    fn recovery_rejects_invalid_network_values() {
+        let mut entry = api_entry();
+        entry.confirm_daa = -1;
+        assert!(recovered_escrow_state(vec![entry]).is_err());
+
+        let mut entry = api_entry();
+        entry.output_index = i64::from(u32::MAX) + 1;
+        assert!(recovered_escrow_state(vec![entry]).is_err());
+
+        let mut entry = api_entry();
+        entry.coinbase_txid = "not-a-hash".into();
+        assert!(recovered_escrow_state(vec![entry]).is_err());
+
+        assert!(recovered_escrow_state(vec![api_entry(), api_entry()]).is_err());
+    }
+}
+
 fn filter_plugins(dirname: &str) -> Vec<String> {
     match fs::read_dir(dirname) {
         Ok(readdir) => readdir
@@ -168,8 +204,7 @@ fn redirect_stderr_for_tui(path: &str) -> Result<(), String> {
         .open(path)
         .map_err(|e| format!("open stderr log '{}': {}", path, e))?;
 
-    dup2(file.as_raw_fd(), STDERR_FILENO)
-        .map_err(|e| format!("dup2(stderr -> '{}') failed: {}", path, e))?;
+    dup2(file.as_raw_fd(), STDERR_FILENO).map_err(|e| format!("dup2(stderr -> '{}') failed: {}", path, e))?;
     Ok(())
 }
 
@@ -207,10 +242,7 @@ extern "C" fn plugin_log_sink(level: u8, msg_ptr: *const u8, msg_len: usize) {
 /// Power thresholds empirically derived: Xid 32 observed at ≤300W on RTX 3090 with 32B GGUF.
 fn check_gpu_power_limit(needs_high: bool, needs_very_high: bool) {
     let output = std::process::Command::new("nvidia-smi")
-        .args([
-            "--query-gpu=power.limit,power.max_limit,memory.total",
-            "--format=csv,noheader,nounits",
-        ])
+        .args(["--query-gpu=power.limit,power.max_limit,memory.total", "--format=csv,noheader,nounits"])
         .output();
 
     // nvidia-smi prints one line per GPU; the power + VRAM check applies to GPU 0
@@ -335,10 +367,14 @@ fn assign_pom_tiers(
     if devices.is_empty() {
         // No enumeration: a forced first entry still wins for the fallback device-0 tier.
         if let Some(t) = forced.first().copied().flatten() {
-            log::warn!("No CUDA device enumerated for PoM tier assignment — assigning the forced tier to device 0 (fallback).");
+            log::warn!(
+                "No CUDA device enumerated for PoM tier assignment — assigning the forced tier to device 0 (fallback)."
+            );
             return vec![(0u32, t, keryx_miner::models::spec_for_tier(t))];
         }
-        log::warn!("No CUDA device enumerated for PoM tier assignment — assigning the ceiling tier to device 0 (fallback).");
+        log::warn!(
+            "No CUDA device enumerated for PoM tier assignment — assigning the ceiling tier to device 0 (fallback)."
+        );
         return candidates.first().map(|(_, t, s)| vec![(0u32, *t, *s)]).unwrap_or_default();
     }
     let mut out = Vec::with_capacity(devices.len());
@@ -361,7 +397,9 @@ fn assign_pom_tiers(
         }
         match pick(vram_mb) {
             Some((t, spec)) => out.push((id as u32, t, spec)),
-            None => log::warn!("PoM: GPU {} ({} MB VRAM) fits no tier ≤ the ceiling — it will not mine PoM.", id, vram_mb),
+            None => {
+                log::warn!("PoM: GPU {} ({} MB VRAM) fits no tier ≤ the ceiling — it will not mine PoM.", id, vram_mb)
+            }
         }
     }
     out
@@ -447,6 +485,71 @@ async fn get_client(
     }
 }
 
+#[derive(Debug)]
+struct EscrowFlushError(String);
+
+impl std::fmt::Display for EscrowFlushError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for EscrowFlushError {}
+
+#[derive(serde::Deserialize)]
+struct ApiEscrowEntry {
+    coinbase_txid: String,
+    block_hash: String,
+    confirm_daa: i64,
+    amount_sompi: i64,
+    output_index: i64,
+}
+
+fn recovered_escrow_state(api_entries: Vec<ApiEscrowEntry>) -> Result<(escrow::EscrowState, u64), String> {
+    let mut entries = Vec::with_capacity(api_entries.len());
+    let mut outpoints = std::collections::HashSet::with_capacity(api_entries.len());
+    let mut total_sompi = 0u64;
+    for api_entry in api_entries {
+        if api_entry.coinbase_txid.len() != 64 || !api_entry.coinbase_txid.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err("Recovery API returned an invalid coinbase transaction ID".into());
+        }
+        if api_entry.block_hash.len() != 64 || !api_entry.block_hash.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err("Recovery API returned an invalid block hash".into());
+        }
+        let confirm_daa = u64::try_from(api_entry.confirm_daa)
+            .map_err(|_| "Recovery API returned a negative confirmation DAA score")?;
+        let amount_sompi =
+            u64::try_from(api_entry.amount_sompi).map_err(|_| "Recovery API returned a negative escrow amount")?;
+        if amount_sompi == 0 {
+            return Err("Recovery API returned a zero escrow amount".into());
+        }
+        let output_index =
+            u32::try_from(api_entry.output_index).map_err(|_| "Recovery API returned an invalid output index")?;
+        let coinbase_txid = api_entry.coinbase_txid.to_ascii_lowercase();
+        if !outpoints.insert((coinbase_txid.clone(), output_index)) {
+            return Err("Recovery API returned a duplicate escrow outpoint".into());
+        }
+        total_sompi = total_sompi.checked_add(amount_sompi).ok_or("Recovered escrow amount overflow")?;
+        entries.push(escrow::EscrowEntry {
+            coinbase_txid,
+            block_hash: api_entry.block_hash.to_ascii_lowercase(),
+            confirm_daa,
+            amount_sompi,
+            output_index,
+            claimed: false,
+            slashed: false,
+            orphan_slashed: false,
+            orphan_retries: 0,
+            orphan_retry_after_daa: None,
+            submit_retries: 0,
+            batch_cap: 0,
+            cap_set_daa: 0,
+            is_inference: false,
+        });
+    }
+    Ok((escrow::EscrowState { entries }, total_sompi))
+}
+
 async fn client_main(
     opt: &Opt,
     block_template_ctr: Arc<AtomicU16>,
@@ -474,16 +577,38 @@ async fn client_main(
     }
     client.register().await?;
     let mut miner_manager = MinerManager::new(client.get_block_channel(), opt.num_threads, plugin_manager, stats);
-    tokio::select! {
+    let listen_result = tokio::select! {
         listen_res = client.listen(&mut miner_manager) => {
-            listen_res?;
+            listen_res
         }
         _ = wait_for_shutdown(shutdown_requested) => {
             info!("Shutdown requested, stopping client listen loop");
+            Ok(())
+        }
+    };
+    // Flush funds-critical client state before potentially blocking on worker shutdown.
+    let mut flush_error = None;
+    for attempt in 1..=3 {
+        match client.flush_escrow_state() {
+            Ok(()) => {
+                flush_error = None;
+                break;
+            }
+            Err(e) => {
+                flush_error = Some(e.to_string());
+                warn!("Escrow final flush attempt {}/3 failed: {}", attempt, e);
+                if attempt < 3 {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
         }
     }
+    drop(client);
     drop(miner_manager);
-    Ok(())
+    if let Some(error) = flush_error {
+        return Err(Box::new(EscrowFlushError(error)));
+    }
+    listen_result
 }
 
 async fn wait_for_shutdown(shutdown_requested: Arc<AtomicBool>) {
@@ -497,11 +622,7 @@ async fn wait_for_shutdown(shutdown_requested: Arc<AtomicBool>) {
 /// idle executor threads on a many-core rig are pure scheduler overhead. Override with
 /// KERYX_ASYNC_WORKERS.
 fn tokio_worker_threads() -> usize {
-    std::env::var("KERYX_ASYNC_WORKERS")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(2)
-        .clamp(1, 8)
+    std::env::var("KERYX_ASYNC_WORKERS").ok().and_then(|s| s.parse::<usize>().ok()).unwrap_or(2).clamp(1, 8)
 }
 
 /// Optional cap for the `spawn_blocking` pool (SLM inference, IPFS upload, model prefetch). Only
@@ -509,10 +630,7 @@ fn tokio_worker_threads() -> usize {
 /// tokio's default costs nothing at rest and capping it low would bottleneck parallel multi-model
 /// prefetch on multi-GPU rigs.
 fn tokio_blocking_threads() -> Option<usize> {
-    std::env::var("KERYX_BLOCKING_THREADS")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .map(|n| n.clamp(2, 64))
+    std::env::var("KERYX_BLOCKING_THREADS").ok().and_then(|s| s.parse::<usize>().ok()).map(|n| n.clamp(2, 64))
 }
 
 fn main() -> Result<(), Error> {
@@ -557,23 +675,50 @@ async fn run() -> Result<(), Error> {
     {
         let shutdown_requested = Arc::clone(&shutdown_requested);
         tokio::spawn(async move {
-            let _ = tokio::signal::ctrl_c().await;
-            shutdown_requested.store(true, Ordering::Release);
+            #[cfg(unix)]
+            {
+                let mut terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate());
+                loop {
+                    match terminate.as_mut() {
+                        Ok(terminate) => {
+                            tokio::select! {
+                                _ = tokio::signal::ctrl_c() => {}
+                                _ = terminate.recv() => {}
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to register SIGTERM handler: {}", e);
+                            if tokio::signal::ctrl_c().await.is_err() {
+                                return;
+                            }
+                        }
+                    }
+                    if shutdown_requested.swap(true, Ordering::AcqRel) {
+                        eprintln!("Second shutdown signal received; forcing exit");
+                        std::process::exit(1);
+                    }
+                }
+            }
+            #[cfg(not(unix))]
+            loop {
+                if tokio::signal::ctrl_c().await.is_err() {
+                    return;
+                }
+                if shutdown_requested.swap(true, Ordering::AcqRel) {
+                    eprintln!("Second shutdown signal received; forcing exit");
+                    std::process::exit(1);
+                }
+            }
         });
     }
     let ui_state = if is_tty { Some(Arc::new(UiState::new())) } else { None };
-    let plain_log_path = opt
-        .plain_log_file
-        .clone()
-        .or_else(|| std::env::var("KERYX_PLAIN_LOG_FILE").ok());
-    let plain_log_file = plain_log_path
-        .and_then(|path| {
-            match OpenOptions::new().create(true).append(true).open(&path) {
-                Ok(file) => Some(file),
-                Err(e) => {
-                    eprintln!("Failed to open plain log file '{}': {}", path, e);
-                    None
-                }
+    let plain_log_path = opt.plain_log_file.clone().or_else(|| std::env::var("KERYX_PLAIN_LOG_FILE").ok());
+    let plain_log_file =
+        plain_log_path.and_then(|path| match OpenOptions::new().create(true).append(true).open(&path) {
+            Ok(file) => Some(file),
+            Err(e) => {
+                eprintln!("Failed to open plain log file '{}': {}", path, e);
+                None
             }
         });
     init_logging(opt.log_level(), ui_state.clone(), !is_tty, plain_log_file)?;
@@ -608,19 +753,15 @@ async fn run() -> Result<(), Error> {
     let stats = Arc::new(MinerStats::new(opt.hiveos));
     stats.set_mining_address(opt.mining_address.clone());
     stats.set_api_port(opt.stats_port);
-    let _ui_guard = ui_state
-        .as_ref()
-        .map(|ui| spawn_ui(Arc::clone(&stats), Arc::clone(ui), Arc::clone(&shutdown_requested)));
+    let _ui_guard =
+        ui_state.as_ref().map(|ui| spawn_ui(Arc::clone(&stats), Arc::clone(ui), Arc::clone(&shutdown_requested)));
 
     match spawn_stats_server(Arc::clone(&stats), opt.stats_bind.clone(), opt.stats_port) {
         Ok(_handle) => {
             info!("Stats API listening on {}:{}", opt.stats_bind, opt.stats_port);
         }
         Err(e) => {
-            warn!(
-                "Failed to start stats API on {}:{} ({})",
-                opt.stats_bind, opt.stats_port, e
-            );
+            warn!("Failed to start stats API on {}:{} ({})", opt.stats_bind, opt.stats_port, e);
         }
     }
 
@@ -650,57 +791,23 @@ async fn run() -> Result<(), Error> {
         let url = format!("{}/api/v1/escrow/{}", opt.recover_escrow_api.trim_end_matches('/'), pubkey_hex);
         info!("Querying escrow UTXOs from {}", url);
 
-        #[derive(serde::Deserialize)]
-        struct ApiEscrowEntry {
-            coinbase_txid: String,
-            block_hash: String,
-            confirm_daa: i64,
-            amount_sompi: i64,
-            output_index: i64,
-        }
-
         let url_clone = url.clone();
         let api_entries: Vec<ApiEscrowEntry> = tokio::task::spawn_blocking(move || {
-            let response = ureq::get(&url_clone)
-                .call()
-                .map_err(|e| format!("HTTP request failed: {}", e))?;
+            let response = ureq::get(&url_clone).call().map_err(|e| format!("HTTP request failed: {}", e))?;
             serde_json::from_reader::<_, Vec<ApiEscrowEntry>>(response.into_reader())
                 .map_err(|e| format!("JSON parse error: {}", e))
         })
         .await
         .map_err(|e| format!("spawn_blocking failed: {}", e))??;
 
-        let entries: Vec<escrow::EscrowEntry> = api_entries
-            .into_iter()
-            .map(|a| escrow::EscrowEntry {
-                coinbase_txid: a.coinbase_txid,
-                block_hash: a.block_hash,
-                confirm_daa: a.confirm_daa as u64,
-                amount_sompi: a.amount_sompi as u64,
-                output_index: a.output_index as u32,
-                claimed: false,
-                slashed: false,
-                orphan_slashed: false,
-                orphan_retries: 0,
-                orphan_retry_after_daa: None,
-                submit_retries: 0,
-                batch_cap: 0,
-                cap_set_daa: 0,
-                is_inference: false,
-            })
-            .collect();
+        let (state, total_sompi) = recovered_escrow_state(api_entries)?;
+        let count = state.entries.len();
+        if shutdown_requested.load(Ordering::Acquire) {
+            return Err("Shutdown requested before recovered escrow state was saved".into());
+        }
+        escrow::save_state_atomic(std::path::Path::new(&opt.escrow_state_file), &state)?;
 
-        let total_sompi: u64 = entries.iter().map(|e| e.amount_sompi).sum();
-        let count = entries.len();
-        let state = escrow::EscrowState { entries };
-        let json = serde_json::to_string_pretty(&state)?;
-        fs::write(&opt.escrow_state_file, &json)?;
-
-        info!(
-            "Recovered {} escrow entries — claimable: {:.4} KRX",
-            count,
-            total_sompi as f64 / 1e8
-        );
+        info!("Recovered {} escrow entries — claimable: {:.4} KRX", count, total_sompi as f64 / 1e8);
         info!("State saved to '{}'.", opt.escrow_state_file);
         return Ok(());
     }
@@ -728,13 +835,13 @@ async fn run() -> Result<(), Error> {
 
     // Per-card tier overrides (--force-model, CUDA-driver order). Parsed once here — the power
     // warning below and the per-GPU assignment both need them.
-    let forced_tiers: Vec<Option<keryx_miner::models::Tier>> = opt
-        .force_model
-        .as_deref()
-        .map(|s| s.split(',').map(parse_tier_name).collect())
-        .unwrap_or_default();
+    let forced_tiers: Vec<Option<keryx_miner::models::Tier>> =
+        opt.force_model.as_deref().map(|s| s.split(',').map(parse_tier_name).collect()).unwrap_or_default();
     if let Some(raw) = opt.force_model.as_deref() {
-        info!("--force-model: {} — per-card tier override (VRAM floor bypassed; unlisted/extra cards use auto).", raw.trim());
+        info!(
+            "--force-model: {} — per-card tier override (VRAM floor bypassed; unlisted/extra cards use auto).",
+            raw.trim()
+        );
     }
     let forced_max_rank = forced_tiers.iter().flatten().map(|t| tier_rank(*t)).max();
 
@@ -796,8 +903,10 @@ async fn run() -> Result<(), Error> {
             let gpath = keryx_miner::slm::gguf_path_for(spec).to_string_lossy().into_owned();
             keryx_miner::pom_gpu::set_mining_tier(*device_id, spec.model_id, gpath);
             keryx_miner::pom_gpu::set_device_tier(*device_id, *gpu_tier);
-            info!("PoM: GPU {} → {} (index + GPU walk load lazily once the lineup is active).",
-                device_id, spec.dir_name);
+            info!(
+                "PoM: GPU {} → {} (index + GPU walk load lazily once the lineup is active).",
+                device_id, spec.dir_name
+            );
         }
     }
 
@@ -805,7 +914,9 @@ async fn run() -> Result<(), Error> {
     // that cannot run inference must fail fast with a clear message rather than spam panics.
     info!("Probing GPU inference (cuBLAS + llama engine) before mining…");
     match tokio::task::spawn_blocking(keryx_miner::slm::probe_gpu_inference).await {
-        Ok(keryx_miner::slm::GpuProbe::Ok) => info!("GPU inference verified — cuBLAS and the llama engine loaded successfully."),
+        Ok(keryx_miner::slm::GpuProbe::Ok) => {
+            info!("GPU inference verified — cuBLAS and the llama engine loaded successfully.")
+        }
         Ok(keryx_miner::slm::GpuProbe::NoCuda) => {
             error!("No CUDA device detected — OPoI inference is GPU-only and is mandatory, cannot mine.");
             return Err("No CUDA device — cannot start OPoI mining".into());
@@ -889,6 +1000,10 @@ async fn run() -> Result<(), Error> {
         .await
         {
             Ok(_) => info!("Client closed gracefully"),
+            Err(e) if e.downcast_ref::<EscrowFlushError>().is_some() => {
+                error!("Funds-critical escrow state could not be persisted: {}", e);
+                return Err(e);
+            }
             Err(e) => error!("Client closed with error {:?}", e),
         }
         if shutdown_requested.load(Ordering::Acquire) {


### PR DESCRIPTION
# Make escrow and HiveOS state persistence durable

Intended base: `Keryx-Labs/keryx-miner:main`

Independent branch: `fix/escrow-hiveos-durability`

Local commits:

- `25b6b8b fix(escrow): make state persistence durable`
- `06fded9 fix(escrow): declare tempfile dependency`

## Problem

Escrow keys, escrow state, and recovery state could be reported as saved before their directory metadata was durable. HiveOS upgrades and rollbacks could also return to package-local state paths, lose valid state, or accept an incomplete migration.

## Changes

- Persist escrow keys and state through same-directory temporary files, file synchronization, atomic replacement, and parent-directory synchronization.
- Use write-through replacement on Windows and synchronize newly created directory ancestors on Unix.
- Preserve valid destination files and fail closed on malformed key, escrow, and recovery data.
- Keep dirty state pending after write failures, retry final flushes during shutdown, and stop reconnecting when the final flush cannot be completed.
- Handle SIGTERM through the normal shutdown path so escrow state is flushed before exit.
- Store HiveOS state under `/hive/miners/custom/keryx-miner-state` with stable permissions and exact persistent Flight Sheet flags.
- Add a source-safe, locked, idempotent migration that rejects symlinks, malformed data, conflicting flags, partial copies, and missing durable keys.
- Make upgrade and rollback instructions use the migration script bundled with the target release.
- Stop only the package's miner processes and use a consistent process set for graceful termination and forced cleanup.

## Additional Fixes Discovered

- Temporary migration files are validated using their logical escrow filename rather than their randomized temporary basename.
- Every durability-critical shell operation propagates failure explicitly instead of relying on `set -e`, which Bash suppresses when a function is called from a conditional.
- Python state validation runs in isolated mode so environment variables cannot disable assertions.
- Recovery parsing uses checked integer conversions and rejects malformed hashes, zero amounts, duplicate outpoints, and overflow before replacing known-good state.

## Invariants Preserved

- Existing valid escrow keys and state are never overwritten by migration.
- Package upgrades and rollbacks use the same persistent state paths.
- Mining does not reconnect after an unrecoverable final escrow flush failure.
- The phase remains limited to escrow durability, shutdown handling, and HiveOS state migration.

## Verification

- Native CUDA 12.2 and MSVC 19.36: escrow persistence tests, 7 passed, 0 failed.
- Native CUDA 12.2 and MSVC 19.36: recovery validation tests, 2 passed, 0 failed.
- `bash integrations/hiveos/tests/state-migration.sh`: all focused migration, failure-injection, concurrency, upgrade, and rollback cases passed under WSL Ubuntu.
- `bash -n` passed for all changed HiveOS scripts and the migration test.
- `cargo test -p keryx-miner --lib`: 32 passed, 0 failed, 3 fixture-dependent tests ignored.
- `cargo test -p keryx-miner --bin keryx-miner` excluding the two unchanged heavy-hash baseline failures: 44 passed, 0 failed, 2 filtered.
- Scoped `rustfmt --check` and `git diff --check` passed.
- Reorganized directly from `origin/main`: 17 library tests passed with 2 fixture-dependent tests ignored; 35 binary tests passed with only the two unchanged heavy-hash fixtures filtered.
- Disposable Ubuntu 22.04 practical proof used committed LF source bytes on a native Linux filesystem. Nine escrow persistence tests passed as UID 1000.
- `strace` observed the production durability sequence twice: temporary-file `fsync`, `renameat` to `escrow_state.json`, then parent-directory `fsync` (`fsync_calls=4`, `rename_to_state_calls=2`).
- A root-run migration at `/hive/miners/custom/keryx-miner-state` passed on a named ext4 volume. It verified directory mode `0700`, file mode `0600`, root ownership, unreadability by UID 1000, lock exclusion, symlink rejection, two same-filesystem hard-link installs, six `syncfs` calls, exact persistent rollback flags, old/new package deletion and recreation, state retention across rollback, unchanged wallet configuration, and no temporary residue.
- The disposable container and volumes were removed after verification.

The independent branch explicitly declares `tempfile`, which production escrow persistence uses for same-directory atomic replacement. The previous stack had supplied this dependency accidentally through model integrity.

## Residual risk

- Linux filesystem synchronization, ownership, permissions, locks, hard links, and destructive package rollback are practically verified in disposable Ubuntu 22.04 with an ext4 Hive state volume. Actual HiveOS agent integration, Flight Sheet cloud updates, archive-cache behavior, and power-loss survival remain unavailable locally.
- The two existing `heavy_hash` fixture assertions still fail and are unchanged by this branch.

This PR was made by AI
