### PR TITLE
Expose structured miner readiness state

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,20 @@ models/
 
 If the miner still downloads a model although the folder is there, check your tier flag before anything else: the flag decides **which** model is requested, `--models-dir` only says **where** to look.
 
+### Structured readiness
+
+The existing `/stats` and `/v1/miner/stats` responses use `stats_schema_version: 2` and
+retain all legacy fields. The top-level `phase`, `fatal_error`, `keryxd`, `escrow`, and
+`template_notifications` fields expose startup state without log parsing. Every configured
+CUDA device also reports its UUID, selected tier and model, download progress, integrity,
+load, inference, PoM, error, and mining state independently.
+
+For deployment tooling, the model/node readiness portion is satisfied when the escrow
+certificate is valid, keryxd is connected, and at least one device is in `mining` with
+inference verified, PoM ready, and non-zero hashrate. `partial` means another device is
+still preparing and none has failed. `degraded` takes precedence when any tracked device
+has failed while another continues mining.
+
 ### Escrow state durability
 
 Escrow keys and claim state are written through a same-directory temporary file, synced, and atomically installed. An unreadable key or malformed state file stops escrow initialization without replacing the existing bytes. Recovery output uses the same atomic write path.

--- a/src/client/grpc.rs
+++ b/src/client/grpc.rs
@@ -176,10 +176,34 @@ impl Client for KeryxdHandler {
     async fn listen(&mut self, miner: &mut MinerManager) -> Result<(), Error> {
         self.opoi_challenge_active = Some(miner.opoi_challenge_flag());
         self.stats = Some(miner.stats_handle());
-        // Harvest in-flight inference on a timer, independently of node notifications.
-        // On a sole-producer node, pausing mining for inference stops block production,
-        // so the node stops sending NewBlockTemplate notifications — without this timer
-        // the finished inference would never be collected and mining would deadlock.
+        let outcome = self.listen_loop(miner).await;
+        // Readiness: every exit path of the loop — the node closed the stream, a handler
+        // errored, or the stream dropped — means the session is down. Clear the event-driven
+        // flags so a reconnect derives them from scratch (connect()/GetInfoResponse/
+        // NotifyNewBlockTemplateResponse) instead of carrying stale state across sessions.
+        if let Some(stats) = crate::stats::readiness_stats() {
+            stats.set_keryxd_connected(false);
+            stats.set_template_notifications(false);
+        }
+        outcome
+    }
+
+    fn get_block_channel(&self) -> Sender<BlockSeed> {
+        self.block_channel.clone()
+    }
+
+    fn flush_escrow_state(&mut self) -> Result<(), Error> {
+        self.escrow_watcher.as_mut().map_or(Ok(()), |watcher| watcher.flush_state().map_err(Into::into))
+    }
+}
+
+impl KeryxdHandler {
+    /// The actual message loop (see `Client::listen` for why it is split from the readiness
+    /// bookkeeping). Harvests in-flight inference on a timer, independently of node
+    /// notifications: on a sole-producer node, pausing mining for inference stops block
+    /// production, so the node stops sending NewBlockTemplate notifications — without this
+    /// timer the finished inference would never be collected and mining would deadlock.
+    async fn listen_loop(&mut self, miner: &mut MinerManager) -> Result<(), Error> {
         let mut tick = tokio::time::interval(tokio::time::Duration::from_millis(200));
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
@@ -215,16 +239,6 @@ impl Client for KeryxdHandler {
         Ok(())
     }
 
-    fn get_block_channel(&self) -> Sender<BlockSeed> {
-        self.block_channel.clone()
-    }
-
-    fn flush_escrow_state(&mut self) -> Result<(), Error> {
-        self.escrow_watcher.as_mut().map_or(Ok(()), |watcher| watcher.flush_state().map_err(Into::into))
-    }
-}
-
-impl KeryxdHandler {
     pub async fn connect<D>(
         address: D,
         miner_address: String,
@@ -266,6 +280,13 @@ impl KeryxdHandler {
                 None
             }
         };
+
+        // Readiness: the connection is down until the node actually answers the GetInfo
+        // handshake below (see GetInfoResponse) — and reconnects start from a cleared
+        // flag so a stale "connected" never survives a dropped stream.
+        if let Some(stats) = crate::stats::readiness_stats() {
+            stats.set_keryxd_connected(false);
+        }
 
         let mut client = RpcClient::connect(address).await?;
         // Outbound message channel to the node. ALL client->node messages share this:
@@ -912,6 +933,10 @@ impl KeryxdHandler {
                 None => self.report_service_strikes(&resp),
             },
             Payload::GetBlockTemplateResponse(template) => {
+                // Readiness: the node's own sync verdict, refreshed with every template.
+                if let Some(stats) = crate::stats::readiness_stats() {
+                    stats.set_keryxd_synced(template.is_synced);
+                }
                 // Track DAA score for challenge_window_end computation.
                 if let Some(daa) = template.block.as_ref()
                     .and_then(|b| b.header.as_ref())
@@ -1139,6 +1164,11 @@ impl KeryxdHandler {
             }
             Payload::GetInfoResponse(info) => {
                 info!("Keryxd version: {}", info.server_version);
+                // Readiness: the first usable node response — this is the connection being up.
+                if let Some(stats) = crate::stats::readiness_stats() {
+                    stats.set_keryxd_connected(true);
+                    stats.set_keryxd_version(Some(info.server_version.clone()));
+                }
                 // Register for all notification types:
                 // - NewBlockTemplate drives the mining loop
                 // - BlockAdded lets us scan confirmed blocks for AiRequests
@@ -1162,8 +1192,18 @@ impl KeryxdHandler {
                 self.client_get_block_template().await?;
             }
             Payload::NotifyNewBlockTemplateResponse(res) => match res.error {
-                None => info!("Registered for new template notifications"),
-                Some(e) => error!("Failed registering for new template notifications: {:?}", e),
+                None => {
+                    info!("Registered for new template notifications");
+                    if let Some(stats) = crate::stats::readiness_stats() {
+                        stats.set_template_notifications(true);
+                    }
+                }
+                Some(e) => {
+                    error!("Failed registering for new template notifications: {:?}", e);
+                    if let Some(stats) = crate::stats::readiness_stats() {
+                        stats.set_template_notifications(false);
+                    }
+                }
             },
             Payload::NotifyBlockAddedResponse(res) => match res.error {
                 None => info!("Registered for block added notifications (AI request scanning)"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod pom_gpu;
 pub mod pom_v3;
 pub mod pom_v4;
 pub mod slm;
+pub mod stats;
 pub mod xoshiro256starstar;
 use libloading::{Library, Symbol};
 
@@ -38,11 +39,7 @@ pub struct PluginManager {
 */
 impl PluginManager {
     pub fn new() -> Self {
-        Self {
-            plugins: Vec::new(),
-            loaded_libraries: Vec::new(),
-            startup_warnings: Vec::new(),
-        }
+        Self { plugins: Vec::new(), loaded_libraries: Vec::new(), startup_warnings: Vec::new() }
     }
 
     fn record_startup_warning(&mut self, message: String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,10 +36,14 @@ mod keryxd_messages;
 mod logging;
 mod miner;
 mod pow;
-mod stats;
 mod target;
 mod ui;
 mod watch;
+
+// `stats` is owned by the library crate (keryx_miner::stats) so binary modules and library
+// modules share one compiled module and one `READINESS_STATS` OnceLock. Re-export at the
+// binary crate root so existing `crate::stats::*` references resolve to the library module.
+pub use keryx_miner::stats;
 
 // PoM mining is CUDA-only (the walk kernel is CUDA). The OpenCL/AMD plugin did legacy
 // kHeavyHash only — it cannot produce a possession proof, so an OpenCL worker's blocks are
@@ -430,6 +434,18 @@ fn tier_rank(t: keryx_miner::models::Tier) -> u8 {
     }
 }
 
+/// Canonical kebab-case tier name for structured readiness output.
+fn tier_name(t: keryx_miner::models::Tier) -> &'static str {
+    use keryx_miner::models::Tier::*;
+    match t {
+        VeryLight => "very-light",
+        Light => "light",
+        Default => "default",
+        High => "high",
+        VeryHigh => "very-high",
+    }
+}
+
 /// Parse a `--force-model` tier name. None on an unrecognised token.
 fn parse_tier_name(s: &str) -> Option<keryx_miner::models::Tier> {
     use keryx_miner::models::Tier;
@@ -765,6 +781,13 @@ fn main() -> Result<(), Error> {
     let outcome = rt.block_on(run());
     if let Err(e) = &outcome {
         report_fatal(&e.to_string());
+        // Fatal startup failures become structural: keep the already-running stats server
+        // observable briefly so deployment tooling can read `phase: "fatal"` + `fatal_error`
+        // instead of racing immediate process exit. No-op when failure preceded stats setup.
+        if let Some(stats) = crate::stats::readiness_stats() {
+            stats.set_fatal_error(Some(e.to_string()));
+            std::thread::sleep(Duration::from_secs(5));
+        }
     }
     outcome
 }
@@ -877,6 +900,10 @@ async fn run() -> Result<(), Error> {
     }
 
     let stats = Arc::new(MinerStats::new(opt.hiveos));
+    // Register the process-wide readiness handle FIRST, before any download/probe/client
+    // activity: every readiness reporter (slm/pom_gpu download progress, the gRPC client's
+    // keryxd flags, fatal paths) reads through this registration.
+    crate::stats::install_readiness_stats(Arc::clone(&stats));
     stats.set_mining_address(opt.mining_address.clone());
     stats.set_api_port(opt.stats_port);
     let _ui_guard =
@@ -1051,6 +1078,13 @@ async fn run() -> Result<(), Error> {
         _ => None,
     };
 
+    // Readiness: expose the resolved escrow state structurally. The key counts as loaded when
+    // the OPoI keyfile resolved; the certificate is valid exactly when a cert resolved for this
+    // payout address (explicit flag, local self-signature, or validated file). The public key
+    // is safe to expose — it is embedded in every coinbase extra_data anyway.
+    let escrow_pubkey_hex = escrow_privkey.as_deref().and_then(|k| escrow::pubkey_hex_from_privkey(k).ok());
+    stats.set_escrow_readiness(escrow_privkey.is_some(), escrow_cert.is_some(), escrow_pubkey_hex);
+
     // Phase-3 OPoI / PoM: load inference models before mining starts. Under PoM each tier
     // mines AND serves exactly ONE model (1 GPU = 1 tier); multi-tier coverage is a network
     // property, not a per-GPU one.
@@ -1104,6 +1138,18 @@ async fn run() -> Result<(), Error> {
     let specs = lineup_from_assignments(&pom_assignments, tier);
     keryx_miner::slm::init_supported(specs);
     log::debug!("OPoI Phase-3 active — {} model(s) staged.", specs.len());
+    // Readiness: register every per-GPU assignment BEFORE any download starts, so the first-run
+    // model acquisition (prefetch below) reports into the right device row — download progress is
+    // keyed by model_id and requires the row to exist. tier = kebab-case, model_id = hex of the
+    // 32-byte on-chain id, model = the GGUF directory name (matches the node's label).
+    for (device_id, gpu_tier, spec) in &pom_assignments {
+        stats.configure_device(
+            *device_id,
+            tier_name(*gpu_tier).to_string(),
+            hex::encode(spec.model_id),
+            spec.dir_name.to_string(),
+        );
+    }
     // Where the chain actually is, so the eras it has already left are not downloaded. Bounded and
     // fail-open: an unreachable node (or pool mining) just falls back to prefetching every era.
     // Prefetch every era this miner can still reach, so a crossing ahead of us hot-swaps without a

--- a/src/pom_gpu.rs
+++ b/src/pom_gpu.rs
@@ -1043,11 +1043,45 @@ fn mining_tiers() -> &'static Mutex<HashMap<u32, ([u8; 32], String)>> {
     MINING_TIERS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Kebab-case tier label reported in readiness (`"very-light"` … `"very-high"`), matching the
+/// `--force-model` spelling and the readiness schema's example (`"tier": "light"`).
+fn tier_label(tier: crate::models::Tier) -> &'static str {
+    use crate::models::Tier::*;
+    match tier {
+        VeryLight => "very-light",
+        Light => "light",
+        Default => "default",
+        High => "high",
+        VeryHigh => "very-high",
+    }
+}
+
+/// The registered spec owning `model_id`, if any — the readiness `model` label is the spec's
+/// human-readable `dir_name` (e.g. "GLM-4-9B-0414").
+fn spec_for_model_id(model_id: [u8; 32]) -> Option<&'static crate::models::ModelSpec> {
+    crate::models::REGISTRY.iter().copied().find(|s| s.model_id == model_id)
+}
+
+/// Push a device's configured tier + model to the readiness stats. Called on every assignment
+/// (startup and era-crossing swaps) and on OOM downgrades, so the reported model always matches
+/// what the device is actually staged to mine.
+fn register_device_readiness(device_id: u32) {
+    let Some(tier) = device_tiers().lock().ok().and_then(|g| g.get(&device_id).copied()) else { return };
+    let Some(model_id) = mining_tiers().lock().ok().and_then(|g| g.get(&device_id).map(|(id, _)| *id)) else { return };
+    let model_label = spec_for_model_id(model_id)
+        .map(|s| s.dir_name.to_string())
+        .unwrap_or_else(|| hex::encode(model_id)[..8].to_string());
+    crate::stats::readiness_stats().as_deref().map(|stats| {
+        stats.configure_device(device_id, tier_label(tier).to_string(), hex::encode(model_id), model_label);
+    });
+}
+
 /// Record a GPU's mining tier so its miner can be rebuilt after an inference swapped the model away.
 pub fn set_mining_tier(device_id: u32, model_id: [u8; 32], gguf_path: String) {
     if let Ok(mut g) = mining_tiers().lock() {
         g.insert(device_id, (model_id, gguf_path));
     }
+    register_device_readiness(device_id);
 }
 
 /// Per-GPU **hardware** tier (VRAM-derived, DAA-independent). Distinct from `mining_tiers` (the
@@ -1065,6 +1099,7 @@ pub fn set_device_tier(device_id: u32, tier: crate::models::Tier) {
     if let Ok(mut g) = device_tiers().lock() {
         g.insert(device_id, tier);
     }
+    register_device_readiness(device_id);
 }
 
 /// Hot-swap the resident mining model at an era crossing: when `daa` reaches a model's gate, the
@@ -1278,6 +1313,9 @@ pub fn ensure_installed(device_id: u32, daa: u64) -> bool {
         return false;
     }
     if is_installed(device_id) {
+        // The miner is already resident — clear any stale per-device load/index error so a
+        // recovered device stops reading as failed.
+        crate::stats::readiness_stats().as_deref().map(|stats| stats.set_device_error(device_id, None));
         return true;
     }
     // Flag the heavy load so the stall watchdog stays benign while the worker is blocked here.
@@ -1429,19 +1467,34 @@ fn reset_stale_gpu_state(device_id: u32, use_llama: bool) {
 fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
     // Re-check under the per-device lifecycle lock: a worker that queued on the lock before the
     // pause was raised must not reload the mining model while inference is still generating.
+    // This is normal control flow, not a device failure — a healthy device pausing for
+    // inference must not read as Fatal/Degraded, so no error is recorded here.
     if inference_paused() {
         return false;
     }
     let (model_id, gguf) = match mining_tiers().lock().ok().and_then(|g| g.get(&device_id).cloned()) {
         Some(x) => x,
-        None => return false,
+        None => {
+            crate::stats::readiness_stats()
+                .as_deref()
+                .map(|stats| stats.set_device_error(device_id, Some("no mining tier assigned".into())));
+            return false;
+        }
     };
     // This GPU's tier at the current block DAA (recomputed per block, H2-gated).
     let tier = match crate::models::pom_tier_index(&model_id, daa) {
         Some(t) => t,
-        None => return false,
+        None => {
+            crate::stats::readiness_stats()
+                .as_deref()
+                .map(|stats| stats.set_device_error(device_id, Some("model not active at current DAA".into())));
+            return false;
+        }
     };
     if is_oom_banlisted(device_id, &model_id) {
+        crate::stats::readiness_stats()
+            .as_deref()
+            .map(|stats| stats.set_device_error(device_id, Some("model OOM'd on this GPU — banlisted".into())));
         return false; // this model OOM'd on this GPU before — don't retry (avoids a hot reload spin).
     }
     // Build THIS model's possession index once (host, heavy) — deferred from boot so the pre-PoM
@@ -1476,6 +1529,9 @@ fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
                 }
                 Err(e) => {
                     log::error!("PoM: host index build failed for tier {} on gpu{}: {}", tier, device_id, e);
+                    crate::stats::readiness_stats()
+                        .as_deref()
+                        .map(|stats| stats.set_device_error(device_id, Some(format!("host index build failed: {e}"))));
                     return false;
                 }
             }
@@ -1561,6 +1617,9 @@ fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
                     device_id,
                     e_msg
                 );
+                crate::stats::readiness_stats().as_deref().map(|stats| {
+                    stats.set_device_error(device_id, Some(format!("transient GPU runtime fault: {e_msg}")))
+                });
                 reset_stale_gpu_state(device_id, use_llama);
                 return false;
             }
@@ -1572,6 +1631,9 @@ fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
                         device_id,
                         e_msg
                     );
+                    crate::stats::readiness_stats()
+                        .as_deref()
+                        .map(|stats| stats.set_device_error(device_id, Some(format!("PTX incompatibility: {e_msg}"))));
                 }
                 MinerLoadFailureKind::OomLikely => {
                     log::error!(
@@ -1579,6 +1641,9 @@ fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
                         device_id,
                         e_msg
                     );
+                    crate::stats::readiness_stats()
+                        .as_deref()
+                        .map(|stats| stats.set_device_error(device_id, Some(format!("model load OOM: {e_msg}"))));
                     oom_banlist_add(device_id, model_id);
                     downgrade_after_oom(device_id, &model_id, daa);
                 }
@@ -1588,12 +1653,18 @@ fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
                         device_id,
                         e_msg
                     );
+                    crate::stats::readiness_stats()
+                        .as_deref()
+                        .map(|stats| stats.set_device_error(device_id, Some(format!("miner load failed: {e_msg}"))));
                 }
             }
             return false;
         }
         Err(_) => {
             log::error!("PoM[gpu{}]: device miner load panicked (likely OOM) — banlisting this model and downgrading.", device_id);
+            crate::stats::readiness_stats()
+                .as_deref()
+                .map(|stats| stats.set_device_error(device_id, Some("model load panicked (likely OOM)".into())));
             oom_banlist_add(device_id, model_id);
             downgrade_after_oom(device_id, &model_id, daa);
             return false;
@@ -1604,11 +1675,19 @@ fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
     if let Some(idx) = crate::pom::active_index_for_model(&model_id) {
         if n != idx.n_chunks {
             log::error!("PoM[gpu{}]: gather N={} != tier {} index N={} — refusing to mine", device_id, n, tier, idx.n_chunks);
+            crate::stats::readiness_stats().as_deref().map(|stats| {
+                stats.set_device_error(device_id, Some("gather N != host index N — refusing to mine".into()))
+            });
             return false;
         }
     }
     install(device_id, gm);
     info!("PoM[gpu{}]: GPU miner ready — N={} chunks resident (matches shared index)", device_id, n);
+    // The GPU miner AND the host weight index are both live — the device is PoM-ready.
+    crate::stats::readiness_stats().as_deref().map(|stats| {
+        stats.set_device_pom_ready(device_id, true);
+        stats.set_device_error(device_id, None);
+    });
     true
 }
 

--- a/src/slm.rs
+++ b/src/slm.rs
@@ -58,11 +58,30 @@ pub fn gguf_path_for(spec: &ModelSpec) -> std::path::PathBuf {
 /// consistent, and an already-complete file (e.g. pre-staged with `wget -c`) is
 /// detected via a 416 response and left untouched instead of being re-downloaded.
 fn download_file(url: &str, dest: &std::path::Path) -> Result<()> {
+    download_file_inner(url, dest, None)
+}
+
+/// Like `download_file` but reports per-chunk download progress (bytes downloaded / total) to the
+/// readiness stats while streaming, keyed by the model's hex id. The final sample on completion —
+/// including the "already on disk" fast paths — is also pushed so `percent` reaches 100 even when
+/// a pre-staged file skips the stream.
+fn download_model_file(url: &str, dest: &std::path::Path, model_id: &[u8; 32]) -> Result<()> {
+    download_file_inner(url, dest, Some(*model_id))
+}
+
+fn download_file_inner(url: &str, dest: &std::path::Path, model_id: Option<[u8; 32]>) -> Result<()> {
     const MAX_ATTEMPTS: u32 = 240; // survives long gateway outages (~40 min of retries)
     const BACKOFF_SECS: u64 = 10;
     ui_download_info(&format!("[keryx-miner] Downloading {} ...", url));
     let mut attempt = 0u32;
     let mut last_logged_percent: u64 = 0;
+    let report_progress = |downloaded: u64, total: Option<u64>| {
+        if let Some(model_id) = model_id {
+            crate::stats::readiness_stats()
+                .as_deref()
+                .map(|stats| stats.set_device_download(&hex::encode(model_id), downloaded, total));
+        }
+    };
     loop {
         // Resume offset = how many bytes we already have on disk.
         let resume_from = std::fs::metadata(dest).map(|m| m.len()).unwrap_or(0);
@@ -103,6 +122,7 @@ fn download_file(url: &str, dest: &std::path::Path) -> Result<()> {
                 (f, resume_from, total)
             } else if resume_from > 0 && status == 416 {
                 // Range not satisfiable ⇒ the file is already fully downloaded.
+                report_progress(resume_from, Some(resume_from));
                 if ui_progress_to_stderr() {
                     eprintln!("\r  already complete ({} MB).            ", resume_from / 1_000_000);
                 } else {
@@ -117,6 +137,7 @@ fn download_file(url: &str, dest: &std::path::Path) -> Result<()> {
                 if resume_from > 0 {
                     if let Some(t) = total {
                         if resume_from >= t {
+                            report_progress(resume_from, Some(resume_from));
                             if ui_progress_to_stderr() {
                                 eprintln!("\r  already complete ({} MB).            ", resume_from / 1_000_000);
                             } else {
@@ -166,6 +187,7 @@ fn download_file(url: &str, dest: &std::path::Path) -> Result<()> {
                         break;
                     }
                     downloaded += n as u64;
+                    report_progress(downloaded, total);
                     if let Some(t) = total {
                         let pct = downloaded * 100 / t.max(1);
                         if ui_progress_to_stderr() {
@@ -198,6 +220,7 @@ fn download_file(url: &str, dest: &std::path::Path) -> Result<()> {
         // usually returns a parsable Content-Range and self-heals.
         let complete = stream_err.is_none() && matches!(total, Some(t) if downloaded >= t);
         if complete {
+            report_progress(downloaded, total);
             if ui_progress_to_stderr() {
                 eprintln!();
             }
@@ -291,7 +314,7 @@ fn ensure_gguf(spec: &ModelSpec) -> Result<(std::path::PathBuf, std::path::PathB
             "[keryx-miner] Downloading model '{}' via IPFS. This happens once.",
             spec.name
         ));
-        download_file(&ipfs_url(spec.weight_cids[0]), &gguf)?;
+        download_model_file(&ipfs_url(spec.weight_cids[0]), &gguf, &spec.model_id)?;
         if !crate::gguf::is_complete_file(&gguf) {
             return Err(anyhow!(
                 "model '{}' download finished but GGUF is incomplete at {}",
@@ -526,16 +549,25 @@ fn verify_model_file(gguf: &Path, ok_flag: &Path, expected: [u8; 32], name: &str
 fn verify_gguf(spec: &ModelSpec, gguf: &Path, ok_flag: &Path) -> Result<()> {
     if marker_certifies(ok_flag, &spec.model_id) {
         verified_models().write().unwrap().insert(spec.model_id);
+        crate::stats::readiness_stats()
+            .as_deref()
+            .map(|stats| stats.set_model_integrity(&hex::encode(spec.model_id), true));
         return Ok(());
     }
     verified_models().write().unwrap().remove(&spec.model_id);
     ui_download_info(&format!("[keryx-miner] Verifying model '{}' integrity before mining...", spec.name));
     if let Err(error) = verify_model_file(gguf, ok_flag, spec.model_id, spec.name) {
         mark_model_unavailable(&spec.model_id, "integrity_mismatch");
+        crate::stats::readiness_stats()
+            .as_deref()
+            .map(|stats| stats.set_model_integrity(&hex::encode(spec.model_id), false));
         return Err(error);
     }
     verified_models().write().unwrap().insert(spec.model_id);
     mark_model_available(&spec.model_id, "integrity_verified");
+    crate::stats::readiness_stats()
+        .as_deref()
+        .map(|stats| stats.set_model_integrity(&hex::encode(spec.model_id), true));
     ui_download_info(&format!("[keryx-miner] Model '{}' integrity verified.", spec.name));
     Ok(())
 }
@@ -676,17 +708,28 @@ pub fn load_and_run_inference(model_id: &[u8; 32], prompt: &str, max_tokens: usi
         if let Err(e) = crate::pom_gpu::load_llama_for_inference(&gguf, dev_id) {
             log::error!("SlmEngine: cannot load '{}' — {}; response dropped", spec.name, e);
             mark_model_unavailable(model_id, if e.is_oom() { "llama_load_oom" } else { "llama_load_failed" });
+            crate::stats::readiness_stats().as_deref().map(|stats| {
+                stats.set_model_loaded(&hex::encode(model_id), false);
+                stats.set_device_error(dev_id, Some(format!("inference model load failed: {e}")));
+            });
             return None;
         }
     }
+    crate::stats::readiness_stats().as_deref().map(|stats| stats.set_model_loaded(&hex::encode(model_id), true));
 
     match crate::llama_engine::generate(&templated, max_tokens) {
         Some(text) if !text.trim().is_empty() => {
             mark_model_available(model_id, "generation_success");
+            crate::stats::readiness_stats()
+                .as_deref()
+                .map(|stats| stats.set_model_inference_verified(&hex::encode(model_id), true));
             Some(text)
         }
         _ => {
             log::warn!("SlmEngine '{}': llama generate failed or empty — response dropped", spec.name);
+            crate::stats::readiness_stats()
+                .as_deref()
+                .map(|stats| stats.set_model_inference_verified(&hex::encode(model_id), false));
             None
         }
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,7 +1,7 @@
 use cudarc::driver::{result, sys};
 use nvml_wrapper::{enum_wrappers::device::TemperatureSensor, structs::device::FieldId, Nvml};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::CStr;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -39,6 +39,22 @@ impl Drop for StatsConnectionPermit {
 
 static NVML_HANDLE: OnceLock<Option<Nvml>> = OnceLock::new();
 
+/// Schema version of the stats snapshot. v2 adds `phase`, `fatal_error`, `stats_schema_version`,
+/// nested `keryxd`/`escrow` state and per-device readiness fields while keeping every v1 key.
+pub const STATS_SCHEMA_VERSION: u32 = 2;
+
+/// Process-wide registration of the miner's stats handle, installed once by main at startup.
+/// The stats server and any readiness reporters read through this.
+static READINESS_STATS: OnceLock<Arc<MinerStats>> = OnceLock::new();
+
+pub fn install_readiness_stats(stats: Arc<MinerStats>) {
+    let _ = READINESS_STATS.set(stats);
+}
+
+pub fn readiness_stats() -> Option<Arc<MinerStats>> {
+    READINESS_STATS.get().cloned()
+}
+
 #[derive(Default)]
 pub struct MinerStats {
     started_at: Mutex<Option<Instant>>,
@@ -62,7 +78,18 @@ pub struct MinerStats {
     device_blocks_rejected: Mutex<HashMap<String, u64>>,
     gpu_telemetry: Mutex<HashMap<u32, GpuTelemetry>>,
     gpu_memory_temp_supported: Mutex<HashMap<u32, bool>>,
+    gpu_identity: Mutex<HashMap<u32, GpuIdentity>>,
     hiveos: AtomicBool,
+    // Readiness state (schema v2). All optional/mutable — old clients see the same v1 fields.
+    devices_configured: Mutex<HashMap<u32, ConfiguredDevice>>,
+    fatal_error: Mutex<Option<String>>,
+    keryxd_connected: AtomicBool,
+    keryxd_version: Mutex<Option<String>>,
+    keryxd_synced: AtomicBool,
+    template_notifications: AtomicBool,
+    escrow_key_loaded: AtomicBool,
+    escrow_certificate_valid: AtomicBool,
+    escrow_public_key: Mutex<Option<String>>,
 }
 
 #[derive(Default, Clone, Copy)]
@@ -71,6 +98,66 @@ struct GpuTelemetry {
     memory_temp_c: Option<u32>,
     fan_percent: Option<u32>,
     power_draw_w: Option<f32>,
+}
+
+/// Physical GPU identity for readiness rows, keyed by logical CUDA device id.
+#[derive(Default, Clone)]
+struct GpuIdentity {
+    uuid: Option<String>,
+    name: Option<String>,
+}
+
+/// Per-CUDA-device readiness state tracked by the miner. `tier`/`model_id`/`model` are set by
+/// `configure_device`; the sticky flags are latched by their setters and never reset by a `false`
+/// (a `false` only means "no new evidence this cycle", not "no longer ready"). Reconfiguring a
+/// device to a **different** model resets the whole record — the old model's progress and any
+/// latched error must not leak into the new assignment.
+#[derive(Default, Clone)]
+struct ConfiguredDevice {
+    tier: Option<String>,
+    model_id: Option<String>,
+    model: Option<String>,
+    /// Cumulative bytes of the model file downloaded so far.
+    downloaded: u64,
+    /// Total bytes when known; `None` while unknown (server did not send a size). Never
+    /// downgraded by a later `None` after a known total was recorded.
+    download_total: Option<u64>,
+    download_complete: bool,
+    integrity_verified: bool,
+    model_loaded: bool,
+    inference_verified: bool,
+    pom_ready: bool,
+    error: Option<String>,
+}
+
+/// Overall startup/mine readiness, derived from per-device and node state. Serialized snake_case.
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReadinessPhase {
+    #[default]
+    Starting,
+    Downloading,
+    Verifying,
+    Loading,
+    Preparing,
+    Partial,
+    Degraded,
+    Mining,
+    Fatal,
+}
+
+#[derive(Default, Clone, Serialize)]
+pub struct KeryxdReadiness {
+    pub connected: bool,
+    pub version: Option<String>,
+    pub synced: bool,
+}
+
+#[derive(Default, Clone, Serialize)]
+pub struct EscrowReadiness {
+    pub key_loaded: bool,
+    pub certificate_valid: bool,
+    pub public_key: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -84,6 +171,22 @@ pub struct DeviceRate {
     pub memory_temp_c: Option<u32>,
     pub fan_percent: Option<u32>,
     pub power_draw_w: Option<f32>,
+    // Readiness enrichment (schema v2). `uuid`/`name` are the physical GPU identity from
+    // NVML/nvidia-smi telemetry when available; `tier`/`model` come from configure_device.
+    pub uuid: Option<String>,
+    pub name: Option<String>,
+    pub tier: Option<String>,
+    pub model_id: Option<String>,
+    pub model: Option<String>,
+    pub phase: ReadinessPhase,
+    pub download_percent: Option<u32>,
+    pub download_complete: bool,
+    pub integrity_verified: bool,
+    pub model_loaded: bool,
+    pub inference_verified: bool,
+    pub pom_ready: bool,
+    pub mining: bool,
+    pub error: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -104,6 +207,13 @@ pub struct MinerStatsSnapshot {
     pub escrow_pending_sompi: u64,
     pub last_update_epoch_s: u64,
     pub devices: Vec<DeviceRate>,
+    // Readiness (schema v2).
+    pub stats_schema_version: u32,
+    pub phase: ReadinessPhase,
+    pub fatal_error: Option<String>,
+    pub keryxd: KeryxdReadiness,
+    pub escrow: EscrowReadiness,
+    pub template_notifications: bool,
 }
 
 impl MinerStats {
@@ -130,7 +240,17 @@ impl MinerStats {
             device_blocks_rejected: Mutex::new(HashMap::new()),
             gpu_telemetry: Mutex::new(HashMap::new()),
             gpu_memory_temp_supported: Mutex::new(HashMap::new()),
+            gpu_identity: Mutex::new(HashMap::new()),
             hiveos: AtomicBool::new(hiveos),
+            devices_configured: Mutex::new(HashMap::new()),
+            fatal_error: Mutex::new(None),
+            keryxd_connected: AtomicBool::new(false),
+            keryxd_version: Mutex::new(None),
+            keryxd_synced: AtomicBool::new(false),
+            template_notifications: AtomicBool::new(false),
+            escrow_key_loaded: AtomicBool::new(false),
+            escrow_certificate_valid: AtomicBool::new(false),
+            escrow_public_key: Mutex::new(None),
         }
     }
 
@@ -197,6 +317,140 @@ impl MinerStats {
         self.escrow_pending_sompi.store(amount_sompi, Ordering::Release);
     }
 
+    /// Record that CUDA device `id` is configured to mine tier `tier` with model `model_id`
+    /// (human label `model`). Reconfiguration to the **same** model preserves the progress
+    /// already latched for it (download, verification flags, pom readiness); reconfiguration
+    /// to a different model restarts the device's pipeline — the old model's download/flags
+    /// and any latched error must not leak into the new assignment.
+    pub fn configure_device(&self, id: u32, tier: String, model_id: String, model: String) {
+        if let Ok(mut devices) = self.devices_configured.lock() {
+            let device = devices.entry(id).or_default();
+            if device.model_id.as_deref() != Some(model_id.as_str()) {
+                *device = ConfiguredDevice {
+                    tier: Some(tier),
+                    model_id: Some(model_id),
+                    model: Some(model),
+                    ..Default::default()
+                };
+                return;
+            }
+            device.tier = Some(tier);
+            device.model_id = Some(model_id);
+            device.model = Some(model);
+        }
+    }
+
+    /// Record cumulative download progress for a model. `downloaded` is cumulative bytes;
+    /// `total` is the file size when known. A known total is never lost: a later `None` (or a
+    /// degenerate zero size) keeps the previously recorded size, and the download is latched
+    /// complete when the cumulative bytes reach the total.
+    pub fn set_device_download(&self, model_id: &str, downloaded: u64, total: Option<u64>) {
+        if let Ok(mut devices) = self.devices_configured.lock() {
+            // Every device sharing this model gets the same progress — a mixed rig can serve one
+            // model on several GPUs and each row must advance in lockstep, not just the first.
+            for device in devices.values_mut().filter(|d| d.model_id.as_deref() == Some(model_id)) {
+                if let Some(total) = total.filter(|total| *total > 0) {
+                    device.download_total = Some(total);
+                }
+                device.downloaded = downloaded;
+                if let Some(total) = device.download_total {
+                    if downloaded >= total {
+                        device.download_complete = true;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Latch model integrity verification on every device sharing `model_id` (true-only; a
+    /// `false` is a no-op).
+    pub fn set_model_integrity(&self, model_id: &str, verified: bool) {
+        if !verified {
+            return;
+        }
+        if let Ok(mut devices) = self.devices_configured.lock() {
+            for device in devices.values_mut().filter(|d| d.model_id.as_deref() == Some(model_id)) {
+                device.integrity_verified = true;
+            }
+        }
+    }
+
+    /// Latch model load state on every device sharing `model_id` (true-only; a `false` is a no-op).
+    pub fn set_model_loaded(&self, model_id: &str, loaded: bool) {
+        if !loaded {
+            return;
+        }
+        if let Ok(mut devices) = self.devices_configured.lock() {
+            for device in devices.values_mut().filter(|d| d.model_id.as_deref() == Some(model_id)) {
+                device.model_loaded = true;
+            }
+        }
+    }
+
+    /// Latch inference verification on every device sharing `model_id` (true-only; a `false` is
+    /// a no-op).
+    pub fn set_model_inference_verified(&self, model_id: &str, verified: bool) {
+        if !verified {
+            return;
+        }
+        if let Ok(mut devices) = self.devices_configured.lock() {
+            for device in devices.values_mut().filter(|d| d.model_id.as_deref() == Some(model_id)) {
+                device.inference_verified = true;
+            }
+        }
+    }
+
+    /// Latch that the PoM kernel is installed and ready for a device (true-only).
+    pub fn set_device_pom_ready(&self, id: u32, ready: bool) {
+        if !ready {
+            return;
+        }
+        if let Ok(mut devices) = self.devices_configured.lock() {
+            devices.entry(id).or_default().pom_ready = true;
+        }
+    }
+
+    /// Set/clear a device-level error. `None` clears the failure and lets the device resume
+    /// its truthful phase.
+    pub fn set_device_error(&self, id: u32, error: Option<String>) {
+        if let Ok(mut devices) = self.devices_configured.lock() {
+            devices.entry(id).or_default().error = error;
+        }
+    }
+
+    /// Set a fatal, miner-wide error. `None` clears it.
+    pub fn set_fatal_error(&self, error: Option<String>) {
+        if let Ok(mut slot) = self.fatal_error.lock() {
+            *slot = error;
+        }
+    }
+
+    pub fn set_escrow_readiness(&self, key_loaded: bool, certificate_valid: bool, public_key: Option<String>) {
+        self.escrow_key_loaded.store(key_loaded, Ordering::Release);
+        self.escrow_certificate_valid.store(certificate_valid, Ordering::Release);
+        if let Ok(mut slot) = self.escrow_public_key.lock() {
+            *slot = public_key;
+        }
+    }
+
+    pub fn set_keryxd_connected(&self, connected: bool) {
+        self.keryxd_connected.store(connected, Ordering::Release);
+    }
+
+    pub fn set_keryxd_version(&self, version: Option<String>) {
+        if let Ok(mut slot) = self.keryxd_version.lock() {
+            *slot = version;
+        }
+    }
+
+    pub fn set_keryxd_synced(&self, synced: bool) {
+        self.keryxd_synced.store(synced, Ordering::Release);
+    }
+
+    pub fn set_template_notifications(&self, enabled: bool) {
+        self.template_notifications.store(enabled, Ordering::Release);
+    }
+
     pub fn refresh_gpu_telemetry(&self) {
         let cuda_bus_ids = cuda_device_bus_ids();
         let mut physical_to_logical = HashMap::new();
@@ -228,6 +482,20 @@ impl MinerStats {
                         .ok()
                         .map(|milliwatts| normalize_power_draw_w(Some(milliwatts as f32), None))
                         .flatten();
+                    // Physical GPU identity for the readiness rows; keyed by logical device id.
+                    let uuid = device.uuid().ok();
+                    let name = device.name().ok();
+                    if uuid.is_some() || name.is_some() {
+                        if let Ok(mut identity) = self.gpu_identity.lock() {
+                            identity.insert(
+                                logical_idx,
+                                GpuIdentity {
+                                    uuid: uuid.filter(|u| !u.is_empty()),
+                                    name: name.filter(|n| !n.is_empty()),
+                                },
+                            );
+                        }
+                    }
 
                     if let Ok(field_values) = device.field_values_for(&[FieldId(82)]) {
                         if let Some(Ok(field_sample)) = field_values.first() {
@@ -263,11 +531,8 @@ impl MinerStats {
         }
 
         let mut memory_temp_supported = self.gpu_memory_temp_supported.lock().expect("gpu telemetry mutex poisoned");
-        let should_query_nvidia_smi = should_query_nvidia_smi(
-            &fresh,
-            &memory_temp_supported,
-            self.hiveos.load(Ordering::Acquire),
-        );
+        let should_query_nvidia_smi =
+            should_query_nvidia_smi(&fresh, &memory_temp_supported, self.hiveos.load(Ordering::Acquire));
         let output = if should_query_nvidia_smi {
             Some(
                 Command::new("nvidia-smi")
@@ -298,17 +563,15 @@ impl MinerStats {
 
                     if let Some(telemetry) = fresh.get_mut(&gpu_idx) {
                         telemetry.temp_c = prefer_nvml_u32_or_nvidia_smi(telemetry.temp_c, temp_c);
-                        telemetry.memory_temp_c = normalize_memory_temp_c(
-                            nvidia_smi_memory_temp_c,
-                            telemetry.memory_temp_c,
-                        );
+                        telemetry.memory_temp_c =
+                            normalize_memory_temp_c(nvidia_smi_memory_temp_c, telemetry.memory_temp_c);
                         telemetry.fan_percent = prefer_nvml_u32_or_nvidia_smi(telemetry.fan_percent, fan_percent);
                         telemetry.power_draw_w = prefer_nvml_f32_or_nvidia_smi(telemetry.power_draw_w, power_draw_w);
                     } else {
                         fresh.insert(
                             gpu_idx,
                             GpuTelemetry {
-                                temp_c: temp_c,
+                                temp_c,
                                 memory_temp_c: normalize_memory_temp_c(nvidia_smi_memory_temp_c, None),
                                 fan_percent,
                                 power_draw_w,
@@ -317,7 +580,8 @@ impl MinerStats {
                     }
 
                     if !self.hiveos.load(Ordering::Acquire) {
-                        memory_temp_supported.insert(gpu_idx, fresh.get(&gpu_idx).and_then(|entry| entry.memory_temp_c).is_some());
+                        memory_temp_supported
+                            .insert(gpu_idx, fresh.get(&gpu_idx).and_then(|entry| entry.memory_temp_c).is_some());
                     }
                 }
             }
@@ -350,35 +614,28 @@ impl MinerStats {
 
     pub fn snapshot(&self) -> MinerStatsSnapshot {
         let started_epoch_s = self.started_epoch_s.load(Ordering::Acquire);
-        let uptime_s = self
-            .started_at
-            .lock()
-            .expect("start time mutex poisoned")
-            .map(|t| t.elapsed().as_secs())
-            .unwrap_or(0);
+        let uptime_s =
+            self.started_at.lock().expect("start time mutex poisoned").map(|t| t.elapsed().as_secs()).unwrap_or(0);
 
-        let telemetry = self
-            .gpu_telemetry
-            .lock()
-            .expect("gpu telemetry mutex poisoned")
-            .clone();
+        let telemetry = self.gpu_telemetry.lock().expect("gpu telemetry mutex poisoned").clone();
         let service_status = self.service_status.lock().ok().and_then(|s| s.clone());
-        let mining_address = self
-            .mining_address
-            .lock()
-            .expect("mining address mutex poisoned")
-            .clone();
+        let mining_address = self.mining_address.lock().expect("mining address mutex poisoned").clone();
 
-        let device_blocks_accepted = self.device_blocks_accepted.lock().expect("device block count mutex poisoned").clone();
-        let device_blocks_rejected = self.device_blocks_rejected.lock().expect("device rejected block count mutex poisoned").clone();
-        let mut devices = self
-            .device_hashrate_hs
-            .lock()
-            .expect("device stats mutex poisoned")
+        let device_blocks_accepted =
+            self.device_blocks_accepted.lock().expect("device block count mutex poisoned").clone();
+        let device_blocks_rejected =
+            self.device_blocks_rejected.lock().expect("device rejected block count mutex poisoned").clone();
+        let configured = self.devices_configured.lock().expect("configured devices mutex poisoned").clone();
+        let identities = self.gpu_identity.lock().expect("gpu identity mutex poisoned").clone();
+        let hashrates = self.device_hashrate_hs.lock().expect("device stats mutex poisoned");
+        let mut devices = hashrates
             .iter()
             .map(|(id, rate)| {
                 let gpu_idx = parse_device_number(id);
                 let telem = gpu_idx.and_then(|idx| telemetry.get(&idx).copied());
+                let identity = gpu_idx.and_then(|idx| identities.get(&idx).cloned());
+                let device = gpu_idx.and_then(|idx| configured.get(&idx));
+                let mining = *rate > 0 && device.map(|d| d.error.is_none()).unwrap_or(true);
                 DeviceRate {
                     id: id.clone(),
                     hashrate_hs: *rate,
@@ -388,9 +645,57 @@ impl MinerStats {
                     memory_temp_c: telem.and_then(|t| t.memory_temp_c),
                     fan_percent: telem.and_then(|t| t.fan_percent),
                     power_draw_w: telem.and_then(|t| t.power_draw_w),
+                    uuid: identity.as_ref().and_then(|i| i.uuid.clone()),
+                    name: identity.as_ref().and_then(|i| i.name.clone()),
+                    tier: device.and_then(|d| d.tier.clone()),
+                    model_id: device.and_then(|d| d.model_id.clone()),
+                    model: device.and_then(|d| d.model.clone()),
+                    phase: device_phase(*rate, device),
+                    download_percent: device.and_then(|d| download_percent(d)),
+                    download_complete: device.map(|d| d.download_complete).unwrap_or(false),
+                    integrity_verified: device.map(|d| d.integrity_verified).unwrap_or(false),
+                    model_loaded: device.map(|d| d.model_loaded).unwrap_or(false),
+                    inference_verified: device.map(|d| d.inference_verified).unwrap_or(false),
+                    pom_ready: device.map(|d| d.pom_ready).unwrap_or(false),
+                    mining,
+                    error: device.and_then(|d| d.error.clone()),
                 }
             })
             .collect::<Vec<_>>();
+        // Every configured CUDA device gets a row even before its first hashrate tick (it may
+        // still be downloading/preparing); the numeric id is the canonical `GPU #N` label.
+        let mut seen = hashrates.keys().filter_map(|id| parse_device_number(id)).collect::<HashSet<_>>();
+        for (gpu_idx, device) in configured.iter() {
+            if !seen.insert(*gpu_idx) {
+                continue;
+            }
+            let telem = telemetry.get(gpu_idx).copied();
+            let identity = identities.get(gpu_idx).cloned();
+            devices.push(DeviceRate {
+                id: format!("#{}", gpu_idx),
+                hashrate_hs: 0,
+                blocks_accepted: 0,
+                blocks_rejected: 0,
+                temp_c: telem.and_then(|t| t.temp_c),
+                memory_temp_c: telem.and_then(|t| t.memory_temp_c),
+                fan_percent: telem.and_then(|t| t.fan_percent),
+                power_draw_w: telem.and_then(|t| t.power_draw_w),
+                uuid: identity.as_ref().and_then(|i| i.uuid.clone()),
+                name: identity.as_ref().and_then(|i| i.name.clone()),
+                tier: device.tier.clone(),
+                model_id: device.model_id.clone(),
+                model: device.model.clone(),
+                phase: device_phase(0, Some(device)),
+                download_percent: download_percent(device),
+                download_complete: device.download_complete,
+                integrity_verified: device.integrity_verified,
+                model_loaded: device.model_loaded,
+                inference_verified: device.inference_verified,
+                pom_ready: device.pom_ready,
+                mining: false,
+                error: device.error.clone(),
+            });
+        }
         devices.sort_by(|a, b| {
             let a_num = parse_device_number(&a.id);
             let b_num = parse_device_number(&b.id);
@@ -401,6 +706,11 @@ impl MinerStats {
                 (None, None) => a.id.cmp(&b.id),
             }
         });
+
+        let fatal_error = self.fatal_error.lock().ok().and_then(|f| f.clone());
+        let phase = overall_phase(&devices, &configured, fatal_error.as_deref());
+        let escrow_public_key = self.escrow_public_key.lock().ok().and_then(|k| k.clone());
+        let keryxd_version = self.keryxd_version.lock().ok().and_then(|v| v.clone());
 
         MinerStatsSnapshot {
             started_epoch_s,
@@ -422,7 +732,134 @@ impl MinerStats {
             escrow_pending_sompi: self.escrow_pending_sompi.load(Ordering::Acquire),
             last_update_epoch_s: self.last_update_epoch_s.load(Ordering::Acquire),
             devices,
+            stats_schema_version: STATS_SCHEMA_VERSION,
+            phase,
+            fatal_error,
+            keryxd: KeryxdReadiness {
+                connected: self.keryxd_connected.load(Ordering::Acquire),
+                version: keryxd_version,
+                synced: self.keryxd_synced.load(Ordering::Acquire),
+            },
+            escrow: EscrowReadiness {
+                key_loaded: self.escrow_key_loaded.load(Ordering::Acquire),
+                certificate_valid: self.escrow_certificate_valid.load(Ordering::Acquire),
+                public_key: escrow_public_key,
+            },
+            template_notifications: self.template_notifications.load(Ordering::Acquire),
         }
+    }
+}
+
+/// Download progress as a percentage, bounded to 100. `None` when the total size is unknown
+/// (or zero), since a percentage would be meaningless.
+fn download_percent(device: &ConfiguredDevice) -> Option<u32> {
+    let total = device.download_total?;
+    if total == 0 {
+        return None;
+    }
+    let percent = (u128::from(device.downloaded.min(total)) * 100) / u128::from(total);
+    Some(percent.min(100) as u32)
+}
+
+/// Per-device readiness phase: failed when a device error is set (overrides a stale hashrate),
+/// mining when the hashrate is non-zero (ground truth — applies even to v1 rows that were never
+/// configured), otherwise the furthest truthful startup step (downloading → verifying → loading →
+/// preparing). Rows without any readiness configuration report `Starting`.
+fn device_phase(hashrate_hs: u64, device: Option<&ConfiguredDevice>) -> ReadinessPhase {
+    match device {
+        Some(device) if device.error.is_some() => ReadinessPhase::Fatal,
+        _ => {
+            if hashrate_hs > 0 {
+                return ReadinessPhase::Mining;
+            }
+            match device {
+                None => ReadinessPhase::Starting,
+                Some(device) => {
+                    if !device.download_complete {
+                        return ReadinessPhase::Downloading;
+                    }
+                    if !device.integrity_verified {
+                        return ReadinessPhase::Verifying;
+                    }
+                    if !device.model_loaded {
+                        return ReadinessPhase::Loading;
+                    }
+                    ReadinessPhase::Preparing
+                }
+            }
+        }
+    }
+}
+
+/// Derive the overall readiness phase from per-device state.
+///
+/// Order of precedence (checked before the truthful startup progression so a stuck device can
+/// never masquerade as healthy):
+/// - `Fatal` when a miner-wide fatal error is set;
+/// - `Degraded` when at least one tracked device failed and at least one other still mines.
+///   "Tracked" is any device the stats hold a `ConfiguredDevice` entry for — even one whose
+///   `configure_device` never ran (a device that failed before a tier was assigned must still
+///   degrade the aggregate, not silently vanish from it);
+/// - `Partial` when at least one device mines while another is still preparing;
+/// - `Mining` when every configured CUDA device mines (each row non-fatal with a positive rate);
+/// - otherwise the furthest truthful startup phase across devices (download → verify → load →
+///   prepare), which is also `Mining` for the empty set (no GPUs configured).
+fn overall_phase(
+    devices: &[DeviceRate],
+    configured: &HashMap<u32, ConfiguredDevice>,
+    fatal_error: Option<&str>,
+) -> ReadinessPhase {
+    if fatal_error.is_some() {
+        return ReadinessPhase::Fatal;
+    }
+    if devices.is_empty() {
+        return ReadinessPhase::Mining;
+    }
+
+    let mut failed = 0usize;
+    let mut mining = 0usize;
+    let mut preparing = 0usize;
+    let mut furthest = ReadinessPhase::Starting;
+    for device in devices {
+        let gpu_idx = parse_device_number(&device.id);
+        let device_entry = gpu_idx.and_then(|idx| configured.get(&idx));
+        // A device must hold a tier to drive the startup progression; any tracked entry at all
+        // still counts as a failed device when it has an error.
+        let is_configured = device_entry.map(|d| d.tier.is_some()).unwrap_or(false);
+        if device.phase == ReadinessPhase::Fatal || device.error.is_some() {
+            if device_entry.is_some() {
+                failed += 1;
+        }
+            continue;
+        }
+        if device.mining {
+            mining += 1;
+        } else if is_configured {
+            preparing += 1;
+        }
+        if is_configured {
+            furthest = furthest.max(device.phase);
+        }
+    }
+
+    if failed > 0 && mining > 0 {
+        return ReadinessPhase::Degraded;
+    }
+    if mining > 0 && preparing > 0 {
+        return ReadinessPhase::Partial;
+    }
+    if mining > 0 && failed == 0 && preparing == 0 {
+        return ReadinessPhase::Mining;
+    }
+    if furthest != ReadinessPhase::Starting {
+        return furthest;
+    }
+    // No configured device is on a truthful startup path (all idle or failed) and none mines:
+    // stay neutral. Only the vacuous case — no GPUs at all — reports Mining.
+    if configured.is_empty() {
+        ReadinessPhase::Mining
+    } else {
+        ReadinessPhase::Starting
     }
 }
 
@@ -447,11 +884,392 @@ mod tests {
     }
 }
 
+#[cfg(test)]
+mod readiness_tests {
+    use super::*;
+
+    fn hashrates(per_device: &[(&str, u64)]) -> HashMap<String, u64> {
+        per_device.iter().map(|(id, rate)| (id.to_string(), *rate)).collect()
+    }
+
+    /// Ready device row: configured, model downloaded/verified/loaded, inference verified, PoM ready.
+    fn fully_ready(stats: &MinerStats, id: u32) {
+        let model_id = format!("model-a{id}");
+        let model = format!("Keryx 7B-{id}");
+        stats.configure_device(id, "tier-1".into(), model_id.clone(), model);
+        stats.set_device_download(&model_id, 100, Some(100));
+        stats.set_model_integrity(&model_id, true);
+        stats.set_model_loaded(&model_id, true);
+        stats.set_model_inference_verified(&model_id, true);
+        stats.set_device_pom_ready(id, true);
+    }
+
+    #[test]
+    fn mixed_tier_phase_serializes_enriched_rows_with_old_fields() {
+        let stats = MinerStats::new(false);
+        fully_ready(&stats, 0);
+        stats.configure_device(1, "tier-2".into(), "model-2".into(), "Keryx 14B".into());
+        stats.set_device_download("model-2", 25, Some(100));
+
+        let per_device_hashrates = hashrates(&[("#0", 4_000_000_000u64)]);
+        stats.set_hashrates(4_000_000_000, &per_device_hashrates);
+
+        let snapshot = stats.snapshot();
+
+        // v2 envelope: schema version and overall mixed phase.
+        assert_eq!(snapshot.stats_schema_version, 2);
+        assert_eq!(snapshot.phase, ReadinessPhase::Partial);
+
+        assert_eq!(snapshot.devices.len(), 2);
+        let gpu0 = snapshot.devices.iter().find(|d| d.id == "#0").unwrap();
+        let gpu1 = snapshot.devices.iter().find(|d| d.id == "#1").unwrap();
+
+        // GPU0: ready + actively mining.
+        assert_eq!(gpu0.tier.as_deref(), Some("tier-1"));
+        assert_eq!(gpu0.model_id.as_deref(), Some("model-a0"));
+        assert_eq!(gpu0.model.as_deref(), Some("Keryx 7B-0"));
+        assert_eq!(gpu0.phase, ReadinessPhase::Mining);
+        assert_eq!(gpu0.hashrate_hs, 4_000_000_000);
+        assert!(gpu0.mining);
+        assert_eq!(gpu0.download_percent, Some(100));
+        assert!(gpu0.download_complete);
+        assert!(gpu0.integrity_verified);
+        assert!(gpu0.model_loaded);
+        assert!(gpu0.inference_verified);
+        assert!(gpu0.pom_ready);
+        assert!(gpu0.error.is_none());
+
+        // GPU1: still downloading, not mining.
+        assert_eq!(gpu1.tier.as_deref(), Some("tier-2"));
+        assert_eq!(gpu1.model_id.as_deref(), Some("model-2"));
+        assert_eq!(gpu1.phase, ReadinessPhase::Downloading);
+        assert_eq!(gpu1.hashrate_hs, 0);
+        assert!(!gpu1.mining);
+        assert_eq!(gpu1.download_percent, Some(25));
+        assert!(!gpu1.download_complete);
+        assert!(!gpu1.integrity_verified);
+        assert!(!gpu1.model_loaded);
+        assert!(!gpu1.inference_verified);
+        assert!(!gpu1.pom_ready);
+
+        // Old (v1) fields retained and serialized.
+        let json = serde_json::to_value(&snapshot).unwrap();
+        let device_json = &json["devices"][0];
+        assert_eq!(device_json["hashrate_hs"], 4_000_000_000u64);
+        assert!(device_json.get("blocks_accepted").is_some());
+        assert!(device_json.get("temp_c").is_some());
+        assert!(device_json.get("memory_temp_c").is_some());
+        assert!(device_json.get("fan_percent").is_some());
+        assert!(device_json.get("power_draw_w").is_some());
+        assert!(json.get("started_epoch_s").is_some());
+        assert!(json.get("total_hashrate_hs").is_some());
+        assert_eq!(json["phase"], "partial");
+    }
+
+    #[test]
+    fn fully_ready_devices_mine() {
+        let stats = MinerStats::new(false);
+        fully_ready(&stats, 0);
+        fully_ready(&stats, 1);
+        let rates = hashrates(&[("#0", 2_000_000_000u64), ("#1", 3_000_000_000u64)]);
+        stats.set_hashrates(5_000_000_000, &rates);
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.phase, ReadinessPhase::Mining);
+        assert!(snapshot.devices.iter().all(|d| d.mining && d.phase == ReadinessPhase::Mining));
+    }
+
+    #[test]
+    fn degraded_when_one_device_fails_and_another_mines() {
+        let stats = MinerStats::new(false);
+        fully_ready(&stats, 0);
+        fully_ready(&stats, 1);
+        let rates = hashrates(&[("#0", 2_000_000_000u64), ("#1", 3_000_000_000u64)]);
+        stats.set_hashrates(5_000_000_000, &rates);
+
+        stats.set_device_error(1, Some("cuda error 999: device lost".into()));
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.phase, ReadinessPhase::Degraded);
+        let failed = snapshot.devices.iter().find(|d| d.id == "#1").unwrap();
+        assert_eq!(failed.phase, ReadinessPhase::Fatal);
+        assert_eq!(failed.error.as_deref(), Some("cuda error 999: device lost"));
+        assert!(!failed.mining);
+        assert!(snapshot.devices.iter().find(|d| d.id == "#0").unwrap().mining);
+
+        // Clearing the error restores the healthy phase.
+        stats.set_device_error(1, None);
+        assert_eq!(stats.snapshot().phase, ReadinessPhase::Mining);
+    }
+
+    #[test]
+    fn tier_less_failed_device_still_degrades_a_mining_rig() {
+        // A device that failed before configure_device ever assigned a tier must still count in
+        // the aggregate: a failed card plus a mining card reads Degraded, not healthy Mining.
+        let stats = MinerStats::new(false);
+        fully_ready(&stats, 0);
+        let rates = hashrates(&[("#0", 2_000_000_000u64)]);
+        stats.set_hashrates(2_000_000_000, &rates);
+
+        // Device 1 errors without ever being configured (no tier/model rows in readiness).
+        stats.set_device_error(1, Some("cuda error 999: device lost".into()));
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.phase, ReadinessPhase::Degraded);
+        let failed = snapshot.devices.iter().find(|d| d.id == "#1").unwrap();
+        assert_eq!(failed.phase, ReadinessPhase::Fatal);
+        assert_eq!(failed.error.as_deref(), Some("cuda error 999: device lost"));
+        assert!(failed.tier.is_none());
+        assert!(!failed.mining);
+        assert!(snapshot.devices.iter().find(|d| d.id == "#0").unwrap().mining);
+
+        // Clearing the error restores the healthy phase.
+        stats.set_device_error(1, None);
+        assert_eq!(stats.snapshot().phase, ReadinessPhase::Mining);
+    }
+
+    #[test]
+    fn all_tier_less_devices_failed_without_mining_stays_neutral() {
+        // Deliberate all-failed/no-mining behavior is preserved: with no device mining, the
+        // aggregate must not invent Degraded (or Mining) — it stays on the neutral Starting path.
+        let stats = MinerStats::new(false);
+        stats.set_device_error(0, Some("no mining tier assigned".into()));
+        stats.set_device_error(1, Some("cuda error 999: device lost".into()));
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.phase, ReadinessPhase::Starting);
+        assert_ne!(snapshot.phase, ReadinessPhase::Degraded);
+        assert_ne!(snapshot.phase, ReadinessPhase::Mining);
+        assert_ne!(snapshot.phase, ReadinessPhase::Fatal);
+        assert!(snapshot.devices.iter().all(|d| d.error.is_some() && !d.mining));
+    }
+
+    #[test]
+    fn fatal_error_overrides_every_phase() {
+        let stats = MinerStats::new(false);
+        fully_ready(&stats, 0);
+        let rates = hashrates(&[("#0", 2_000_000_000u64)]);
+        stats.set_hashrates(2_000_000_000, &rates);
+
+        stats.set_fatal_error(Some("keryxd node unreachable".into()));
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.phase, ReadinessPhase::Fatal);
+        assert_eq!(snapshot.fatal_error.as_deref(), Some("keryxd node unreachable"));
+        let json = serde_json::to_value(&snapshot).unwrap();
+        assert_eq!(json["fatal_error"], "keryxd node unreachable");
+        assert_eq!(json["phase"], "fatal");
+
+        stats.set_fatal_error(None);
+        assert_eq!(stats.snapshot().phase, ReadinessPhase::Mining);
+    }
+
+    #[test]
+    fn keryxd_and_escrow_nested_state_serialize() {
+        let stats = MinerStats::new(false);
+        stats.set_keryxd_connected(true);
+        stats.set_keryxd_version(Some("0.9.1".into()));
+        stats.set_keryxd_synced(true);
+        stats.set_template_notifications(true);
+        stats.set_escrow_readiness(true, true, Some("0x1a2b3c".into()));
+
+        let snapshot = stats.snapshot();
+        assert!(snapshot.keryxd.connected);
+        assert_eq!(snapshot.keryxd.version.as_deref(), Some("0.9.1"));
+        assert!(snapshot.keryxd.synced);
+        assert!(snapshot.escrow.key_loaded);
+        assert!(snapshot.escrow.certificate_valid);
+        assert_eq!(snapshot.escrow.public_key.as_deref(), Some("0x1a2b3c"));
+
+        let json = serde_json::to_value(&snapshot).unwrap();
+        assert_eq!(json["keryxd"]["connected"], true);
+        assert_eq!(json["keryxd"]["version"], "0.9.1");
+        assert_eq!(json["keryxd"]["synced"], true);
+        assert_eq!(json["escrow"]["key_loaded"], true);
+        assert_eq!(json["escrow"]["certificate_valid"], true);
+        assert_eq!(json["escrow"]["public_key"], "0x1a2b3c");
+        assert_eq!(json["stats_schema_version"], 2);
+        assert_eq!(json["template_notifications"], true);
+
+        // Older clients still see their keys (v1 keys untouched, phase snake_case).
+        assert_eq!(json["phase"], "mining");
+        assert!(json.get("started_epoch_s").is_some());
+        assert!(json.get("service_status").is_some());
+        assert!(json.get("opoi_challenge_active").is_some());
+    }
+
+    #[test]
+    fn configure_device_to_a_new_model_resets_download_flags_and_error() {
+        let stats = MinerStats::new(false);
+        stats.configure_device(0, "tier-1".into(), "model-1".into(), "Keryx 7B".into());
+        stats.set_device_download("model-1", 100, Some(100));
+        stats.set_model_integrity("model-1", true);
+        stats.set_model_loaded("model-1", true);
+        stats.set_model_inference_verified("model-1", true);
+        stats.set_device_pom_ready(0, true);
+        stats.set_device_error(0, Some("cuda error 999: device lost".into()));
+        let before = stats.snapshot();
+        assert_eq!(before.devices[0].phase, ReadinessPhase::Fatal);
+        assert_eq!(before.devices[0].error.as_deref(), Some("cuda error 999: device lost"));
+
+        // Reconfigure to a different model: the old model's progress and the latched error must
+        // not leak into the new assignment.
+        stats.configure_device(0, "tier-2".into(), "model-2".into(), "Keryx 14B".into());
+        let snapshot = stats.snapshot();
+        let device = snapshot.devices.iter().find(|d| d.id == "#0").unwrap();
+        assert_eq!(device.tier.as_deref(), Some("tier-2"));
+        assert_eq!(device.model_id.as_deref(), Some("model-2"));
+        assert_eq!(device.model.as_deref(), Some("Keryx 14B"));
+        assert_eq!(device.download_percent, None);
+        assert!(!device.download_complete);
+        assert!(!device.integrity_verified);
+        assert!(!device.model_loaded);
+        assert!(!device.inference_verified);
+        assert!(!device.pom_ready);
+        assert!(device.error.is_none());
+        // With the error cleared and no hashrate for the fresh assignment, the device reports
+        // its truthful startup step instead of the old model's failure.
+        assert_eq!(device.phase, ReadinessPhase::Downloading);
+        assert_eq!(snapshot.phase, ReadinessPhase::Downloading);
+    }
+
+    #[test]
+    fn configure_device_with_same_model_preserves_latched_progress() {
+        let stats = MinerStats::new(false);
+        stats.configure_device(0, "tier-1".into(), "model-1".into(), "Keryx 7B".into());
+        stats.set_device_download("model-1", 100, Some(100));
+        stats.set_model_integrity("model-1", true);
+        stats.set_model_loaded("model-1", true);
+        stats.set_model_inference_verified("model-1", true);
+        stats.set_device_pom_ready(0, true);
+
+        // Reconfiguration to the same model (e.g. a tier-label refresh) keeps the pipeline.
+        stats.configure_device(0, "tier-1".into(), "model-1".into(), "Keryx 7B".into());
+        let device = &stats.snapshot().devices[0];
+        assert!(device.download_complete);
+        assert!(device.integrity_verified);
+        assert!(device.model_loaded);
+        assert!(device.inference_verified);
+        assert!(device.pom_ready);
+        assert_eq!(device.phase, ReadinessPhase::Preparing);
+    }
+
+    #[test]
+    fn model_setters_update_every_device_sharing_the_model() {
+        // A mixed rig serves one model on several GPUs; progress latched for the model must
+        // reach every configured device, not just the first row that matches.
+        let stats = MinerStats::new(false);
+        stats.configure_device(0, "tier-1".into(), "model-1".into(), "Keryx 7B".into());
+        stats.configure_device(1, "tier-1".into(), "model-1".into(), "Keryx 7B".into());
+
+        stats.set_device_download("model-1", 100, Some(100));
+        stats.set_model_integrity("model-1", true);
+        stats.set_model_loaded("model-1", true);
+        stats.set_model_inference_verified("model-1", true);
+        stats.set_device_pom_ready(0, true);
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.devices.len(), 2);
+        for device in &snapshot.devices {
+            assert_eq!(device.model_id.as_deref(), Some("model-1"));
+            assert_eq!(device.download_percent, Some(100), "device {} missed download", device.id);
+            assert!(device.download_complete, "device {} missed download_complete", device.id);
+            assert!(device.integrity_verified, "device {} missed integrity", device.id);
+            assert!(device.model_loaded, "device {} missed model_loaded", device.id);
+            assert!(device.inference_verified, "device {} missed inference_verified", device.id);
+        }
+    }
+
+    #[test]
+    fn download_progress_updates_and_bounds() {
+        let stats = MinerStats::new(false);
+        stats.configure_device(0, "tier-1".into(), "model-1".into(), "Keryx 7B".into());
+        stats.set_device_download("model-1", 50, Some(100));
+        assert_eq!(stats.snapshot().devices[0].download_percent, Some(50));
+
+        // Cumulative progress advances.
+        stats.set_device_download("model-1", 100, Some(100));
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.devices[0].download_percent, Some(100));
+        assert!(snapshot.devices[0].download_complete);
+
+        // A later unknown total keeps the known one; progress beyond the total stays bounded.
+        stats.set_device_download("model-1", 4096, None);
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.devices[0].download_percent, Some(100));
+        assert!(snapshot.devices[0].download_complete);
+
+        // Zero/unknown totals stay unknown (None, not 0%) and never flag completion on a
+        // device that has not finished yet.
+        stats.configure_device(1, "tier-1".into(), "model-zero".into(), "Keryx 7B".into());
+        stats.set_device_download("model-zero", 0, Some(0));
+        stats.set_device_download("model-zero", 10, None);
+        let snapshot = stats.snapshot();
+        let zero = snapshot.devices.iter().find(|d| d.id == "#1").unwrap();
+        assert_eq!(zero.download_percent, None);
+        assert!(!zero.download_complete);
+
+        // Downloads for unknown models are ignored; the configured row keeps its identity.
+        stats.set_device_download("model-ghost", 10, Some(50));
+        assert_eq!(stats.snapshot().devices[0].id, "#0");
+    }
+
+    #[test]
+    fn ready_device_advances_phase_through_startup_steps() {
+        let stats = MinerStats::new(false);
+        stats.configure_device(0, "tier-1".into(), "model-1".into(), "K-1".into());
+
+        // Downloading → verifying once the file is complete.
+        stats.set_device_download("model-1", 42, Some(100));
+        assert_eq!(stats.snapshot().devices[0].phase, ReadinessPhase::Downloading);
+        stats.set_device_download("model-1", 100, Some(100));
+        assert_eq!(stats.snapshot().devices[0].phase, ReadinessPhase::Verifying);
+
+        // Verifying → loading → preparing as flags latch.
+        stats.set_model_integrity("model-1", true);
+        assert_eq!(stats.snapshot().devices[0].phase, ReadinessPhase::Loading);
+        stats.set_model_loaded("model-1", true);
+        assert_eq!(stats.snapshot().devices[0].phase, ReadinessPhase::Preparing);
+        stats.set_device_pom_ready(0, true);
+
+        // A false after a true never downgrades (sticky latch).
+        stats.set_model_integrity("model-1", false);
+        stats.set_model_loaded("model-1", false);
+        let snapshot = stats.snapshot();
+        assert!(snapshot.devices[0].integrity_verified);
+        assert!(snapshot.devices[0].model_loaded);
+        assert_eq!(snapshot.devices[0].phase, ReadinessPhase::Preparing);
+
+        // Mining once hashrate flows.
+        let rates = hashrates(&[("#0", 1_000_000_000u64)]);
+        stats.set_hashrates(1_000_000_000, &rates);
+        assert_eq!(stats.snapshot().phase, ReadinessPhase::Mining);
+    }
+
+    #[test]
+    fn hashrate_without_configuration_reports_rows_without_regressing() {
+        // v1 behavior: devices exist purely from hashrate reports; no readiness config set.
+        let stats = MinerStats::new(false);
+        let rates = hashrates(&[("#0", 500u64)]);
+        stats.set_hashrates(500, &rates);
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.devices.len(), 1);
+        let device = &snapshot.devices[0];
+        assert_eq!(device.id, "#0");
+        assert_eq!(device.hashrate_hs, 500);
+        assert_eq!(device.phase, ReadinessPhase::Mining);
+        assert!(device.mining);
+        assert!(device.tier.is_none());
+        assert!(device.uuid.is_none());
+        assert_eq!(device.download_percent, None);
+        assert_eq!(snapshot.phase, ReadinessPhase::Mining);
+        assert_eq!(snapshot.stats_schema_version, 2);
+    }
+}
+
 fn parse_f32_field(value: &str) -> Option<f32> {
-    value
-        .split_whitespace()
-        .next()
-        .and_then(|x| x.parse::<f32>().ok())
+    value.split_whitespace().next().and_then(|x| x.parse::<f32>().ok())
 }
 
 fn prefer_nvml_u32_or_nvidia_smi(nvml_value: Option<u32>, nvidia_smi_value: Option<u32>) -> Option<u32> {
@@ -534,8 +1352,8 @@ fn parse_nvtool_memtemp_output(output: &str) -> HashMap<u32, u32> {
 mod telemetry_tests {
     use super::{
         logical_device_number, logical_nvtool_device_number, merge_physical_to_logical, normalize_memory_temp_c,
-        normalize_pci_bus_id, parse_nvidia_smi_device_map, parse_nvtool_memtemp_output,
-        prefer_nvml_f32_or_nvidia_smi, prefer_nvml_u32_or_nvidia_smi, should_query_nvidia_smi,
+        normalize_pci_bus_id, parse_nvidia_smi_device_map, parse_nvtool_memtemp_output, prefer_nvml_f32_or_nvidia_smi,
+        prefer_nvml_u32_or_nvidia_smi, should_query_nvidia_smi,
     };
 
     #[test]
@@ -679,7 +1497,11 @@ DEVICE #1:
     }
 }
 
-pub fn spawn_stats_server(stats: Arc<MinerStats>, bind_addr: String, port: u16) -> std::io::Result<thread::JoinHandle<()>> {
+pub fn spawn_stats_server(
+    stats: Arc<MinerStats>,
+    bind_addr: String,
+    port: u16,
+) -> std::io::Result<thread::JoinHandle<()>> {
     let listener = TcpListener::bind((bind_addr.as_str(), port))?;
     Ok(thread::spawn(move || {
         let active_connections = Arc::new(AtomicUsize::new(0));
@@ -707,15 +1529,10 @@ fn handle_connection(mut stream: TcpStream, stats: &MinerStats) -> std::io::Resu
 
     let mut reader = BufReader::new(stream.try_clone()?);
     let mut request_line = Vec::with_capacity(256);
-    let read_res = reader
-        .by_ref()
-        .take((MAX_REQUEST_LINE_BYTES + 1) as u64)
-        .read_until(b'\n', &mut request_line);
+    let read_res = reader.by_ref().take((MAX_REQUEST_LINE_BYTES + 1) as u64).read_until(b'\n', &mut request_line);
     let bytes_read = match read_res {
         Ok(n) => n,
-        Err(err)
-            if err.kind() == std::io::ErrorKind::WouldBlock || err.kind() == std::io::ErrorKind::TimedOut =>
-        {
+        Err(err) if err.kind() == std::io::ErrorKind::WouldBlock || err.kind() == std::io::ErrorKind::TimedOut => {
             return Ok(());
         }
         Err(err) => return Err(err),
@@ -724,11 +1541,7 @@ fn handle_connection(mut stream: TcpStream, stats: &MinerStats) -> std::io::Resu
         return Ok(());
     }
     if request_line.len() > MAX_REQUEST_LINE_BYTES {
-        return write_json_response(
-            &mut stream,
-            "414 URI Too Long",
-            b"{\"error\":\"request line too long\"}".to_vec(),
-        );
+        return write_json_response(&mut stream, "414 URI Too Long", b"{\"error\":\"request line too long\"}".to_vec());
     }
 
     let request_line = String::from_utf8_lossy(&request_line);
@@ -737,7 +1550,8 @@ fn handle_connection(mut stream: TcpStream, stats: &MinerStats) -> std::io::Resu
     let (status, body) = if path == "/stats" || path == "/v1/miner/stats" {
         (
             "200 OK",
-            serde_json::to_vec(&stats.snapshot()).unwrap_or_else(|_| b"{\"error\":\"failed to serialize stats\"}".to_vec()),
+            serde_json::to_vec(&stats.snapshot())
+                .unwrap_or_else(|_| b"{\"error\":\"failed to serialize stats\"}".to_vec()),
         )
     } else {
         ("404 Not Found", b"{\"error\":\"not found\"}".to_vec())
@@ -759,16 +1573,11 @@ fn write_json_response(stream: &mut TcpStream, status: &str, body: Vec<u8>) -> s
 }
 
 fn now_epoch_s() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)
 }
 
 fn parse_device_number(id: &str) -> Option<u32> {
-    id.strip_prefix('#')
-        .and_then(|s| s.split_whitespace().next())
-        .and_then(|s| s.parse::<u32>().ok())
+    id.strip_prefix('#').and_then(|s| s.split_whitespace().next()).and_then(|s| s.parse::<u32>().ok())
 }
 
 /// CUDA logical ordinal per PCI bus id. NVML, nvidia-smi and nvtool all number GPUs by bus
@@ -858,10 +1667,7 @@ fn normalize_pci_bus_id(pci_bus_id: &str) -> String {
 }
 
 fn parse_u32_field(value: &str) -> Option<u32> {
-    let filtered = value
-        .chars()
-        .take_while(|c| c.is_ascii_digit())
-        .collect::<String>();
+    let filtered = value.chars().take_while(|c| c.is_ascii_digit()).collect::<String>();
     if filtered.is_empty() {
         None
     } else {


### PR DESCRIPTION
Part of #19.

## Why this is needed

A running miner process is not necessarily ready to mine or serve inference. It may still be downloading a model, verifying weights, loading a GPU, waiting for keryxd, validating escrow, or preparing PoM. Today an operator or deployment manager has to infer those states from human-readable logs and process uptime, which is brittle and especially misleading on mixed multi-GPU rigs.

## What this PR does

- Upgrades `/stats` and `/v1/miner/stats` to an additive `stats_schema_version: 2` response while retaining every existing field.
- Reports the overall startup/mining phase and any fatal startup error.
- Reports keryxd connection, version, sync state, template notifications, and escrow readiness.
- Adds one readiness row per configured CUDA device with its UUID, tier, model, download progress, integrity verification, model load, inference verification, PoM readiness, mining state, and error.
- Updates those fields at the real lifecycle events rather than parsing logs or guessing from timers.
- Handles mixed rigs explicitly: one GPU may mine while another is preparing or has failed.
- Keeps same-model devices synchronized without losing per-device failures or progress.

## Operator impact

HiveOS tooling, health checks, and deployment managers can make deterministic decisions from JSON. They can distinguish "still preparing" from "partially available", "degraded", and "fatal" instead of restarting a healthy miner merely because one GPU or model is still loading.

## Safety and compatibility

- The schema change is additive; existing consumers keep all legacy fields.
- No escrow private key, inference prompt, or generated response is exposed.
- Readiness comes from the same in-process state used by the miner, not a second monitoring state machine.

## Verification

- `cargo test -p keryx-miner --lib readiness_tests` — 13 passed
- `cargo test -p keryx-miner --lib stats::tests` — 1 passed
- `cargo test -p keryx-miner --bin keryx-miner --no-run`
- `git diff --check`

Tests ran in an NVIDIA CUDA 12.9.1 development container on a disposable Ubuntu build host. No live miner deployment or mutation was performed.