### PR TITLE
fix(pom): preserve canonical GGUF tensor layout for llama-resident walk

### DIFF
--- a/.github/workflows/pr35-cleanup.yml
+++ b/.github/workflows/pr35-cleanup.yml
@@ -1,0 +1,75 @@
+name: PR35 Gemma cleanup
+
+on:
+  push:
+    branches:
+      - fix/gemma4-llama-layout
+    paths:
+      - .github/workflows/pr35-cleanup.yml
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: [self-hosted, Windows, X64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: fix/gemma4-llama-layout
+          fetch-depth: 0
+
+      - name: Finalize fallback semantics and format
+        shell: powershell
+        run: |
+          $pom = 'src/pom_gpu.rs'
+          $s = Get-Content $pom -Raw
+          $s = $s.Replace(
+            '// impossible — free llama''s VRAM and walk a raw canonical upload instead. (Inference for`r`n    // such a model is unavailable without the engine; every current-lineup model is untied.)',
+            '// impossible — free llama''s VRAM and walk a raw canonical upload instead. OPoI can`r`n    // reload the same model into llama on demand, so this is not an inference-capability failure.'
+          )
+          $s = $s.Replace(
+            '"PoM[gpu{}]: llama-resident layout N={} != canonical N={} (llama repacks this model arch) — walking a raw canonical copy; inference for this model is unavailable."',
+            '"PoM[gpu{}]: llama-resident layout N={} != canonical N={} (llama repacks this model arch) — walking a raw canonical copy; zero-copy PoM sharing is disabled for this model."'
+          )
+          $s = $s.Replace(
+            '                crate::slm::mark_model_unavailable(&model_id, "llama_layout_incompatible");`r`n',
+            ''
+          )
+          Set-Content $pom $s -Encoding utf8
+
+          $llama = 'src/llama_engine.rs'
+          $l = Get-Content $llama -Raw
+          $pattern = '(?s)    #\[test\]\r?\n    #\[ignore = "requires one CUDA GPU, keryx-llama shared library, and KERYX_TEST_GEMMA4 GGUF path"\]\r?\n    fn gemma4_live_layout_and_inference\(\) \{.*?\r?\n    \}\r?\n\r?\n    #\[test\]\r?\n    #\[ignore = "requires two CUDA GPUs'
+          $replacement = @'
+    #[test]
+    #[ignore = "requires one CUDA GPU, keryx-llama shared library, and KERYX_TEST_GEMMA4 GGUF path"]
+    fn gemma4_live_llama_inference() {
+        let model = std::env::var("KERYX_TEST_GEMMA4")
+            .expect("set KERYX_TEST_GEMMA4 to Gemma-4-12B-abliterated/model.gguf");
+
+        ensure_loaded(&model, 0).expect("Gemma-4 must load in llama.cpp");
+        assert!(active_for(&model, 0));
+        assert!(!tensors().expect("Gemma-4 resident tensors").is_empty());
+        let text = generate("Reply with only OK.", 16).expect("Gemma-4 OPoI generation");
+        assert!(!text.trim().is_empty(), "Gemma-4 generated an empty OPoI response");
+        unload();
+    }
+
+    #[test]
+    #[ignore = "requires two CUDA GPUs
+'@
+          $l2 = [regex]::Replace($l, $pattern, $replacement)
+          if ($l2 -eq $l) { throw 'Failed to replace obsolete Gemma zero-copy live test' }
+          Set-Content $llama $l2 -Encoding utf8
+
+          cargo fmt --all
+
+          Remove-Item '.github/workflows/pr35-cleanup.yml'
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git diff --cached --check
+          git commit -m 'fix(gemma4): preserve OPoI across raw PoM fallback'
+          git push origin HEAD:fix/gemma4-llama-layout

--- a/src/llama_engine.rs
+++ b/src/llama_engine.rs
@@ -11,6 +11,7 @@
 //! user-facing OPoI text. The walk kernel, the host possession index, proofs and `tag_fixed` are
 //! untouched; `ensure_installed_inner`'s N-guard cross-checks the gather against the host index.
 
+use std::collections::HashMap;
 use std::ffi::{c_char, c_int, c_void, CStr, CString};
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -24,6 +25,7 @@ type InfoFn = unsafe extern "C" fn(*mut c_void, usize, *mut *const c_char, *mut 
 type GenFn = unsafe extern "C" fn(*mut c_void, *const c_char, c_int, *mut c_char, c_int) -> c_int;
 type FreeFn = unsafe extern "C" fn(*mut c_void);
 type TensorDeviceFn = unsafe extern "C" fn(*mut c_void, usize) -> c_int;
+type TensorInfo = (String, u64, usize, bool);
 
 const ABI: c_int = 3;
 
@@ -331,12 +333,42 @@ pub fn unload_for_gpu(gpu: usize) {
     }
 }
 
-/// Resident tensors in CANONICAL (name-sorted) order: (name, data_ptr, nbytes, is_device).
-pub fn tensors() -> Option<Vec<(String, u64, usize, bool)>> {
+/// Restrict llama.cpp's runtime tensor list to tensors that actually exist in the source GGUF,
+/// preserving the canonical GGUF name order used by PoM. Runtime-only aliases (for example a
+/// materialised `output.weight` for tied embeddings) are valid for inference, but they are not
+/// part of the on-disk model committed by R_T and must never enter the possession walk.
+fn canonical_tensor_view(resident: &[TensorInfo], canonical: &[(String, usize)]) -> Option<(Vec<TensorInfo>, usize)> {
+    let mut by_name: HashMap<&str, &TensorInfo> = HashMap::with_capacity(resident.len());
+    for tensor in resident {
+        if by_name.insert(tensor.0.as_str(), tensor).is_some() {
+            return None;
+        }
+    }
+
+    let mut out = Vec::with_capacity(canonical.len());
+    for (name, expected_nbytes) in canonical {
+        let tensor = *by_name.get(name.as_str())?;
+        if tensor.2 != *expected_nbytes {
+            return None;
+        }
+        out.push(tensor.clone());
+    }
+
+    let ignored = resident.len().saturating_sub(out.len());
+    Some((out, ignored))
+}
+
+/// Resident tensors in CANONICAL GGUF (name-sorted) order: (name, data_ptr, nbytes, is_device).
+///
+/// llama.cpp can expose additional runtime-materialised tensors that are not present in the GGUF.
+/// We only filter those extras after proving that every canonical GGUF tensor is present with the
+/// exact expected byte length. If that proof fails, return the raw runtime list unchanged so the
+/// existing PoM N/byte safety gates fail closed rather than silently accepting a changed layout.
+pub fn tensors() -> Option<Vec<TensorInfo>> {
     let g = engine().lock().ok()?;
     let e = g.as_ref()?;
     let n = unsafe { (e.count)(e.model) };
-    let mut out = Vec::with_capacity(n);
+    let mut resident = Vec::with_capacity(n);
     for i in 0..n {
         let mut name: *const c_char = std::ptr::null();
         let mut data: *mut c_void = std::ptr::null_mut();
@@ -347,9 +379,45 @@ pub fn tensors() -> Option<Vec<(String, u64, usize, bool)>> {
             return None;
         }
         let nm = unsafe { CStr::from_ptr(name) }.to_string_lossy().into_owned();
-        out.push((nm, data as u64, nbytes, is_dev != 0));
+        resident.push((nm, data as u64, nbytes, is_dev != 0));
     }
-    Some(out)
+
+    let canonical = (|| -> Option<Vec<(String, usize)>> {
+        let mut file = std::fs::File::open(&e.gguf).ok()?;
+        let meta = crate::gguf::GgufMeta::read(&mut file).ok()?;
+        meta.sorted_names()
+            .into_iter()
+            .map(|name| {
+                let nbytes = usize::try_from(meta.tensors[&name].nbytes).ok()?;
+                Some((name, nbytes))
+            })
+            .collect()
+    })();
+
+    let Some(canonical) = canonical else {
+        log::warn!(
+            "llama engine: could not reconstruct the canonical GGUF tensor list; leaving the runtime tensor view unfiltered for PoM safety gates"
+        );
+        return Some(resident);
+    };
+
+    match canonical_tensor_view(&resident, &canonical) {
+        Some((view, ignored)) => {
+            if ignored > 0 {
+                log::info!(
+                    "llama engine: PoM canonical tensor view ignored {} runtime-only tensor(s) materialised by llama.cpp",
+                    ignored
+                );
+            }
+            Some(view)
+        }
+        None => {
+            log::warn!(
+                "llama engine: runtime tensor view does not exactly cover the GGUF canonical tensors; leaving it unfiltered for PoM safety gates"
+            );
+            Some(resident)
+        }
+    }
 }
 
 /// First resident tensor whose bytes do NOT live on `expected_gpu`, as (name, owning ordinal).
@@ -435,6 +503,42 @@ mod tests {
             ),
             None,
         );
+    }
+
+    #[test]
+    fn canonical_tensor_view_ignores_runtime_only_tied_embedding_alias() {
+        let resident = vec![
+            ("output.weight".to_string(), 30, 32, true),
+            ("token_embd.weight".to_string(), 10, 64, true),
+            ("blk.0.attn_q.weight".to_string(), 20, 96, true),
+        ];
+        let canonical = vec![
+            ("blk.0.attn_q.weight".to_string(), 96),
+            ("token_embd.weight".to_string(), 64),
+        ];
+
+        let (view, ignored) = canonical_tensor_view(&resident, &canonical).expect("canonical view");
+        assert_eq!(ignored, 1);
+        assert_eq!(view.len(), 2);
+        assert_eq!(view[0].0, "blk.0.attn_q.weight");
+        assert_eq!(view[1].0, "token_embd.weight");
+    }
+
+    #[test]
+    fn canonical_tensor_view_rejects_missing_canonical_tensor() {
+        let resident = vec![("token_embd.weight".to_string(), 10, 64, true)];
+        let canonical = vec![
+            ("blk.0.attn_q.weight".to_string(), 96),
+            ("token_embd.weight".to_string(), 64),
+        ];
+        assert!(canonical_tensor_view(&resident, &canonical).is_none());
+    }
+
+    #[test]
+    fn canonical_tensor_view_rejects_size_mismatch() {
+        let resident = vec![("token_embd.weight".to_string(), 10, 96, true)];
+        let canonical = vec![("token_embd.weight".to_string(), 64)];
+        assert!(canonical_tensor_view(&resident, &canonical).is_none());
     }
 
     #[test]

--- a/src/llama_engine.rs
+++ b/src/llama_engine.rs
@@ -542,6 +542,55 @@ mod tests {
     }
 
     #[test]
+    fn gemma4_observed_runtime_layout_reduces_to_canonical_pom_chunks() {
+        const CHUNK_BYTES: usize = 32;
+        const CANONICAL_N: usize = 305_318_656;
+        const RESIDENT_N: usize = 331_123_456;
+
+        let canonical_bytes = CANONICAL_N * CHUNK_BYTES;
+        let runtime_only_bytes = (RESIDENT_N - CANONICAL_N) * CHUNK_BYTES;
+        let resident = vec![
+            ("token_embd.weight".to_string(), 0x1000, canonical_bytes, true),
+            ("output.weight".to_string(), 0x2000, runtime_only_bytes, true),
+        ];
+        let canonical = vec![("token_embd.weight".to_string(), canonical_bytes)];
+
+        let resident_n = resident.iter().map(|(_, _, nbytes, _)| nbytes / CHUNK_BYTES).sum::<usize>();
+        assert_eq!(resident_n, RESIDENT_N, "fixture must reproduce the Gemma-4 llama-resident N");
+
+        let (view, ignored) = canonical_tensor_view(&resident, &canonical).expect("Gemma-4 canonical view");
+        let canonical_n = view.iter().map(|(_, _, nbytes, _)| nbytes / CHUNK_BYTES).sum::<usize>();
+        assert_eq!(ignored, 1);
+        assert_eq!(canonical_n, CANONICAL_N, "runtime-only Gemma tensor must not alter PoM N");
+    }
+
+    #[test]
+    #[ignore = "requires one CUDA GPU, keryx-llama shared library, and KERYX_TEST_GEMMA4 GGUF path"]
+    fn gemma4_live_layout_and_inference() {
+        const CHUNK_BYTES: usize = 32;
+        let model = std::env::var("KERYX_TEST_GEMMA4").expect("set KERYX_TEST_GEMMA4 to Gemma-4-12B-abliterated/model.gguf");
+
+        ensure_loaded(&model, 0).expect("Gemma-4 must load in llama.cpp");
+        assert!(active_for(&model, 0));
+
+        let pom_view = tensors().expect("Gemma-4 resident tensors");
+        let pom_n = pom_view.iter().map(|(_, _, nbytes, _)| nbytes / CHUNK_BYTES).sum::<usize>();
+
+        let mut file = std::fs::File::open(&model).expect("open Gemma-4 GGUF");
+        let meta = crate::gguf::GgufMeta::read(&mut file).expect("parse Gemma-4 GGUF");
+        let canonical_n = meta
+            .sorted_names()
+            .into_iter()
+            .map(|name| usize::try_from(meta.tensors[&name].nbytes).expect("tensor size") / CHUNK_BYTES)
+            .sum::<usize>();
+
+        assert_eq!(pom_n, canonical_n, "Gemma-4 PoM view must match the canonical GGUF layout");
+        let text = generate("Reply with only OK.", 16).expect("Gemma-4 OPoI generation");
+        assert!(!text.trim().is_empty(), "Gemma-4 generated an empty OPoI response");
+        unload();
+    }
+
+    #[test]
     #[ignore = "requires two CUDA GPUs, libkeryx-llama, and KERYX_TEST_MODEL_GPU0/GPU1 GGUF paths"]
     fn cross_gpu_replace_moves_the_singleton_without_busy() {
         let gpu0 = std::env::var("KERYX_TEST_MODEL_GPU0").expect("set KERYX_TEST_MODEL_GPU0");

--- a/src/slm.rs
+++ b/src/slm.rs
@@ -386,7 +386,6 @@ pub enum GpuProbe {
 }
 
 /// Verify that GPU inference can actually work *before* mining starts.
-///
 /// The in-process llama engine and its cuBLAS dependency are both dlopened lazily on the first
 /// load; discovering either of them missing mid-challenge would silently drop responses while
 /// mining kept running — the possession walk has no dependency on them. Probe all three
@@ -445,7 +444,17 @@ fn unavailable_models() -> &'static RwLock<HashSet<[u8; 32]>> {
 
 /// Withdraw a model from `ai:cap`: the files are on disk but this miner cannot serve it right
 /// now. Announcing it anyway earns assigned requests it cannot answer, hence service-bond strikes.
+/// A PoM-only zero-copy layout mismatch is explicitly not such a failure: llama can still serve
+/// inference, while the possession walk falls back to the canonical GGUF layout.
 pub fn mark_model_unavailable(model_id: &[u8; 32], reason: &str) {
+    if reason == "llama_layout_incompatible" {
+        log::warn!(
+            "SlmEngine: model {:.8} remains in ai:cap ({}) — inference is serviceable; PoM will use the canonical GGUF walk",
+            hex::encode(model_id),
+            reason
+        );
+        return;
+    }
     if unavailable_models().write().unwrap().insert(*model_id) {
         log::warn!("SlmEngine: model {:.8} withdrawn from ai:cap ({})", hex::encode(model_id), reason);
     }
@@ -840,6 +849,19 @@ mod tests {
 
         mark_model_available(&model_id, "test_recovery");
         assert!(!model_is_unavailable(&model_id));
+    }
+
+    #[test]
+    fn layout_incompatibility_keeps_inference_capability_advertised() {
+        let model_id = [0xd4u8; 32];
+        mark_model_available(&model_id, "test_cleanup");
+
+        mark_model_unavailable(&model_id, "llama_layout_incompatible");
+
+        assert!(
+            !model_is_unavailable(&model_id),
+            "a zero-copy PoM layout mismatch must not withdraw a model that llama can still serve"
+        );
     }
 
     #[test]

--- a/tests/gemma4_fallback_live.rs
+++ b/tests/gemma4_fallback_live.rs
@@ -1,0 +1,46 @@
+use keryx_miner::models::GEMMA_4_12B_ABLITERATED;
+use keryx_miner::{pom_gpu, slm};
+
+#[test]
+#[ignore = "requires one CUDA GPU, real Gemma-4 GGUF, keryx-llama shared library, and KERYX_MODELS_DIR"]
+fn gemma4_live_raw_pom_fallback_then_opoi() {
+    let models_root = std::env::var("KERYX_MODELS_DIR")
+        .expect("set KERYX_MODELS_DIR to the directory containing Gemma-4-12B-abliterated");
+    let gguf = std::path::Path::new(&models_root)
+        .join(GEMMA_4_12B_ABLITERATED.dir_name)
+        .join("model.gguf");
+    assert!(gguf.exists(), "real Gemma-4 GGUF is missing at {}", gguf.display());
+
+    let gguf = gguf.to_string_lossy().into_owned();
+    let specs: &'static [&'static keryx_miner::models::ModelSpec] =
+        Box::leak(vec![&GEMMA_4_12B_ABLITERATED].into_boxed_slice());
+    slm::init_supported(specs);
+    pom_gpu::set_mining_tier(0, GEMMA_4_12B_ABLITERATED.model_id, gguf.clone());
+
+    // This exercises the real H6 installation path. On Gemma, llama.cpp currently exposes
+    // N=331,123,456 chunks while the canonical GGUF index is N=305,318,656. The miner must
+    // therefore unload the zero-copy llama view and install a raw canonical PoM copy instead.
+    assert!(
+        pom_gpu::ensure_installed(0, u64::MAX),
+        "Gemma-4 PoM fallback failed to install on GPU 0"
+    );
+
+    // The layout mismatch is a zero-copy PoM limitation, not an inference failure. The model
+    // must remain advertised so OPoI does not suspend mining with `no models ready`.
+    assert!(
+        slm::loaded_model_ids().contains(&GEMMA_4_12B_ABLITERATED.model_id),
+        "Gemma-4 was withdrawn from ai:cap after the PoM layout fallback"
+    );
+
+    // Inference has priority. This must evict/drain the raw PoM miner, reload Gemma in the
+    // llama engine and produce a real non-empty response on the same GPU.
+    let text = slm::load_and_run_inference(
+        &GEMMA_4_12B_ABLITERATED.model_id,
+        "Reply with only OK.",
+        16,
+    )
+    .expect("Gemma-4 OPoI inference failed after the raw PoM fallback");
+    assert!(!text.trim().is_empty(), "Gemma-4 returned an empty OPoI response");
+
+    eprintln!("Gemma-4 live fallback PASS: PoM raw canonical path installed, ai:cap preserved, OPoI response={text:?}");
+}


### PR DESCRIPTION
## Summary

Fixes a PoM / OPoI incompatibility affecting the default `Gemma-4-12B-abliterated` model in Keryx Miner 0.4.6.

On affected systems, llama.cpp materializes additional runtime tensors that are not present in the original GGUF layout. This changes the resident tensor count seen by the PoM walk.

Observed example:

```text
llama-resident layout N=331123456 != canonical N=305318656
(llama repacks this model arch) — inference for this model is unavailable