### PR TITLE
Make IPFS startup and upload recovery reliable

### DIFF
--- a/integrations/hiveos/HIVEOS_README.md
+++ b/integrations/hiveos/HIVEOS_README.md
@@ -13,6 +13,15 @@ The directory is mode `0700`; both files are mode `0600`. `h-run.sh` validates a
 
 Back up both durable files together before an upgrade or recovery. If validation fails, restore the matching pair from backup. Do not delete `escrow.key` to regenerate it because the original key controls existing rewards.
 
+## Local IPFS/Kubo
+
+The launcher supplies `HOME=/root` only when HiveOS omitted or emptied `HOME`; an explicit
+operator value is preserved. Keryx gives every managed Kubo child that same `HOME` and the
+matching `IPFS_PATH`, waits up to 60 seconds for the local API, and exits before mining or
+advertising inference capability if upload storage remains unavailable. A failed local
+inference upload performs one serialized Kubo recovery and one retry. Remote `--ipfs-url`
+endpoints are never started, stopped, or otherwise managed by the miner.
+
 ## Rollback-safe upgrade
 
 An old Keryx package understands the escrow path flags but defaults to files in its replaceable working directory. Before changing the Install URL, persist these exact flags in the HiveOS Flight Sheet **Extra config**:

--- a/integrations/hiveos/h-run.sh
+++ b/integrations/hiveos/h-run.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# HiveOS may launch miners without HOME set, which aborts child processes that
+# need it (notably Kubo/IPFS: "Error: $HOME is not defined"). Fall back to /root
+# at the earliest launcher point, BEFORE any helper script is sourced, so every
+# sourced script and every child sees HOME. A real HOME is never overridden.
+export HOME="${HOME:-/root}"
+
 cd "$(dirname "$0")" || exit 1
 
 [ -t 1 ] && . colors
@@ -21,8 +27,10 @@ if [[ -n "${STY:-}" && -z "${KERYX_TRUECOLOR:-}" ]]; then
   export KERYX_TRUECOLOR=0
 fi
 
-# Shared, stable model cache path across package updates/reinstalls.
-export KERYX_MODELS_DIR="/hive/miners/custom/models"
+# Shared, stable model cache path across package updates/reinstalls. An
+# explicitly supplied KERYX_MODELS_DIR (e.g. a sandboxed test root) is
+# preserved; HiveOS packages fall back to the shared cache by default.
+export KERYX_MODELS_DIR="${KERYX_MODELS_DIR:-/hive/miners/custom/models}"
 
 cleanup_legacy_models() {
   local legacy_dir="$CUSTOM_MINER_DIR/models"

--- a/integrations/hiveos/tests/home-fallback.sh
+++ b/integrations/hiveos/tests/home-fallback.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+install -m 0755 "$ROOT/h-run.sh" "$TEST_ROOT/h-run.sh"
+install -m 0644 "$ROOT/h-manifest.conf" "$TEST_ROOT/h-manifest.conf"
+install -m 0644 "$ROOT/pre-hive-upgrade.sh" "$TEST_ROOT/pre-hive-upgrade.sh"
+# Append a source-time HOME capture to the sandboxed helper copy so it records
+# the HOME value in effect WHILE pre-hive-upgrade.sh is being sourced, before
+# the launcher proceeds past helper sourcing to the miner launch. A regression
+# that moves the launcher's HOME export below helper sourcing leaves HOME unset
+# or raw at this point, so the per-case source check below fails. The capture
+# guard keeps the appended snippet inert unless the test opts in via
+# KERYX_TEST_HOME_CAPTURE.
+cat >> "$TEST_ROOT/pre-hive-upgrade.sh" <<'EOF'
+if [[ -n "${KERYX_TEST_HOME_CAPTURE:-}" ]]; then
+    printf '%s\n' "HOME=$HOME" > "$KERYX_TEST_HOME_CAPTURE"
+fi
+EOF
+install -m 0644 "$ROOT/h-manifest.conf" "$TEST_ROOT/config.ini"
+install -d "$TEST_ROOT/bin"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$TEST_ROOT/bin/flock"
+chmod +x "$TEST_ROOT/bin/flock"
+
+fail() {
+    echo "home-fallback: $*" >&2
+    exit 1
+}
+
+# Stub miner: sourcing h-run.sh runs the real launcher preamble (escrow
+# migration, model-cache mkdir) and launches "./$CUSTOM_MINERBIN" as its
+# child. This stub replaces the real binary, records the HOME and
+# KERYX_MODELS_DIR the child process actually sees, and exits 0 so the
+# launcher completes. It writes only to the absolute CAPTURE_FILE path —
+# never under $HOME — and the stub flock, KERYX_SYNC_COMMAND=true,
+# KERYX_STATE_DIR and KERYX_MODELS_DIR pin every launcher write inside
+# TEST_ROOT, so no /root or live HiveOS path can be touched.
+cat > "$TEST_ROOT/keryx-miner" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "HOME=$HOME" "KERYX_MODELS_DIR=${KERYX_MODELS_DIR:-}" > "$CAPTURE_FILE"
+EOF
+chmod +x "$TEST_ROOT/keryx-miner"
+
+# The live HiveOS paths that the launcher would touch if its overrides were
+# not honored. A successful test must leave them exactly as it found them.
+hive_state_path=/hive/miners/custom/keryx-miner-state
+hive_models_path=/hive/miners/custom/models
+[[ -e "$hive_state_path" ]] && hive_state_preexisting=1 || hive_state_preexisting=0
+[[ -e "$hive_models_path" ]] && hive_models_preexisting=1 || hive_models_preexisting=0
+root_before=""
+[[ -d /root ]] && root_before="$(ls -A /root)"
+
+# Source the launcher with the given HOME environment (extra env(1) args),
+# then assert HOME was already correct WHILE pre-hive-upgrade.sh was being
+# sourced (before miner launch), that the sourced session ended with HOME
+# exported and equal to $2, that the stub child inherited it, and that
+# state/model writes stayed sandboxed. Launcher stderr is kept in a per-case
+# log under TEST_ROOT and dumped on failure instead of being discarded.
+launch_case() {
+    local label="$1" expect="$2" capture="$3" source_capture="$4" state_dir="$5" models_dir="$6"
+    shift 6
+    local launch_log="$TEST_ROOT/launch-$label.log"
+    env "$@" PATH="$TEST_ROOT/bin:$PATH" \
+        CAPTURE_FILE="$capture" \
+        KERYX_TEST_HOME_CAPTURE="$source_capture" \
+        KERYX_STATE_DIR="$state_dir" KERYX_MODELS_DIR="$models_dir" \
+        KERYX_SYNC_COMMAND=true LAUNCH_LOG="$launch_log" bash -c '
+        cd "$1"
+        rc=0
+        . ./h-run.sh 2>"$LAUNCH_LOG" || rc=$?
+        if [[ "$rc" != 0 ]]; then
+            echo "launcher did not complete with the stub miner (rc=$rc); launcher stderr:" >&2
+            cat "$LAUNCH_LOG" >&2
+            exit 1
+        fi
+        [[ "${HOME:-}" == "$2" ]] || { echo "unexpected HOME after launch (got: ${HOME:-}, want: $2)" >&2; exit 1; }
+        export -p | grep -q "declare -x HOME" || { echo "HOME was not exported after launch" >&2; exit 1; }
+    ' bash "$TEST_ROOT" "$expect" || fail "$label: launcher session failed"
+    # HOME must already be in force at helper-source time (i.e. the export sits
+    # before the helper sourcing in the launcher), not only by child launch.
+    grep -Fxq "HOME=$expect" "$source_capture" || fail "$label: HOME=$expect was not in effect while pre-hive-upgrade.sh was sourced"
+    grep -Fxq "HOME=$expect" "$capture" || fail "$label: child did not see HOME=$expect"
+    grep -Fxq "KERYX_MODELS_DIR=$models_dir" "$capture" || fail "$label: child did not see sandboxed models dir"
+    [[ -d "$models_dir" ]] || fail "$label: model dir $models_dir was not created inside TEST_ROOT"
+    [[ -d "$state_dir" ]] || fail "$label: escrow state dir was not created inside TEST_ROOT"
+}
+
+# A launcher session with HOME unset must fall back to /root before any
+# helper is sourced, stay exported, and be visible to the launched child.
+launch_case "unset" /root \
+    "$TEST_ROOT/capture-unset.txt" "$TEST_ROOT/source-unset.txt" \
+    "$TEST_ROOT/state" "$TEST_ROOT/models" -u HOME
+
+# HOME set to the empty string is as broken as unset: the launcher must
+# replace it with /root rather than exporting an empty HOME to children.
+launch_case "empty" /root \
+    "$TEST_ROOT/capture-empty.txt" "$TEST_ROOT/source-empty.txt" \
+    "$TEST_ROOT/state-empty" "$TEST_ROOT/models-empty" HOME=
+
+# A custom HOME must pass through untouched, and an explicitly supplied
+# custom KERYX_MODELS_DIR must be preserved (not reset to /hive/...).
+launch_case "custom" /custom/home \
+    "$TEST_ROOT/capture-custom.txt" "$TEST_ROOT/source-custom.txt" \
+    "$TEST_ROOT/custom-state" "$TEST_ROOT/custom-models" HOME=/custom/home
+
+# Nothing outside TEST_ROOT may have been created or modified: the fallback
+# HOME value is only exported to children, never written to, and the only
+# launcher writes are the state and model dirs pinned inside TEST_ROOT.
+root_after=""
+[[ -d /root ]] && root_after="$(ls -A /root)"
+[[ "$root_before" == "$root_after" ]] || fail "/root changed during the test"
+[[ -e "$hive_state_path" ]] && [[ "$hive_state_preexisting" == 1 ]] \
+    || [[ ! -e "$hive_state_path" ]] || fail "live HiveOS state path was created: $hive_state_path"
+[[ -e "$hive_models_path" ]] && [[ "$hive_models_preexisting" == 1 ]] \
+    || [[ ! -e "$hive_models_path" ]] || fail "live HiveOS models path was created: $hive_models_path"
+
+echo 'HiveOS HOME fallback tests passed'

--- a/src/client/grpc.rs
+++ b/src/client/grpc.rs
@@ -740,7 +740,7 @@ impl KeryxdHandler {
 
         let ipfs_url = self.ipfs_url.clone();
         let result_clone = result.clone();
-        let cid = match tokio::task::spawn_blocking(move || crate::ipfs::upload(&result_clone, &ipfs_url)).await {
+        let cid = match tokio::task::spawn_blocking(move || crate::ipfs::upload_with_recovery(&result_clone, &ipfs_url)).await {
             Ok(Ok(cid)) => cid,
             Ok(Err(e)) => { warn!("OPoI: IPFS upload failed: {} — AiResponse tx skipped", e); return true; }
             Err(e) => { warn!("OPoI: IPFS spawn_blocking failed: {} — AiResponse tx skipped", e); return true; }

--- a/src/client/stratum.rs
+++ b/src/client/stratum.rs
@@ -811,7 +811,7 @@ fn do_inference_and_upload(
         warn!("OPoI [{}]: inference returned empty text — skipping IPFS upload", stable_id);
         return None;
     }
-    match crate::ipfs::upload(&text, ipfs_url) {
+    match crate::ipfs::upload_with_recovery(&text, ipfs_url) {
         Ok(cid_bytes) => {
             // Convert raw 34-byte multihash to base58 CIDv0 string via AiResponsePayload helper.
             let cid = keryx_inference::AiResponsePayload::new([0u8; 32], 0, cid_bytes, 0).cid_v0();

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -1,11 +1,37 @@
 /// IPFS integration — upload inference results and auto-manage kubo daemon.
+use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
 
 const KUBO_VERSION_FALLBACK: &str = "0.41.0";
 
+/// How many seconds `ensure_daemon` waits for the Kubo API to become reachable after
+/// spawning the daemon. The wait still fails immediately if the child process exits.
+const READINESS_POLL_SECONDS: u32 = 60;
+
+/// Fixed timeout for a single `is_running` probe.
+const PROBE_TIMEOUT_SECS: u64 = 2;
+
+/// Sleep interval between readiness probes. Each sleep — and each probe — is capped by
+/// the time remaining before the deadline so sleep plus probe time stays within budget.
+const READINESS_POLL_INTERVAL_SECS: u64 = 1;
+
+/// Normalize an IPFS API value into a canonical URL form. Scheme-less values such as
+/// `127.0.0.1:5001` become `http://127.0.0.1:5001`; explicit `http://` / `https://`
+/// schemes (and any other scheme) are preserved as-is. Applied consistently before
+/// probing, uploading, and local/remote classification.
+fn normalize_api_url(api_url: &str) -> String {
+    let trimmed = api_url.trim();
+    if trimmed.contains("://") {
+        trimmed.to_string()
+    } else {
+        format!("http://{}", trimmed)
+    }
+}
+
 /// Upload `text` to the IPFS node at `api_url` and return the raw 34-byte multihash.
 /// The multihash format is: [0x12, 0x20, <32-byte sha2-256 digest>].
 pub fn upload(text: &str, api_url: &str) -> anyhow::Result<[u8; 34]> {
+    let api_url = normalize_api_url(api_url);
     let url = format!("{}/api/v0/add?pin=true&quieter=true", api_url.trim_end_matches('/'));
     let boundary = "keryxboundary1234567890";
     let body = format!(
@@ -19,19 +45,17 @@ pub fn upload(text: &str, api_url: &str) -> anyhow::Result<[u8; 34]> {
         .timeout(Duration::from_secs(30))
         .send_bytes(body.as_bytes())
         .map_err(|e| anyhow::anyhow!("IPFS upload failed: {}", e))?;
-    let body = response.into_string()
-        .map_err(|e| anyhow::anyhow!("IPFS response read error: {}", e))?;
-    let json: serde_json::Value = serde_json::from_str(&body)
-        .map_err(|e| anyhow::anyhow!("IPFS response parse error: {}", e))?;
-    let cid_str = json["Hash"].as_str()
-        .ok_or_else(|| anyhow::anyhow!("IPFS response missing Hash field: {:?}", json))?;
+    let body = response.into_string().map_err(|e| anyhow::anyhow!("IPFS response read error: {}", e))?;
+    let json: serde_json::Value =
+        serde_json::from_str(&body).map_err(|e| anyhow::anyhow!("IPFS response parse error: {}", e))?;
+    let cid_str =
+        json["Hash"].as_str().ok_or_else(|| anyhow::anyhow!("IPFS response missing Hash field: {:?}", json))?;
     cid_v0_to_multihash(cid_str)
 }
 
 /// Decode a base58btc CIDv0 string (e.g. "Qm...") into a 34-byte raw multihash.
 fn cid_v0_to_multihash(cid: &str) -> anyhow::Result<[u8; 34]> {
-    let bytes = base58btc_decode(cid)
-        .ok_or_else(|| anyhow::anyhow!("Invalid base58 CID: {}", cid))?;
+    let bytes = base58btc_decode(cid).ok_or_else(|| anyhow::anyhow!("Invalid base58 CID: {}", cid))?;
     if bytes.len() != 34 || bytes[0] != 0x12 || bytes[1] != 0x20 {
         return Err(anyhow::anyhow!("CID is not a CIDv0 sha2-256 multihash: {}", cid));
     }
@@ -70,54 +94,233 @@ fn base58btc_decode(input: &str) -> Option<Vec<u8>> {
 
 /// Check that the IPFS API at `api_url` is reachable.
 pub fn is_running(api_url: &str) -> bool {
-    let url = format!("{}/api/v0/version", api_url.trim_end_matches('/'));
-    ureq::post(&url)
-        .timeout(Duration::from_secs(2))
-        .call()
-        .is_ok()
+    let api_url = normalize_api_url(api_url);
+    probe_running(&api_url, Duration::from_secs(PROBE_TIMEOUT_SECS))
 }
 
-/// Ensure the IPFS daemon is running. If not, download kubo and start it.
-/// Non-fatal: logs warnings on failure so the miner can still work (without inference rewards).
-pub fn ensure_daemon(api_url: &str) {
-    if is_running(api_url) {
+/// Probe the IPFS API with an explicit per-request timeout. Callers bound the timeout by
+/// the time remaining before their deadline so a slow probe cannot overshoot it.
+fn probe_running(api_url: &str, timeout: Duration) -> bool {
+    let url = format!("{}/api/v0/version", api_url.trim_end_matches('/'));
+    ureq::post(&url).timeout(timeout).call().is_ok()
+}
+
+/// Upload `text` to the IPFS node at `api_url`, and on failure recover a local daemon and
+/// retry exactly once. Remote endpoints are never auto-managed: their failures propagate
+/// unchanged.
+pub fn upload_with_recovery(data: &str, api_url: &str) -> anyhow::Result<[u8; 34]> {
+    match upload(data, api_url) {
+        Ok(cid) => Ok(cid),
+        Err(first_err) => match recovery_action(api_url) {
+            RecoveryAction::FailImmediately => Err(first_err),
+            RecoveryAction::RestartDaemonAndRetry => {
+                log::warn!("IPFS upload failed ({}); restarting local daemon and retrying once", first_err);
+                if let Err(restore_err) = ensure_daemon(api_url) {
+                    return Err(recovery_failed_error(first_err, restore_err));
+                }
+                upload(data, api_url).map_err(|e| retry_failed_error(first_err, e))
+            }
+        },
+    }
+}
+
+fn recovery_failed_error(first_err: anyhow::Error, restore_err: anyhow::Error) -> anyhow::Error {
+    anyhow::anyhow!("IPFS daemon recovery failed (original error: {}): {}", first_err, restore_err)
+}
+
+fn retry_failed_error(first_err: anyhow::Error, retry_err: anyhow::Error) -> anyhow::Error {
+    anyhow::anyhow!("IPFS upload failed after daemon recovery (original error: {}): {}", first_err, retry_err)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoveryAction {
+    FailImmediately,
+    RestartDaemonAndRetry,
+}
+
+fn recovery_action(api_url: &str) -> RecoveryAction {
+    if is_local_endpoint(api_url) {
+        RecoveryAction::RestartDaemonAndRetry
+    } else {
+        RecoveryAction::FailImmediately
+    }
+}
+
+/// A URL is local only when its host is exactly a loopback address or `localhost`.
+fn is_local_endpoint(api_url: &str) -> bool {
+    match url_host(api_url) {
+        Some("127.0.0.1") | Some("::1") => true,
+        Some(host) => host.eq_ignore_ascii_case("localhost"),
+        None => false,
+    }
+}
+
+fn url_host(url: &str) -> Option<&str> {
+    let rest = url.trim();
+    let authority = match rest.split_once("://") {
+        Some((_, authority)) => authority,
+        None => rest,
+    };
+    let authority = authority.split(|c: char| c == '/' || c == '?' || c == '#').next()?;
+    if authority.is_empty() {
+        return None;
+    }
+    if authority.starts_with('[') {
+        let mut parts = authority[1..].split(']');
+        let host = parts.next()?;
+        let suffix = parts.next()?;
+        if parts.next().is_some() {
+            return None;
+        }
+        return match suffix {
+            "" => Some(host),
+            rest => {
+                let port = rest.strip_prefix(':').unwrap_or(rest);
+                if port.is_empty() || !port.bytes().all(|b| b.is_ascii_digit()) {
+                    return None;
+                }
+                Some(host)
+            }
+        };
+    }
+    if authority == "::1" {
+        return Some("::1");
+    }
+    let (host, port) = match authority.split_once(':') {
+        Some((host, port)) => (host, port),
+        None => (authority, ""),
+    };
+    if !port.is_empty() && !port.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    Some(host)
+}
+
+fn resolve_home(candidate_home: Option<&str>, fallback_cwd: &std::path::Path) -> std::path::PathBuf {
+    match candidate_home {
+        Some(home) if !home.trim().is_empty() => std::path::PathBuf::from(home),
+        _ => fallback_cwd.to_path_buf(),
+    }
+}
+
+fn ipfs_home() -> std::path::PathBuf {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    resolve_home(std::env::var("HOME").ok().as_deref(), &cwd)
+}
+
+fn kubo_child_env(home: &std::path::Path) -> Vec<(String, String)> {
+    vec![
+        ("HOME".to_string(), home.display().to_string()),
+        ("IPFS_PATH".to_string(), home.join(".ipfs").display().to_string()),
+    ]
+}
+
+/// Time remaining before `deadline`, or zero once the deadline has passed.
+fn remaining_budget(deadline: std::time::Instant, now: std::time::Instant) -> Duration {
+    deadline.saturating_duration_since(now)
+}
+
+/// Duration of the next inter-probe sleep: the full interval while budget remains,
+/// truncated to whatever budget is left so the sleep alone never overshoots.
+fn sleep_duration(deadline: std::time::Instant, now: std::time::Instant) -> Duration {
+    remaining_budget(deadline, now).min(Duration::from_secs(READINESS_POLL_INTERVAL_SECS))
+}
+
+/// Timeout for the next API probe: bounded by the fixed probe timeout and by the budget
+/// remaining *after* the preceding sleep, so sleep plus probe stays within the deadline.
+fn probe_timeout(deadline: std::time::Instant, now: std::time::Instant) -> Duration {
+    remaining_budget(deadline, now).min(Duration::from_secs(PROBE_TIMEOUT_SECS))
+}
+
+/// Serializes local daemon spawn/recovery process-wide so simultaneous failed uploads can
+/// never double-spawn Kubo. Acquired only for local (auto-managed) endpoints; remote
+/// endpoints never touch it.
+fn local_daemon_lock() -> &'static Mutex<()> {
+    static LOCAL_DAEMON_RECOVERY_LOCK: Mutex<()> = Mutex::new(());
+    &LOCAL_DAEMON_RECOVERY_LOCK
+}
+
+/// Lock the process-wide daemon recovery mutex, tolerating a poisoned lock left behind by a
+/// previous recovery that panicked while holding it. Poisoning is never re-raised: it
+/// becomes a plain recovery error the caller surfaces alongside the original upload error
+/// instead of panicking again. Kubo startup is idempotent and the readiness wait fails fast
+/// if the API does not come up, so retrying a recovery after a poison is safe.
+fn acquire_recovery_lock() -> Result<MutexGuard<'static, ()>, anyhow::Error> {
+    lock_recovery(local_daemon_lock())
+}
+
+fn lock_recovery(lock: &'static Mutex<()>) -> Result<MutexGuard<'static, ()>, anyhow::Error> {
+    lock.lock().map_err(|_| {
+        anyhow::anyhow!("IPFS daemon recovery lock is poisoned (a previous recovery panicked while holding it)")
+    })
+}
+
+/// Under the recovery lock, decide whether a daemon spawn is still needed. The API was
+/// unreachable before the lock was acquired; the lock winner may have restored the daemon
+/// while this caller waited, so the decision is made on a fresh probe — the waiter reuses
+/// the winner's daemon instead of spawning a second one.
+fn spawn_still_needed(api_url: &str) -> bool {
+    !is_running(api_url)
+}
+
+/// Ensure the IPFS daemon at `api_url` is running. Returns only once its API is reachable,
+/// waiting up to 60 seconds after spawning the daemon (failing immediately if the child
+/// exits). Local daemons are auto-managed; remote endpoints are never auto-managed.
+///
+/// Local recovery is serialized process-wide: once a caller discovers the API is down it
+/// acquires the recovery lock, and under the lock re-probes before spawning. If the daemon
+/// was restored by another caller (the lock winner) in the meantime, the waiter reuses it
+/// instead of spawning a second Kubo. The lock is held for the entire spawn + readiness
+/// wait, so at most one daemon spawn happens at a time.
+pub fn ensure_daemon(api_url: &str) -> anyhow::Result<()> {
+    let api_url = normalize_api_url(api_url);
+    if is_running(&api_url) {
         log::info!("IPFS daemon reachable at {}", api_url);
-        return;
+        return Ok(());
     }
 
-    // Only auto-manage local daemon.
-    if !api_url.contains("127.0.0.1") && !api_url.contains("localhost") {
-        log::warn!("IPFS daemon not reachable at {} — inference rewards disabled", api_url);
-        return;
+    if !is_local_endpoint(&api_url) {
+        return Err(anyhow::anyhow!(
+            "IPFS daemon not reachable at {} — remote endpoints are not auto-managed",
+            api_url
+        ));
+    }
+
+    // Serialize spawn/recovery. The lock guard lives for the whole function body below.
+    let _recovery_guard = acquire_recovery_lock()?;
+
+    // The API was unreachable before we took the lock; another concurrent caller may have
+    // restored the daemon while we waited. Re-probe before spawning so a waiter reuses the
+    // daemon the winner started instead of double-spawning.
+    if !spawn_still_needed(&api_url) {
+        log::info!("IPFS daemon reachable at {}", api_url);
+        return Ok(());
     }
 
     log::info!("IPFS daemon not running — attempting to start kubo...");
+    let ipfs_bin = find_or_download_kubo()?;
 
-    let ipfs_bin = match find_or_download_kubo() {
-        Ok(p) => p,
-        Err(e) => {
-            log::warn!("Could not obtain kubo binary: {} — inference rewards disabled", e);
-            return;
-        }
-    };
-
-    // Init repo if first run.
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    let ipfs_repo = std::path::PathBuf::from(&home).join(".ipfs");
+    // Every Kubo child gets explicit HOME and IPFS_PATH derived from the same home path.
+    let home = ipfs_home();
+    let ipfs_repo = home.join(".ipfs");
+    let child_env = kubo_child_env(&home);
     if !ipfs_repo.exists() {
-        log::info!("Initialising IPFS repo...");
-        let _ = std::process::Command::new(&ipfs_bin)
+        log::info!("Initialising IPFS repo at {}", ipfs_repo.display());
+        let status = std::process::Command::new(&ipfs_bin)
             .arg("init")
+            .envs(child_env.iter().cloned())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
-            .status();
+            .status()
+            .map_err(|e| anyhow::anyhow!("Failed to run kubo init: {}", e))?;
+        if !status.success() {
+            return Err(anyhow::anyhow!("kubo init failed with status {}", status));
+        }
     }
 
-    // Start daemon in background, redirecting output to a log file so
-    // mDNS/discovery noise does not pollute the miner terminal while
-    // keeping Kubo logs accessible for inference debugging.
+    // Keep Kubo output out of the miner terminal but available for diagnostics.
     log::info!("Starting IPFS daemon...");
-    let log_dir = std::path::PathBuf::from(&home).join(".keryx");
+    let log_dir = home.join(".keryx");
     let _ = std::fs::create_dir_all(&log_dir);
     let kubo_log = log_dir.join("kubo.log");
     let (stdout, stderr) = match std::fs::OpenOptions::new().create(true).append(true).open(&kubo_log) {
@@ -130,25 +333,45 @@ pub fn ensure_daemon(api_url: &str) {
         },
         Err(_) => (std::process::Stdio::null(), std::process::Stdio::null()),
     };
-    match std::process::Command::new(&ipfs_bin)
+    let mut child = std::process::Command::new(&ipfs_bin)
         .args(["daemon", "--routing=dhtclient"])
+        .envs(child_env)
         .stdout(stdout)
         .stderr(stderr)
         .spawn()
-    {
-        Ok(_) => {
-            // Wait up to 15 seconds for the API to be ready.
-            for _ in 0..15 {
-                std::thread::sleep(Duration::from_secs(1));
-                if is_running(api_url) {
-                    log::info!("IPFS daemon ready");
-                    return;
-                }
-            }
-            log::warn!("IPFS daemon started but API not ready — inference rewards may be delayed");
+        .map_err(|e| anyhow::anyhow!("Failed to start IPFS daemon: {}", e))?;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(READINESS_POLL_SECONDS as u64);
+    loop {
+        let now = std::time::Instant::now();
+        if remaining_budget(deadline, now).is_zero() {
+            break;
         }
-        Err(e) => log::warn!("Failed to start IPFS daemon: {} — inference rewards disabled", e),
+        // Cap the sleep by the time remaining so sleep alone can never overshoot.
+        std::thread::sleep(sleep_duration(deadline, now));
+
+        // Probe with a timeout capped by the budget remaining after the sleep, so sleep
+        // plus probe time stays within the deadline. If the sleep consumed the budget,
+        // the deadline is reached and there is nothing left to probe.
+        let now = std::time::Instant::now();
+        let budget = remaining_budget(deadline, now);
+        if budget.is_zero() {
+            break;
+        }
+        if probe_running(&api_url, probe_timeout(deadline, now)) {
+            log::info!("IPFS daemon ready");
+            return Ok(());
+        }
+        if let Some(status) = child.try_wait().map_err(|e| anyhow::anyhow!("Failed to poll IPFS daemon: {}", e))? {
+            return Err(anyhow::anyhow!("IPFS daemon exited before the API was ready (status {})", status));
+        }
     }
+
+    // Deadline reached. The child may still be running — kill and reap exactly the child
+    // this call spawned before reporting the timeout.
+    let _ = child.kill();
+    let _ = child.wait();
+    Err(anyhow::anyhow!("IPFS daemon started but API not ready after {} seconds", READINESS_POLL_SECONDS))
 }
 
 fn find_or_download_kubo() -> anyhow::Result<std::path::PathBuf> {
@@ -244,7 +467,9 @@ fn download_file(url: &str, dest: &std::path::Path) -> anyhow::Result<()> {
     let mut buf = vec![0u8; 65_536];
     loop {
         let n = reader.read(&mut buf)?;
-        if n == 0 { break; }
+        if n == 0 {
+            break;
+        }
         file.write_all(&buf[..n])?;
     }
     Ok(())
@@ -257,10 +482,7 @@ fn extract_ipfs_binary(archive: &std::path::Path, dest_dir: &std::path::Path) ->
         for i in 0..zip.len() {
             let mut entry = zip.by_index(i)?;
             let name = entry.name().to_string();
-            let file_name = std::path::Path::new(&name)
-                .file_name()
-                .unwrap_or_default()
-                .to_os_string();
+            let file_name = std::path::Path::new(&name).file_name().unwrap_or_default().to_os_string();
             if file_name == "ipfs.exe" {
                 let mut out = std::fs::File::create(dest_dir.join(&file_name))?;
                 std::io::copy(&mut entry, &mut out)?;
@@ -283,4 +505,193 @@ fn extract_ipfs_binary(archive: &std::path::Path, dest_dir: &std::path::Path) ->
         }
     }
     Err(anyhow::anyhow!("ipfs binary not found in kubo archive"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_api_url_adds_http_only_to_scheme_less_values() {
+        assert_eq!(normalize_api_url("127.0.0.1:5001"), "http://127.0.0.1:5001");
+        assert_eq!(normalize_api_url("localhost:5001"), "http://localhost:5001");
+        assert_eq!(normalize_api_url("[::1]:5001"), "http://[::1]:5001");
+        assert_eq!(normalize_api_url("  127.0.0.1:5001  "), "http://127.0.0.1:5001");
+        // Explicit schemes are preserved as-is.
+        assert_eq!(normalize_api_url("http://127.0.0.1:5001"), "http://127.0.0.1:5001");
+        assert_eq!(normalize_api_url("https://gateway.keryx.network"), "https://gateway.keryx.network");
+        assert_eq!(normalize_api_url("http://localhost"), "http://localhost");
+    }
+
+    #[test]
+    fn is_local_endpoint_classifies_exact_loopback_hosts() {
+        assert!(is_local_endpoint("http://127.0.0.1:5001"));
+        assert!(is_local_endpoint("http://localhost:5001"));
+        assert!(is_local_endpoint("http://[::1]:5001"));
+        assert!(is_local_endpoint("http://::1"));
+        assert!(is_local_endpoint("localhost:5001"));
+        assert!(!is_local_endpoint("http://::1:5001"));
+        assert!(!is_local_endpoint("http://192.168.1.10:5001"));
+        assert!(!is_local_endpoint("http://localhost.evil.example:5001"));
+        assert!(!is_local_endpoint("http://127.0.0.1.5.nip.io:5001"));
+        assert!(!is_local_endpoint("http://myhost/path/localhost"));
+        assert!(!is_local_endpoint("http://myhost?redirect=localhost"));
+        assert!(!is_local_endpoint("http://localhost:notaport"));
+        assert!(!is_local_endpoint("http://[::1]:5001]"));
+    }
+
+    #[test]
+    fn kubo_child_env_sets_explicit_home_and_derived_ipfs_path() {
+        let env = kubo_child_env(std::path::Path::new("/custom/home"));
+        let home = env.iter().find(|(k, _)| k == "HOME").expect("HOME env set");
+        let ipfs_path = env.iter().find(|(k, _)| k == "IPFS_PATH").expect("IPFS_PATH env set");
+        assert_eq!(home.1, "/custom/home");
+        assert_eq!(ipfs_path.1, "/custom/home/.ipfs");
+    }
+
+    #[test]
+    fn resolve_home_preserves_explicit_and_falls_back_for_missing_or_empty() {
+        let cwd = std::path::Path::new("/fallback/cwd");
+        assert_eq!(resolve_home(Some("/custom/home"), cwd), std::path::PathBuf::from("/custom/home"));
+        assert_eq!(resolve_home(None, cwd), cwd.to_path_buf());
+        assert_eq!(resolve_home(Some(""), cwd), cwd.to_path_buf());
+        assert_eq!(resolve_home(Some("   "), cwd), cwd.to_path_buf());
+    }
+
+    #[test]
+    fn recovery_action_restarts_local_but_never_remote() {
+        assert_eq!(recovery_action("http://127.0.0.1:5001"), RecoveryAction::RestartDaemonAndRetry);
+        assert_eq!(recovery_action("http://localhost:5001"), RecoveryAction::RestartDaemonAndRetry);
+        assert_eq!(recovery_action("http://10.0.0.5:5001"), RecoveryAction::FailImmediately);
+        assert_eq!(recovery_action("https://gateway.keryx.network"), RecoveryAction::FailImmediately);
+    }
+
+    #[test]
+    fn recovery_errors_retain_original_upload_error_in_plain_display() {
+        let err = recovery_failed_error(
+            anyhow::anyhow!("IPFS upload failed: boom"),
+            anyhow::anyhow!("kubo init failed with status 1"),
+        );
+        let text = format!("{err}");
+        assert!(text.contains("IPFS upload failed: boom"), "{text}");
+        assert!(text.contains("IPFS daemon recovery failed"), "{text}");
+        assert!(text.contains("kubo init failed with status 1"), "{text}");
+
+        let err =
+            retry_failed_error(anyhow::anyhow!("IPFS upload failed: boom"), anyhow::anyhow!("connection refused"));
+        let text = format!("{err}");
+        assert!(text.contains("IPFS upload failed after daemon recovery"), "{text}");
+        assert!(text.contains("original error: IPFS upload failed: boom"), "{text}");
+        assert!(text.contains("connection refused"), "{text}");
+    }
+
+    #[test]
+    fn lock_recovery_acquires_when_uncontended_and_survives_poisoning() {
+        static TEST_RECOVERY_LOCK: Mutex<()> = Mutex::new(());
+
+        // Uncontended acquisition succeeds and the guard releases the lock when dropped.
+        {
+            let guard = lock_recovery(&TEST_RECOVERY_LOCK).expect("uncontended lock acquired");
+            drop(guard);
+        }
+
+        // Simulate a recovery that panicked while holding the lock, exactly as a panic
+        // inside the serialized spawn/readiness section would poison it. The panic is
+        // caught here so it does not fail the test; the default panic hook only writes
+        // to stderr, which the test harness captures per-test and surfaces only when
+        // this test fails. No process-global panic hook swap is needed.
+        let outcome = std::panic::catch_unwind(|| {
+            let _guard = TEST_RECOVERY_LOCK.lock().expect("test lock acquired");
+            panic!("simulated recovery panic");
+        });
+        assert!(outcome.is_err(), "the simulated panic must poison the lock");
+
+        // Poisoning is surfaced as a plain recovery error — never a panic — and names the
+        // poison so `recovery_failed_error` can carry it alongside the original upload error.
+        let err = lock_recovery(&TEST_RECOVERY_LOCK).expect_err("poisoned lock must not acquire");
+        let text = format!("{err:#}");
+        assert!(text.contains("poisoned"), "{text}");
+        assert!(text.contains("IPFS daemon recovery lock"), "{text}");
+    }
+
+    #[test]
+    fn spawn_still_needed_re_probes_so_a_waiter_reuses_the_restored_daemon() {
+        // No daemon behind the endpoint: the probe must fail fast and deterministically,
+        // so a spawn is still needed. The listener stays bound for the whole probe — it is
+        // never dropped into the ephemeral port range, where another test or process could
+        // grab the port and make the endpoint appear reachable. Any connection the probe
+        // opens is accepted and closed immediately, so the request fails with a closed
+        // connection instead of waiting out the probe timeout.
+        let dead_listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind dead listener");
+        let dead_url = format!("http://{}", dead_listener.local_addr().expect("dead local addr"));
+        let dead_reaper = std::thread::spawn(move || {
+            use std::io::Read as _;
+            // Accept and close the probe's connection so it sees a clean EOF instead of
+            // waiting out the probe timeout.
+            for conn in dead_listener.incoming().take(1) {
+                let Ok(mut stream) = conn else { break };
+                let mut buf = [0u8; 1024];
+                let _ = stream.read(&mut buf);
+            }
+        });
+        assert!(spawn_still_needed(&dead_url), "dead API must still need a spawn");
+        // The probe above already contacted the endpoint, but guarantee the accept is
+        // satisfied so the reaper thread cannot outlive the request if it ever did not
+        // connect (e.g. the probe failed before the TCP handshake).
+        let _ = std::net::TcpStream::connect(dead_url.trim_start_matches("http://"));
+        dead_reaper.join().expect("dead reaper thread joined");
+
+        // A restored daemon answers the probe: the waiter must NOT spawn again — it reuses
+        // the daemon the lock winner started.
+        let live = std::net::TcpListener::bind("127.0.0.1:0").expect("bind live listener");
+        let live_url = format!("http://{}", live.local_addr().expect("live local addr"));
+        let responder = std::thread::spawn(move || {
+            use std::io::{Read as _, Write as _};
+            let (mut stream, _) = live.accept().expect("accept probe connection");
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+            let response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            let _ = stream.write_all(response);
+        });
+        assert!(!spawn_still_needed(&live_url), "restored API must not trigger a spawn");
+        responder.join().expect("responder thread joined");
+    }
+
+    #[test]
+    fn deadline_helpers_cap_sleep_and_probe_by_remaining_budget() {
+        let now = std::time::Instant::now();
+        let deadline = now + Duration::from_secs(READINESS_POLL_SECONDS as u64);
+
+        // Full budget: sleep uses the full interval, probe uses the fixed probe timeout.
+        assert_eq!(remaining_budget(deadline, now), Duration::from_secs(READINESS_POLL_SECONDS as u64));
+        assert_eq!(sleep_duration(deadline, now), Duration::from_secs(READINESS_POLL_INTERVAL_SECS));
+        assert_eq!(probe_timeout(deadline, now), Duration::from_secs(PROBE_TIMEOUT_SECS));
+
+        // One second left: sleep and probe are capped by the remaining budget so sleep
+        // plus probe time cannot overshoot the deadline.
+        let near_deadline = now + Duration::from_secs(READINESS_POLL_SECONDS as u64 - 1);
+        assert_eq!(sleep_duration(deadline, near_deadline), Duration::from_secs(1));
+        assert_eq!(probe_timeout(deadline, near_deadline), Duration::from_secs(1));
+
+        // Half a second left: both truncate to the remaining budget.
+        let half_second_left = now + Duration::from_millis(READINESS_POLL_SECONDS as u64 * 1000 - 500);
+        assert_eq!(sleep_duration(deadline, half_second_left), Duration::from_millis(500));
+        assert_eq!(probe_timeout(deadline, half_second_left), Duration::from_millis(500));
+
+        // Deadline reached or passed: no budget remains for sleep or probe.
+        let at_deadline = now + Duration::from_secs(READINESS_POLL_SECONDS as u64);
+        let past_deadline = now + Duration::from_secs(READINESS_POLL_SECONDS as u64 + 1);
+        assert!(remaining_budget(deadline, at_deadline).is_zero());
+        assert!(remaining_budget(deadline, past_deadline).is_zero());
+        assert!(sleep_duration(deadline, past_deadline).is_zero());
+        assert!(probe_timeout(deadline, past_deadline).is_zero());
+    }
+
+    #[test]
+    fn readiness_bound_names_the_60_second_limit() {
+        assert_eq!(READINESS_POLL_SECONDS, 60);
+        let err = anyhow::anyhow!("IPFS daemon started but API not ready after {} seconds", READINESS_POLL_SECONDS);
+        let text = format!("{err:#}");
+        assert!(text.contains("60 seconds"), "{text}");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -676,9 +676,6 @@ async fn client_main(
     stats: Arc<MinerStats>,
     shutdown_requested: Arc<AtomicBool>,
 ) -> Result<(), Error> {
-    let ipfs_url = opt.ipfs_url.clone();
-    tokio::task::spawn_blocking(move || crate::ipfs::ensure_daemon(&ipfs_url)).await.ok();
-
     let mut client = get_client(
         opt.keryxd_address.clone(),
         opt.mining_address.clone().unwrap_or_default(),
@@ -1203,6 +1200,16 @@ async fn run() -> Result<(), Error> {
         error!("No workers specified");
         return Err("No workers specified".into());
     }
+
+    // IPFS readiness gate: make sure the daemon is up before any client/capability activity.
+    // Runs once here, outside the reconnect loop, so a dead daemon fails startup instead of
+    // spinning reconnect attempts, and the miner never advertises/serves inference it cannot
+    // publish. `ensure_daemon` returns only when the API is reachable (waiting up to 60
+    // seconds, failing immediately if the child exits).
+    let ipfs_url = opt.ipfs_url.clone();
+    tokio::task::spawn_blocking(move || crate::ipfs::ensure_daemon(&ipfs_url))
+        .await
+        .map_err(|e| format!("IPFS startup task failed: {}", e))??;
 
     let block_template_ctr = Arc::new(AtomicU16::new((thread_rng().next_u64() % 10_000u64) as u16));
     if opt.devfund_percent > 0 {


### PR DESCRIPTION
Part of #19.

## Why this is needed

Inference results are published through IPFS. If the miner cannot start Kubo, reaches the wrong API URL, or loses the daemon during an upload, it may finish the model work but fail to publish the result. From the network's point of view that is a missed response, which can lead to service strikes and burned escrow.

The previous startup path also treated Kubo readiness as best-effort. A miner could advertise inference capability before its upload path was usable, and concurrent upload failures could start competing recovery attempts.

## What this PR does

- Normalizes values such as `127.0.0.1:5001` into a usable HTTP API URL.
- Auto-manages Kubo only for exact loopback hosts. Remote IPFS endpoints are never started, stopped, or replaced by the miner.
- Gives managed Kubo an explicit `HOME` and `IPFS_PATH`, including HiveOS environments where `HOME` is empty.
- Waits for real API readiness for at most 60 seconds using a wall-clock deadline.
- Stops startup before the miner advertises inference capability if the required IPFS service is unavailable.
- Serializes process-wide local recovery so simultaneous failed uploads cannot launch duplicate daemons.
- Retries a failed upload exactly once after recovery and preserves both the original and retry errors when recovery fails.

## Operator impact

A local Kubo failure becomes a clear startup or upload error instead of a miner that appears healthy while silently missing inference work. Existing remote `--ipfs-url` deployments retain operator control and are never auto-managed.

## Safety and compatibility

- No prompt or inference-result text is added to logs or stats.
- Mining behavior outside IPFS startup and upload recovery is unchanged.
- HiveOS keeps its durable state outside the replaceable package directory.

## Verification

- `cargo test -p keryx-miner --bin keryx-miner ipfs::tests` — 10 passed
- `bash integrations/hiveos/tests/home-fallback.sh`
- Protocol-faithful HTTP scenarios for single-read and split-read uploads, malformed version responses, startup timeout, and concurrent recovery
- Real Kubo lifecycle and recovery in a disposable Docker environment
- `git diff --check`

Tests ran in an NVIDIA CUDA 12.9.1 development container on a disposable Ubuntu build host. No live miner deployment or mutation was performed.