### PR TITLE
fix(slm): serialize cross-GPU model swaps

### DIFF
--- a/src/llama_engine.rs
+++ b/src/llama_engine.rs
@@ -186,6 +186,17 @@ pub fn probe_library() -> Result<std::path::PathBuf, String> {
 /// Load the .so + the model once (idempotent, blocking — a model load takes seconds). Returns the
 /// attempt id of the resident load, or why it failed. Safe to call from multiple threads.
 pub fn ensure_loaded(gguf: &str, gpu: usize) -> Result<u64, LoadError> {
+    load(gguf, gpu, false)
+}
+
+/// Atomically replace the resident model, including across GPUs. The caller must first drain the
+/// hosting GPU's tensor readers. The engine mutex prevents another GPU from claiming the singleton
+/// between freeing the old model and loading the replacement.
+pub fn replace_loaded(gguf: &str, gpu: usize) -> Result<u64, LoadError> {
+    load(gguf, gpu, true)
+}
+
+fn load(gguf: &str, gpu: usize, allow_gpu_change: bool) -> Result<u64, LoadError> {
     let attempt = next_attempt();
     let failed = |stage: &'static str, detail: String, cuda_touched: bool| {
         LoadError::new(attempt, stage, detail, cuda_touched)
@@ -203,7 +214,7 @@ pub fn ensure_loaded(gguf: &str, gpu: usize) -> Result<u64, LoadError> {
         // steal the engine — the hosting GPU's zero-dup walk still gathers over these
         // resident tensors, so freeing them here would be a device use-after-free (and the
         // two GPUs would thrash full model loads stealing the singleton back and forth).
-        if e.gpu != gpu {
+        if e.gpu != gpu && !allow_gpu_change {
             return Err(failed("busy", format!("engine hosts a model on GPU {} — not stealing it", e.gpu), false));
         }
         if let Some(e) = g.take() {
@@ -394,5 +405,23 @@ mod tests {
         assert!(!missing.is_oom());
         assert!(!missing.cuda_context_may_be_invalid());
         assert_eq!(missing.to_string(), "library: keryx-llama shared library not found");
+    }
+
+    #[test]
+    #[ignore = "requires two CUDA GPUs, libkeryx-llama, and KERYX_TEST_MODEL_GPU0/GPU1 GGUF paths"]
+    fn cross_gpu_replace_moves_the_singleton_without_busy() {
+        let gpu0 = std::env::var("KERYX_TEST_MODEL_GPU0").expect("set KERYX_TEST_MODEL_GPU0");
+        let gpu1 = std::env::var("KERYX_TEST_MODEL_GPU1").expect("set KERYX_TEST_MODEL_GPU1");
+
+        ensure_loaded(&gpu1, 1).unwrap();
+        assert!(active_for(&gpu1, 1));
+        assert!(generate("Reply with only OK.", 16).is_some());
+        replace_loaded(&gpu0, 0).unwrap();
+        assert!(active_for(&gpu0, 0));
+        assert!(generate("Reply with only OK.", 16).is_some());
+        replace_loaded(&gpu1, 1).unwrap();
+        assert!(active_for(&gpu1, 1));
+        assert!(generate("Reply with only OK.", 16).is_some());
+        unload();
     }
 }

--- a/src/llama_engine.rs
+++ b/src/llama_engine.rs
@@ -254,17 +254,30 @@ fn load(gguf: &str, gpu: usize, allow_gpu_change: bool) -> Result<u64, LoadError
             Err(_) => return Err(failed("path", "GGUF path contains a NUL byte".to_string(), false)),
         };
         log::info!("llama engine: loading {} on GPU {} via {} (in-process, zero-dup)…", gguf, gpu, so.display());
-        let n_ctx: c_int = std::env::var("KERYX_LLAMA_CTX").ok().and_then(|s| s.parse().ok()).unwrap_or(4096);
-        let model = load(cg.as_ptr(), gpu as c_int, n_ctx);
+        let configured_ctx = std::env::var("KERYX_LLAMA_CTX").ok().and_then(|s| s.parse().ok());
+        let n_ctx: c_int = configured_ctx.unwrap_or(4096);
+        let mut model = load(cg.as_ptr(), gpu as c_int, n_ctx);
         if model.is_null() {
-            let detail = last_error.map_or_else(
+            let mut detail = last_error.map_or_else(
                 || "model load failed (VRAM? arch?)".to_string(),
                 |f| {
                     let msg = CStr::from_ptr(f()).to_string_lossy().into_owned();
                     if msg.is_empty() { "model load failed (VRAM? arch?)".to_string() } else { msg }
                 },
             );
-            return Err(failed("native_load", detail, true));
+            if context_retry_size(n_ctx, configured_ctx.is_some(), &detail).is_some() {
+                log::warn!("llama engine: 4096-token context did not fit; retrying with 1024 tokens");
+                model = load(cg.as_ptr(), gpu as c_int, 1024);
+                if model.is_null() {
+                    detail = last_error.map_or_else(
+                        || "model load failed (VRAM? arch?)".to_string(),
+                        |f| CStr::from_ptr(f()).to_string_lossy().into_owned(),
+                    );
+                }
+            }
+            if model.is_null() {
+                return Err(failed("native_load", detail, true));
+            }
         }
         *g = Some(Engine { model, count, info, generate: gen, free, tensor_device, gpu, gguf: gguf.to_string(), attempt });
         log::info!("llama engine: ✓ active — llama.cpp hosts the model + serves OPoI inference.");
@@ -408,6 +421,23 @@ mod tests {
     }
 
     #[test]
+    fn retries_default_context_only_after_context_allocation_failure() {
+        let context_oom = "context: llama_init_from_model failed [vram: 0 MiB free / 16302 MiB total]";
+        assert_eq!(context_retry_size(4096, false, context_oom), Some(1024));
+        assert_eq!(context_retry_size(4096, true, context_oom), None);
+        assert_eq!(context_retry_size(1024, false, context_oom), None);
+        assert_eq!(context_retry_size(4096, false, "model: unsupported architecture"), None);
+        assert_eq!(
+            context_retry_size(
+                4096,
+                false,
+                "context: llama_init_from_model failed [vram: unavailable (cudaMemGetInfo failed: CUDA_ERROR_INVALID_CONTEXT)]",
+            ),
+            None,
+        );
+    }
+
+    #[test]
     #[ignore = "requires two CUDA GPUs, libkeryx-llama, and KERYX_TEST_MODEL_GPU0/GPU1 GGUF paths"]
     fn cross_gpu_replace_moves_the_singleton_without_busy() {
         let gpu0 = std::env::var("KERYX_TEST_MODEL_GPU0").expect("set KERYX_TEST_MODEL_GPU0");
@@ -424,4 +454,23 @@ mod tests {
         assert!(generate("Reply with only OK.", 16).is_some());
         unload();
     }
+
+    #[test]
+    #[ignore = "requires one CUDA GPU, libkeryx-llama, and KERYX_TEST_MODEL_GPU0 GGUF path"]
+    fn single_gpu_load_and_generate() {
+        let model = std::env::var("KERYX_TEST_MODEL_GPU0").expect("set KERYX_TEST_MODEL_GPU0");
+
+        ensure_loaded(&model, 0).unwrap();
+        assert!(active_for(&model, 0));
+        assert!(generate("Reply with only OK.", 16).is_some());
+        unload();
+    }
+}
+
+fn context_retry_size(n_ctx: c_int, explicitly_configured: bool, detail: &str) -> Option<c_int> {
+    (!explicitly_configured
+        && n_ctx > 1024
+        && detail.contains("context: llama_init_from_model failed")
+        && detail.contains(" MiB free / "))
+    .then_some(1024)
 }

--- a/src/pom_gpu.rs
+++ b/src/pom_gpu.rs
@@ -907,23 +907,34 @@ fn device_lifecycle(device_id: u32) -> Arc<Mutex<()>> {
     g.entry(device_id).or_default().clone()
 }
 
-/// Release the llama engine for a model swap, draining every reader of its resident tensors
-/// first: the hosting device's installed walk (uninstall barrier) and any build in flight on it
-/// (lifecycle lock). Then make room on `target_dev` for the incoming model.
-pub fn evict_llama_host_for_swap(target_dev: u32) {
+static LLAMA_MODEL_SWAP: Mutex<()> = Mutex::new(());
+
+fn with_swap_lifecycle_locks<T>(host: Option<u32>, target_dev: u32, swap: impl FnOnce() -> T) -> T {
+    let mut devices = vec![target_dev];
+    if let Some(host) = host.filter(|host| *host != target_dev) {
+        devices.push(host);
+        devices.sort_unstable();
+    }
+    let locks: Vec<_> = devices.into_iter().map(device_lifecycle).collect();
+    let _guards: Vec<_> = locks.iter().map(|lock| lock.lock().unwrap_or_else(|p| p.into_inner())).collect();
+    swap()
+}
+
+/// Replace the llama engine's resident model while the old and target GPU miners are unable to
+/// rebuild. Keeping both lifecycle locks through the new load closes the gap where the old miner
+/// could reload its model first and make `ensure_loaded` report a cross-GPU busy error.
+pub fn load_llama_for_inference(gguf: &str, target_dev: u32) -> Result<u64, crate::llama_engine::LoadError> {
+    let _swap_guard = LLAMA_MODEL_SWAP.lock().unwrap_or_else(|p| p.into_inner());
     let host = crate::llama_engine::active_gpu().map(|g| g as u32);
-    match host {
-        Some(host) => {
-            let lock = device_lifecycle(host);
-            let _guard = lock.lock().unwrap_or_else(|p| p.into_inner());
+    with_swap_lifecycle_locks(host, target_dev, || {
+        if let Some(host) = host {
             uninstall(host);
-            crate::llama_engine::unload();
         }
-        None => crate::llama_engine::unload(),
-    }
-    if host != Some(target_dev) {
-        uninstall(target_dev);
-    }
+        if host != Some(target_dev) {
+            uninstall(target_dev);
+        }
+        crate::llama_engine::replace_loaded(gguf, target_dev as usize)
+    })
 }
 
 /// Ensure the GPU miner is installed; if an inference evicted the mining model, reload it
@@ -1348,6 +1359,46 @@ mod tests {
         assert!(is_transient_gpu_runtime_fault("CUDA_ERROR_ILLEGAL_ADDRESS"));
         assert!(is_transient_gpu_runtime_fault("illegal memory access was encountered"));
         assert!(!is_transient_gpu_runtime_fault("out of memory"));
+    }
+
+    #[test]
+    fn model_swap_holds_both_gpu_lifecycles_until_replacement_load_finishes() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        const HOST: u32 = 10_000;
+        const TARGET: u32 = 10_001;
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let swap = std::thread::spawn(move || {
+            with_swap_lifecycle_locks(Some(HOST), TARGET, || {
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            });
+        });
+        entered_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let mut waiters = Vec::new();
+        for device in [HOST, TARGET] {
+            let (acquired_tx, acquired_rx) = mpsc::channel();
+            let waiter = std::thread::spawn(move || {
+                let lock = device_lifecycle(device);
+                let _guard = lock.lock().unwrap_or_else(|p| p.into_inner());
+                acquired_tx.send(()).unwrap();
+            });
+            assert!(
+                acquired_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+                "gpu{device} lifecycle escaped before the replacement model finished loading"
+            );
+            waiters.push((acquired_rx, waiter));
+        }
+
+        release_tx.send(()).unwrap();
+        swap.join().unwrap();
+        for (acquired_rx, waiter) in waiters {
+            acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+            waiter.join().unwrap();
+        }
     }
 }
 

--- a/src/slm.rs
+++ b/src/slm.rs
@@ -674,8 +674,7 @@ pub fn load_and_run_inference(model_id: &[u8; 32], prompt: &str, max_tokens: usi
         // The hosted model may live on ANOTHER device whose walk reads its tensors zero-dup:
         // evict drains that device (installed walk AND in-flight build) before freeing anything.
         // Draining only `dev_id` here poisoned the hosting GPU on every two-model rig.
-        crate::pom_gpu::evict_llama_host_for_swap(dev_id);
-        if let Err(e) = crate::llama_engine::ensure_loaded(&gguf, dev_id as usize) {
+        if let Err(e) = crate::pom_gpu::load_llama_for_inference(&gguf, dev_id) {
             log::error!("SlmEngine: cannot load '{}' — {}; response dropped", spec.name, e);
             mark_model_unavailable(model_id, if e.is_oom() { "llama_load_oom" } else { "llama_load_failed" });
             return None;

--- a/tools/keryx-llama/keryx_llama.cpp
+++ b/tools/keryx-llama/keryx_llama.cpp
@@ -114,6 +114,8 @@ KERYX_EXPORT KeryxLlama* keryx_llama_load(const char* gguf_path, int gpu, int n_
 
     llama_context_params cp = llama_context_default_params();
     cp.n_ctx = n_ctx > 0 ? n_ctx : 4096;
+    cp.n_batch = std::min(cp.n_batch, cp.n_ctx);
+    cp.n_ubatch = std::min(cp.n_ubatch, std::max(1u, cp.n_ctx / 4));
     llama_context* ctx = llama_init_from_model(model, cp);
     if (!ctx) {
         keryx_set_error("context", "llama_init_from_model failed");


### PR DESCRIPTION
## Summary

- Fix mixed-GPU OPoI inference requests being dropped when the requested model belongs to a different GPU than the resident llama model.
- Serialize model swaps and hold both GPU lifecycle locks through an atomic engine replacement.
- Preserve the existing cross-GPU busy guard for ordinary model loads.
- Add deterministic lifecycle-lock coverage and an ignored two-GPU inference test.
- Recover from measured VRAM exhaustion during default llama context allocation by retrying with a smaller context, batch, and micro-batch.

## Problem

This was observed on v0.4.5-PoM under both WSL and Windows. A mixed RTX 5080/5060 rig could serve Mistral from GPU 1, but a subsequent GLM request assigned to GPU 0 failed with:

```text
busy: engine hosts a model on GPU 1 - not stealing it; response dropped
```

The inference path evicted the resident model and loaded the requested model as separate operations. In that gap, the old GPU mining worker could reacquire its lifecycle lock and reload Mistral into the singleton engine before GLM loaded on GPU 0. The engine then correctly rejected the cross-GPU load to avoid freeing tensors still in use.

The same rig exposed a second issue after the swap race was fixed. GLM's model weights fit on the 16 GB GPU, but the default 4096-token llama context could exhaust the remaining VRAM while allocating its compute buffer. The model was then withdrawn and PoM downgraded GPU 0 to the light tier.

## Changes

- Add an explicit `replace_loaded` engine operation that frees and replaces the resident model while continuously holding the singleton engine mutex.
- Serialize inference model swaps before reading the active host GPU, keeping the host snapshot stable across concurrent requests.
- Acquire host and target GPU lifecycle locks in deterministic device order and retain them through replacement loading.
- Route SLM inference through the new atomic swap path.
- Add a regression test proving neither GPU lifecycle can rebuild before replacement loading finishes.
- Add an ignored hardware test that loads Mistral on GPU 1, replaces it with GLM on GPU 0, replaces it back, and generates after every transition.
- Retry an implicit 4096-token context at 1024 tokens only when the native loader reports measured numeric VRAM exhaustion. Explicit `KERYX_LLAMA_CTX` values remain authoritative, and invalid CUDA contexts do not retry.
- Clamp llama.cpp batch and micro-batch sizes to the selected context so the 1024-token retry actually reduces its compute-buffer allocation.
- Add focused retry-policy coverage and an ignored single-GPU load/generation test.

## Additional Fixes Discovered

Code review identified two related concurrency windows beyond the production-observed race:

- A third GPU could claim the temporarily empty singleton between a separate unload and load.
- Concurrent inference swaps could snapshot the same stale host GPU before acquiring lifecycle locks.

Atomic replacement under the engine mutex closes the first window. A dedicated swap mutex closes the second while preserving sorted lifecycle-lock ordering.

## Safety Invariants

- Ordinary `ensure_loaded` calls still reject cross-GPU model stealing.
- The hosting GPU's tensor readers are drained before its model is replaced.
- Host and target lifecycle locks remain held until the replacement model finishes loading.
- Deterministic lock ordering prevents host/target lock inversion.
- No CLI, model format, or model-selection behavior changes.
- Explicit context configuration remains unchanged and never falls back automatically.

## Verification

- Supported Ubuntu 22.04/CUDA 12.2 Linux build executed under WSL: 40 passed, 0 failed, 7 ignored.
- Native Windows suite: 40 passed, 0 failed, 7 ignored.
- `model_swap_holds_both_gpu_lifecycles_until_replacement_load_finishes`: passed.
- Direct two-GPU validation on two RTX A4000 GPUs completed 10 cycles of Mistral GPU 1 -> GLM GPU 0 -> Mistral GPU 1.
- All 30 hardware load states generated output; no busy, load, OOM, panic, or inference failures occurred.
- Exact pressure validation on two 16 GB RTX 5060 Ti GPUs reserved 8,000 MiB on GPU 0: the 4096-token context failed on a 304 MiB compute buffer, the automatic 1024-token retry succeeded, and GLM generated output on GPU 0 after Mistral loaded on GPU 1.
- Native Windows RTX 3070 Mistral load/generation test: passed.
- WSL RTX 3070 Mistral load/generation test: passed.
- Linux startup smoke returned `keryx-miner 0.4.5` without the prior locally packaged artifact's startup crash.
- `git diff --check`: passed.

## Residual Risk

The exact RTX 5080/5060 pair was not available. The synchronization path was tested on two RTX A4000 GPUs, and the constrained-context path was tested on two Blackwell RTX 5060 Ti GPUs with the same 16 GB VRAM class. The probes exercised the same model load and generation paths but did not submit a funded on-chain AiRequest. Release binaries should be produced through the project's official build process.

This PR was made by AI
