### PR TITLE
fix(ops): bound services and authenticate CUDA setup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,67 @@ pub type Error = Box<dyn StdError + Send + Sync + 'static>;
 
 type Hash = Uint256;
 
+const CUDA_INSTALL_SCRIPT: &str = r#"set -euo pipefail
+umask 077
+tmp_dir=$(mktemp -d /tmp/keryx-cuda.XXXXXX)
+cleanup() { rm -rf -- "$tmp_dir"; }
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+keyring="$tmp_dir/cuda-keyring.deb"
+curl --fail --silent --show-error --location \
+  --proto '=https' --proto-redir '=https' --tlsv1.2 \
+  --connect-timeout 15 --max-time 300 \
+  'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb' \
+  --output "$keyring"
+printf '%s  %s\n' 'd93190d50b98ad4699ff40f4f7af50f16a76dac3bb8da1eaaf366d47898ff8df' "$keyring" | sha256sum -c -
+
+test "$(dpkg-deb -f "$keyring" Package)" = 'cuda-keyring'
+test "$(dpkg-deb -f "$keyring" Version)" = '1.1-1'
+test "$(dpkg-deb -f "$keyring" Architecture)" = 'all'
+dpkg -i "$keyring"
+apt-get update -qq
+apt-get install -y -qq libcublas-12-2 libcurand-12-2 cuda-cudart-12-2
+
+library_path() {
+  package=$1
+  soname=$2
+  path=$(dpkg -L "$package" | awk -v soname="$soname" '
+    { count = split($0, parts, "/") }
+    parts[count] == soname { match = $0 }
+    END { if (match) print match }
+  ')
+  test -n "$path"
+  test -e "$path"
+  readlink -f "$path"
+}
+
+cublas_path=$(library_path libcublas-12-2 libcublas.so.12)
+curand_path=$(library_path libcurand-12-2 libcurand.so.10)
+cudart_path=$(library_path cuda-cudart-12-2 libcudart.so.12)
+cublas_dir=$(dirname "$cublas_path")
+curand_dir=$(dirname "$curand_path")
+cudart_dir=$(dirname "$cudart_path")
+printf '%s\n' "$cublas_dir" "$curand_dir" "$cudart_dir" | sort -u > "$tmp_dir/keryx-cuda.conf"
+install -m 0644 "$tmp_dir/keryx-cuda.conf" /etc/ld.so.conf.d/keryx-cuda.conf
+ldconfig
+
+loader_has() {
+  soname=$1
+  directory=$2
+  ldconfig -p | awk -v soname="$soname" -v prefix="$directory/" '
+    $1 == soname && index($NF, prefix) == 1 { found = 1 }
+    END { exit !found }
+  '
+}
+
+loader_has libcublas.so.12 "$cublas_dir"
+loader_has libcurand.so.10 "$curand_dir"
+loader_has libcudart.so.12 "$cudart_dir"
+"#;
+
 /// Attempt to install the CUDA runtime libraries inference needs, on a Debian/Ubuntu host (HiveOS).
 ///
 /// OPoI GPU inference (the in-process llama engine) needs cuBLAS/cuBLASLt; cuRAND is kept for
@@ -82,25 +143,8 @@ fn install_cuda_libs() -> bool {
         error!("CUDA lib auto-install needs apt-get (Debian/Ubuntu) — not found on this system.");
         return false;
     }
-    // The CUDA libs install into /usr/local/cuda-*/targets/x86_64-linux/lib, which is NOT in
-    // the default loader search path. Installing alone is not enough: we must register that
-    // directory with ldconfig so dlopen("libcublas.so.12" / "libcurand.so.10") resolves it.
-    let script = r#"set -e
-cd /tmp
-wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb -O cuda-keyring.deb
-dpkg -i cuda-keyring.deb
-apt-get update -qq
-apt-get install -y -qq libcublas-12-2 libcurand-12-2 cuda-cudart-12-2
-CUBLAS_PATH=$(find /usr/local /usr/lib -name 'libcublas.so.12' 2>/dev/null | head -1)
-if [ -z "$CUBLAS_PATH" ]; then echo "libcublas.so.12 not found after install"; exit 1; fi
-echo "$(dirname "$CUBLAS_PATH")" > /etc/ld.so.conf.d/keryx-cuda.conf
-ldconfig
-ldconfig -p | grep -q libcublas.so.12 || { echo "libcublas still not in loader cache"; exit 1; }
-ldconfig -p | grep -q libcurand.so   || { echo "libcurand still not in loader cache"; exit 1; }
-ldconfig -p | grep -q libcudart.so.12 || { echo "libcudart still not in loader cache"; exit 1; }
-rm -f cuda-keyring.deb"#;
     let output = match Command::new("bash")
-        .args(["-c", script])
+        .args(["-c", CUDA_INSTALL_SCRIPT])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()
@@ -128,6 +172,51 @@ rm -f cuda-keyring.deb"#;
     } else {
         error!("CUDA lib auto-install failed with status {}", output.status);
         false
+    }
+}
+
+#[cfg(test)]
+mod installer_tests {
+    use super::CUDA_INSTALL_SCRIPT;
+
+    #[test]
+    fn cuda_installer_security_invariants() {
+        let checksum = CUDA_INSTALL_SCRIPT.find("sha256sum -c").unwrap();
+        let metadata = CUDA_INSTALL_SCRIPT.find("dpkg-deb -f").unwrap();
+        let install = CUDA_INSTALL_SCRIPT.find("dpkg -i").unwrap();
+
+        assert!(CUDA_INSTALL_SCRIPT.contains("mktemp -d /tmp/keryx-cuda.XXXXXX"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("umask 077"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("trap cleanup EXIT"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("trap 'exit 129' HUP"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("trap 'exit 130' INT"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("trap 'exit 143' TERM"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("--proto '=https'"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("--proto-redir '=https'"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("--tlsv1.2"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("--connect-timeout 15 --max-time 300"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("d93190d50b98ad4699ff40f4f7af50f16a76dac3bb8da1eaaf366d47898ff8df"));
+        assert!(checksum < metadata && metadata < install);
+        assert!(CUDA_INSTALL_SCRIPT.contains("Package)\" = 'cuda-keyring'"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("Version)\" = '1.1-1'"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("Architecture)\" = 'all'"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("dpkg -L \"$package\""));
+        assert!(CUDA_INSTALL_SCRIPT.contains("readlink -f \"$path\""));
+        assert!(CUDA_INSTALL_SCRIPT.contains("$1 == soname && index($NF, prefix) == 1"));
+        assert!(!CUDA_INSTALL_SCRIPT.contains("print; exit"));
+        assert!(!CUDA_INSTALL_SCRIPT.contains("find /usr"));
+        assert!(!CUDA_INSTALL_SCRIPT.contains("/tmp/cuda-keyring.deb"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cuda_installer_is_valid_bash() {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+
+        let mut child = Command::new("bash").args(["-n"]).stdin(Stdio::piped()).spawn().unwrap();
+        child.stdin.take().unwrap().write_all(CUDA_INSTALL_SCRIPT.as_bytes()).unwrap();
+        assert!(child.wait().unwrap().success());
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,8 +86,8 @@ library_path() {
   soname=$2
   path=$(dpkg -L "$package" | awk -v soname="$soname" '
     { count = split($0, parts, "/") }
-    parts[count] == soname { match = $0 }
-    END { if (match) print match }
+    parts[count] == soname { matched_path = $0 }
+    END { if (matched_path) print matched_path }
   ')
   test -n "$path"
   test -e "$path"
@@ -106,16 +106,18 @@ ldconfig
 
 loader_has() {
   soname=$1
-  directory=$2
-  ldconfig -p | awk -v soname="$soname" -v prefix="$directory/" '
-    $1 == soname && index($NF, prefix) == 1 { found = 1 }
-    END { exit !found }
-  '
+  expected_path=$2
+  while IFS= read -r path; do
+    if [ "$(readlink -f "$path")" = "$expected_path" ]; then
+      return 0
+    fi
+  done < <(ldconfig -p | awk -v soname="$soname" '$1 == soname { print $NF }')
+  return 1
 }
 
-loader_has libcublas.so.12 "$cublas_dir"
-loader_has libcurand.so.10 "$curand_dir"
-loader_has libcudart.so.12 "$cudart_dir"
+loader_has libcublas.so.12 "$cublas_path"
+loader_has libcurand.so.10 "$curand_path"
+loader_has libcudart.so.12 "$cudart_path"
 "#;
 
 /// Attempt to install the CUDA runtime libraries inference needs, on a Debian/Ubuntu host (HiveOS).
@@ -202,7 +204,8 @@ mod installer_tests {
         assert!(CUDA_INSTALL_SCRIPT.contains("Architecture)\" = 'all'"));
         assert!(CUDA_INSTALL_SCRIPT.contains("dpkg -L \"$package\""));
         assert!(CUDA_INSTALL_SCRIPT.contains("readlink -f \"$path\""));
-        assert!(CUDA_INSTALL_SCRIPT.contains("$1 == soname && index($NF, prefix) == 1"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("$(readlink -f \"$path\")"));
+        assert!(CUDA_INSTALL_SCRIPT.contains("$1 == soname { print $NF }"));
         assert!(!CUDA_INSTALL_SCRIPT.contains("print; exit"));
         assert!(!CUDA_INSTALL_SCRIPT.contains("find /usr"));
         assert!(!CUDA_INSTALL_SCRIPT.contains("/tmp/cuda-keyring.deb"));

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::process::Command;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -12,6 +12,28 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 const STATS_READ_TIMEOUT_SECS: u64 = 5;
 const STATS_WRITE_TIMEOUT_SECS: u64 = 5;
 const MAX_REQUEST_LINE_BYTES: usize = 4096;
+const MAX_STATS_CONNECTIONS: usize = 8;
+
+struct StatsConnectionPermit {
+    active: Arc<AtomicUsize>,
+}
+
+impl StatsConnectionPermit {
+    fn acquire(active: &Arc<AtomicUsize>) -> Option<Self> {
+        active
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                (count < MAX_STATS_CONNECTIONS).then_some(count + 1)
+            })
+            .ok()?;
+        Some(Self { active: Arc::clone(active) })
+    }
+}
+
+impl Drop for StatsConnectionPermit {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::Release);
+    }
+}
 
 static NVML_HANDLE: OnceLock<Option<Nvml>> = OnceLock::new();
 
@@ -580,11 +602,16 @@ DEVICE #1:
 pub fn spawn_stats_server(stats: Arc<MinerStats>, bind_addr: String, port: u16) -> std::io::Result<thread::JoinHandle<()>> {
     let listener = TcpListener::bind((bind_addr.as_str(), port))?;
     Ok(thread::spawn(move || {
+        let active_connections = Arc::new(AtomicUsize::new(0));
         for stream in listener.incoming() {
             match stream {
                 Ok(stream) => {
+                    let Some(permit) = StatsConnectionPermit::acquire(&active_connections) else {
+                        continue;
+                    };
                     let stats = Arc::clone(&stats);
-                    thread::spawn(move || {
+                    let _ = thread::Builder::new().name("stats-handler".into()).spawn(move || {
+                        let _permit = permit;
                         let _ = handle_connection(stream, &stats);
                     });
                 }
@@ -673,5 +700,23 @@ fn parse_u32_field(value: &str) -> Option<u32> {
         None
     } else {
         filtered.parse::<u32>().ok()
+    }
+}
+#[cfg(test)]
+mod connection_tests {
+    use super::{StatsConnectionPermit, MAX_STATS_CONNECTIONS};
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Arc;
+
+    #[test]
+    fn stats_connection_limit_is_bounded_and_released() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let permits = (0..MAX_STATS_CONNECTIONS)
+            .map(|_| StatsConnectionPermit::acquire(&active).expect("connection slot"))
+            .collect::<Vec<_>>();
+
+        assert!(StatsConnectionPermit::acquire(&active).is_none());
+        drop(permits);
+        assert!(StatsConnectionPermit::acquire(&active).is_some());
     }
 }


### PR DESCRIPTION
# Bound stats connections and authenticate CUDA setup

## Branch

This PR targets `Keryx-Labs/keryx-miner:main` independently.

Branch: `fix/operational-service-hardening`

Local commits:

- `8213fea fix(ops): bound services and authenticate CUDA setup`
- `82653a2 fix(ops): validate installed CUDA loader paths`

## Problem

The stats listener applied request-size and socket timeouts but could still create an unbounded number of handler threads. The automatic CUDA runtime installer downloaded a keyring package into a fixed `/tmp` path and installed it as root without authenticating the artifact or constraining library discovery to installed packages.

## Changes

- Limit the stats listener to eight concurrent handlers with an atomic RAII permit.
- Drop excess accepted sockets without allocating another handler thread.
- Preserve the existing five-second read/write timeouts, 4096-byte request-line limit, and connection-close behavior.
- Download the CUDA keyring into a private random directory with HTTPS-only redirects, TLS 1.2, and bounded connection/download times.
- Verify NVIDIA's pinned SHA-256 before inspecting or installing the package.
- Require the expected `cuda-keyring` package name, version `1.1-1`, and `all` architecture before `dpkg -i`.
- Discover CUDA libraries through `dpkg -L`, require package-listed paths to exist, canonicalize them, and validate exact SONAME entries in the loader cache.
- Clean temporary installer state on normal exit and terminating signals.

## Invariants

- Untrusted stats clients cannot create more than eight active handler threads.
- Every acquired handler permit is released on completion, panic, or thread-spawn failure.
- Downloaded bytes do not cross the privileged package-install boundary before checksum and metadata validation.
- Loader configuration is derived from package-owned paths rather than a global filesystem search.

## Additional fixes discovered

Review found that an early-exit `awk` pipeline could trigger `SIGPIPE` under `set -o pipefail`. The final script consumes the full package listing before returning its match. Tests also assert cleanup, signal behavior, exact loader matching, checksum ordering, and the absence of fixed temporary paths and global library searches.

Practical Ubuntu verification found and fixed two additional portability defects in follow-up commit `82653a2`:

- Ubuntu 22.04 uses `mawk`, where `match` is a reserved function name; the package-path variable now uses a portable name.
- `ldconfig` reports CUDA libraries through the `/usr/local/cuda` symlink while package ownership resolves `/usr/local/cuda-12.2`. Loader validation now compares canonical file paths instead of brittle textual prefixes.

## Verification

Native Windows build environment:

- CUDA Toolkit `12.2.140`
- MSVC `19.36.32548` selected with `VsDevCmd.bat -vcvars_ver=14.36`
- `KERYX_LLAMA_SKIP=1`
- `POM_SM_LIST=86`

Results:

- Focused stats connection test: 1 passed, 0 failed.
- Focused CUDA installer invariant test: 1 passed, 0 failed.
- `cargo test -p keryx-miner --bin keryx-miner -- --skip pow::heavy_hash::tests::test_heavy_hash --skip pow::heavy_hash::tests::test_generate_matrix`: 46 passed, 0 failed, 2 unchanged baseline fixtures filtered.
- Extracted installer script through WSL Ubuntu `bash -n`: passed.
- Scoped `rustfmt`: passed.
- `git diff --check`: passed.
- Fresh Ubuntu 22.04 privileged installation passed. The pinned keyring checksum and exact `cuda-keyring 1.1-1 all` metadata were verified before installation; `libcublas.so.12`, `libcurand.so.10`, and `libcudart.so.12` were resolved from package-owned paths and matched their canonical `ldconfig` entries. Temporary files were removed.
- A separate fresh container forced `sha256sum` to return 42 after computing the real checksum. The installer propagated exit 42, did not cross the package-install boundary, and removed its temporary directory.
- A live stats-server proof held all eight permits with silent sockets. The ninth connection closed immediately, held permits released after 5.002 seconds, and a subsequent request returned HTTP 200 with `Connection: close`, proving permit reuse.
- The copied stats module was byte-identical to `src/stats.rs` (SHA-256 `B47BE80BF2D0A114D0E4A8ACD99E89954E14706A49252656833B34BDB7BABB26`).
- Reorganized directly from `origin/main`: 17 library tests passed with 2 fixture-dependent tests ignored; 28 binary tests passed with only the two unchanged heavy-hash fixtures filtered.
- The extracted installer script remained byte-identical to the practically verified version, SHA-256 `512ce8966419baf5a1fa1d59860c5c33f4b5cf70e2c36fb1d76e5eb1b0a289f4`.

## Residual risk

The privileged installer, loader-cache update, cleanup, forced checksum failure, and live socket saturation are practically verified on disposable Ubuntu 22.04. Actual HiveOS package mirrors, agent integration, and host-specific loader policy remain unavailable locally.

This PR was made by AI
