### PR TITLE
Expose structured IPFS health state

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ Escrow keys and claim state are written through a same-directory temporary file,
 
 On HiveOS, the durable files live outside the replaceable miner package at `/hive/miners/custom/keryx-miner-state/escrow.key` and `/hive/miners/custom/keryx-miner-state/escrow_state.json`, with directory mode `0700` and file mode `0600`. Back up both files together before an upgrade or manual recovery. Never delete an invalid key to generate another one: restore the original backup because it controls existing rewards. See [`integrations/hiveos/HIVEOS_README.md`](integrations/hiveos/HIVEOS_README.md) for verified migration and rollback steps.
 
+### IPFS health
+
+The existing `/stats` and `/v1/miner/stats` responses include an `ipfs` object with the
+configured API URL, Kubo reachability and version, daemon ownership, and the latest upload
+timestamp, result, CID, and short error. `inference_rewards_enabled` follows real upload
+outcomes: a failed upload disables inference readiness until a later upload succeeds.
+Uploaded inference text is never included in stats.
+
 ### All options
 
 ```bash

--- a/src/client/grpc.rs
+++ b/src/client/grpc.rs
@@ -154,6 +154,10 @@ pub struct KeryxdHandler {
     /// Status bar sink, so the standing is visible without reading the log.
     stats: Option<Arc<crate::stats::MinerStats>>,
 
+    /// Shared miner stats: IPFS health is recorded here at real probe/upload
+    /// outcomes (issue #19).
+    ipfs_stats: Arc<crate::stats::MinerStats>,
+
     /// DAA of every miss seen since this miner started, for the lifetime tally. Counting the
     /// active strike counter would miss the worst ones: the third strike resets it to zero, and a
     /// served response clears it too. Each miss carries its own daa, so a set of those is exact
@@ -235,6 +239,7 @@ impl KeryxdHandler {
         escrow_cert: Option<String>,
         chain_daa: Option<u64>,
         ipfs_url: String,
+        stats: Arc<crate::stats::MinerStats>,
     ) -> Result<Box<Self>, Error>
     where
         D: std::convert::TryInto<tonic::transport::Endpoint>,
@@ -314,6 +319,7 @@ impl KeryxdHandler {
             last_strike_poll: std::time::Instant::now() - std::time::Duration::from_secs(55),
             strike_status: None,
             stats: None,
+            ipfs_stats: stats,
             misses_seen: std::collections::HashSet::new(),
         }))
     }
@@ -740,10 +746,26 @@ impl KeryxdHandler {
 
         let ipfs_url = self.ipfs_url.clone();
         let result_clone = result.clone();
-        let cid = match tokio::task::spawn_blocking(move || crate::ipfs::upload(&result_clone, &ipfs_url)).await {
+        let stats = Arc::clone(&self.ipfs_stats);
+        let cid = match tokio::task::spawn_blocking({
+            let stats = Arc::clone(&stats);
+            move || crate::ipfs::upload_with_stats(&result_clone, &ipfs_url, &stats)
+        })
+        .await
+        {
             Ok(Ok(cid)) => cid,
-            Ok(Err(e)) => { warn!("OPoI: IPFS upload failed: {} — AiResponse tx skipped", e); return true; }
-            Err(e) => { warn!("OPoI: IPFS spawn_blocking failed: {} — AiResponse tx skipped", e); return true; }
+            Ok(Err(e)) => {
+                warn!("OPoI: IPFS upload failed: {} — AiResponse tx skipped", e);
+                return true;
+            }
+            // The blocking task never ran (or panicked): the upload outcome was not
+            // recorded by `upload_with_stats`, so record the failure here — short
+            // diagnostic, rewards disabled — before skipping the AiResponse.
+            Err(e) => {
+                warn!("OPoI: IPFS spawn_blocking failed: {} — AiResponse tx skipped", e);
+                crate::ipfs::record_upload_failure(&stats, &e.to_string());
+                return true;
+            }
         };
 
         let challenge_window_end = self.last_known_daa + 1000;

--- a/src/client/stratum.rs
+++ b/src/client/stratum.rs
@@ -149,6 +149,9 @@ pub struct StratumHandler {
     inference_cache: InferenceCache,
     /// True while a capability challenge inference is in flight — prevents duplicate spawns.
     challenge_in_flight: Arc<AtomicBool>,
+    /// Shared miner stats: IPFS health is recorded here at real probe/upload
+    /// outcomes (issue #19).
+    ipfs_stats: Arc<crate::stats::MinerStats>,
 }
 
 #[async_trait(?Send)]
@@ -250,6 +253,7 @@ impl StratumHandler {
         mine_when_not_synced: bool,
         block_template_ctr: Option<Arc<AtomicU16>>,
         ipfs_url: String,
+        stats: Arc<crate::stats::MinerStats>,
     ) -> Result<Box<Self>, Error> {
         info!("Connecting to {}", address);
         let socket = TcpStream::connect(address).await?;
@@ -298,6 +302,7 @@ impl StratumHandler {
             current_task_slot,
             inference_cache,
             challenge_in_flight: Arc::new(AtomicBool::new(false)),
+            ipfs_stats: stats,
         }))
     }
 
@@ -741,9 +746,10 @@ impl StratumHandler {
         let ipfs_url = self.ipfs_url.clone();
         let cache_ref = Arc::clone(&self.inference_cache);
         let challenge_flag = Arc::clone(&self.challenge_in_flight);
+        let ipfs_stats = Arc::clone(&self.ipfs_stats);
 
         tokio::task::spawn_blocking(move || {
-            run_inference_and_upload(model_id, prompt, max_tokens, ipfs_url, stable_id, cache_ref);
+            run_inference_and_upload(model_id, prompt, max_tokens, ipfs_url, stable_id, cache_ref, ipfs_stats);
             // Clear both flags — PoW resumes on the next mining.notify from the bridge.
             miner_flag.store(false, Ordering::SeqCst);
             challenge_flag.store(false, Ordering::SeqCst);
@@ -772,8 +778,9 @@ fn run_inference_and_upload(
     ipfs_url: String,
     stable_id: String,
     cache: InferenceCache,
+    ipfs_stats: Arc<crate::stats::MinerStats>,
 ) {
-    let cid_opt = do_inference_and_upload(&model_id, &prompt, max_tokens, &ipfs_url, &stable_id);
+    let cid_opt = do_inference_and_upload(&model_id, &prompt, max_tokens, &ipfs_url, &stable_id, &ipfs_stats);
     let mut guard = cache.blocking_lock();
     guard.in_progress.remove(&stable_id);
     if let Some(cid) = cid_opt {
@@ -804,6 +811,7 @@ fn do_inference_and_upload(
     max_tokens: usize,
     ipfs_url: &str,
     stable_id: &str,
+    ipfs_stats: &Arc<crate::stats::MinerStats>,
 ) -> Option<String> {
     info!("OPoI [{}]: starting SLM inference (max_tokens={})", stable_id, max_tokens);
     let text = keryx_miner::slm::load_and_run_inference(model_id, prompt, max_tokens)?;
@@ -811,7 +819,7 @@ fn do_inference_and_upload(
         warn!("OPoI [{}]: inference returned empty text — skipping IPFS upload", stable_id);
         return None;
     }
-    match crate::ipfs::upload(&text, ipfs_url) {
+    match crate::ipfs::upload_with_stats(&text, ipfs_url, ipfs_stats) {
         Ok(cid_bytes) => {
             // Convert raw 34-byte multihash to base58 CIDv0 string via AiResponsePayload helper.
             let cid = keryx_inference::AiResponsePayload::new([0u8; 32], 0, cid_bytes, 0).cid_v0();

--- a/src/ipfs.rs
+++ b/src/ipfs.rs
@@ -1,7 +1,74 @@
 /// IPFS integration — upload inference results and auto-manage kubo daemon.
+use crate::stats::MinerStats;
+use std::sync::Arc;
 use std::time::Duration;
 
 const KUBO_VERSION_FALLBACK: &str = "0.41.0";
+
+/// Prefix written by `short_error("version probe", ..)` into `last_error`.
+/// The successful-probe clear matches on this so it can remove its own stale
+/// diagnostic without erasing a newer upload failure.
+const PROBE_ERROR_MARKER: &str = "version probe: ";
+
+/// Probe the Kubo API at `/api/v0/version` and record the outcome on `stats`.
+/// Never panics: any failure only flips the reachability flag and records a short
+/// diagnostic in `last_error`. `daemon_managed` is the flag recorded with the
+/// probe outcome: `false` for an externally running daemon, `true` once this
+/// miner has decided to auto-manage the local daemon.
+pub fn probe_version(stats: &MinerStats, api_url: &str, daemon_managed: bool) {
+    let url = format!("{}/api/v0/version", api_url.trim_end_matches('/'));
+    let outcome = ureq::post(&url).timeout(Duration::from_secs(2)).call();
+    match outcome {
+        Ok(response) => {
+            let version = response.into_string().ok().and_then(|body| parse_version_response(&body));
+            stats.set_ipfs_version_probe(true, version, daemon_managed);
+            // A successful probe no longer reports the previous probe failure.
+            // Only the probe's own diagnostic is cleared (matched by prefix) so
+            // a concurrent, newer upload failure in `last_error` is preserved.
+            // The check-and-clear happens under the same mutex `upload_with_stats`
+            // uses, so no real event is lost to a stale clear.
+            let mut slot = stats.last_error_lock();
+            if slot.as_deref().is_some_and(|msg| msg.starts_with(PROBE_ERROR_MARKER)) {
+                *slot = None;
+            }
+        }
+        Err(e) => {
+            stats.set_ipfs_version_probe(false, None, daemon_managed);
+            *stats.last_error_lock() = Some(short_error("version probe", &e.to_string()));
+        }
+    }
+}
+
+/// Parse the kubo version from a protocol-faithful `/api/v0/version` JSON body.
+fn parse_version_response(body: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|json| json["Version"].as_str().map(|s| s.to_string()))
+}
+
+/// Truncate `error` to at most 160 bytes without splitting a UTF-8 character.
+/// `String::truncate` panics when the byte index is not a char boundary, and
+/// arbitrary I/O error text (hostnames, paths, headers) can carry multi-byte
+/// characters — so walk back to the previous boundary before truncating.
+fn short_error(prefix: &str, error: &str) -> String {
+    let mut message = format!("{}: {}", prefix, error);
+    if message.len() > 160 {
+        let mut end = 160;
+        while !message.is_char_boundary(end) {
+            end -= 1;
+        }
+        message.truncate(end);
+    }
+    message
+}
+
+/// Record an upload failure that was not observed by `upload_with_stats` itself
+/// (e.g. the blocking task failed before the upload ran): short diagnostic,
+/// rewards disabled. Mirrors the failure side of `upload_with_stats`.
+pub fn record_upload_failure(stats: &MinerStats, error: &str) {
+    stats.set_ipfs_upload_outcome(false, None, Some(short_error("upload", error)));
+    stats.set_inference_rewards_enabled(false);
+}
 
 /// Upload `text` to the IPFS node at `api_url` and return the raw 34-byte multihash.
 /// The multihash format is: [0x12, 0x20, <32-byte sha2-256 digest>].
@@ -21,11 +88,49 @@ pub fn upload(text: &str, api_url: &str) -> anyhow::Result<[u8; 34]> {
         .map_err(|e| anyhow::anyhow!("IPFS upload failed: {}", e))?;
     let body = response.into_string()
         .map_err(|e| anyhow::anyhow!("IPFS response read error: {}", e))?;
-    let json: serde_json::Value = serde_json::from_str(&body)
-        .map_err(|e| anyhow::anyhow!("IPFS response parse error: {}", e))?;
-    let cid_str = json["Hash"].as_str()
-        .ok_or_else(|| anyhow::anyhow!("IPFS response missing Hash field: {:?}", json))?;
-    cid_v0_to_multihash(cid_str)
+    let cid_str = parse_add_response(&body)?;
+    cid_v0_to_multihash(&cid_str)
+}
+
+/// Parse the CIDv0 string from a protocol-faithful `/api/v0/add` JSON body
+/// (`{"Name": "...", "Hash": "Qm...", "Size": "..."}`).
+/// Errors never embed the response body: a broken gateway or proxy may echo the
+/// uploaded inference text (or other secrets) back inside it.
+fn parse_add_response(body: &str) -> anyhow::Result<String> {
+    let json: serde_json::Value =
+        serde_json::from_str(body).map_err(|e| anyhow::anyhow!("IPFS response parse error: {}", e))?;
+    json["Hash"]
+        .as_str()
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow::anyhow!("IPFS response missing Hash field"))
+}
+
+/// Upload wrapper that records the outcome on the shared stats: CIDv0 string on
+/// success, short diagnostic on failure. The uploaded text never reaches stats.
+/// The inference-rewards flag follows the actual upload outcome: a successful
+/// upload (re)enables rewards, a failed upload disables them, so a later upload
+/// loss turns rewards off even while the daemon stays reachable, and a
+/// successful recovery turns them back on.
+pub fn upload_with_stats(text: &str, api_url: &str, stats: &MinerStats) -> anyhow::Result<[u8; 34]> {
+    match upload(text, api_url) {
+        Ok(cid) => {
+            let cid_str = cid_v0_string(&cid);
+            stats.set_ipfs_upload_outcome(true, Some(cid_str), None);
+            stats.set_inference_rewards_enabled(true);
+            Ok(cid)
+        }
+        Err(e) => {
+            stats.set_ipfs_upload_outcome(false, None, Some(short_error("upload", &e.to_string())));
+            stats.set_inference_rewards_enabled(false);
+            Err(e)
+        }
+    }
+}
+
+/// Encode a 34-byte raw multihash as a base58btc CIDv0 string (e.g. "Qm...").
+/// Prefer the same encoding the inference crate uses for wire-format CIDs.
+fn cid_v0_string(cid: &[u8; 34]) -> String {
+    keryx_inference::AiResponsePayload::new([0u8; 32], 0, *cid, 0).cid_v0()
 }
 
 /// Decode a base58btc CIDv0 string (e.g. "Qm...") into a 34-byte raw multihash.
@@ -68,26 +173,36 @@ fn base58btc_decode(input: &str) -> Option<Vec<u8>> {
     Some(out)
 }
 
-/// Check that the IPFS API at `api_url` is reachable.
-pub fn is_running(api_url: &str) -> bool {
-    let url = format!("{}/api/v0/version", api_url.trim_end_matches('/'));
-    ureq::post(&url)
-        .timeout(Duration::from_secs(2))
-        .call()
-        .is_ok()
+/// Check whether the IPFS API at `api_url` is reachable, recording the probe
+/// outcome on `stats` as an external daemon (not auto-managed by this miner).
+pub fn probe(stats: &MinerStats, api_url: &str) -> bool {
+    probe_version(stats, api_url, false);
+    stats.is_ipfs_reachable()
+}
+
+/// Check reachability of a daemon this miner auto-manages. Identical to `probe`
+/// except every probe records the `daemon_managed` flag as `true`, so a snapshot
+/// taken while the daemon is still starting up never flickers it back to `false`.
+pub fn probe_managed(stats: &MinerStats, api_url: &str) -> bool {
+    probe_version(stats, api_url, true);
+    stats.is_ipfs_reachable()
 }
 
 /// Ensure the IPFS daemon is running. If not, download kubo and start it.
 /// Non-fatal: logs warnings on failure so the miner can still work (without inference rewards).
-pub fn ensure_daemon(api_url: &str) {
-    if is_running(api_url) {
+/// Records reachability/version/daemon-managed state on `stats` at every real
+/// `/api/v0/version` probe.
+pub fn ensure_daemon(api_url: String, stats: Arc<MinerStats>) {
+    if probe(&stats, &api_url) {
         log::info!("IPFS daemon reachable at {}", api_url);
+        stats.set_inference_rewards_enabled(true);
         return;
     }
 
     // Only auto-manage local daemon.
     if !api_url.contains("127.0.0.1") && !api_url.contains("localhost") {
         log::warn!("IPFS daemon not reachable at {} — inference rewards disabled", api_url);
+        stats.set_inference_rewards_enabled(false);
         return;
     }
 
@@ -97,6 +212,8 @@ pub fn ensure_daemon(api_url: &str) {
         Ok(p) => p,
         Err(e) => {
             log::warn!("Could not obtain kubo binary: {} — inference rewards disabled", e);
+            stats.set_ipfs_version_probe(false, None, true);
+            stats.set_inference_rewards_enabled(false);
             return;
         }
     };
@@ -137,17 +254,31 @@ pub fn ensure_daemon(api_url: &str) {
         .spawn()
     {
         Ok(_) => {
-            // Wait up to 15 seconds for the API to be ready.
+            // Wait up to 15 seconds for the API to be ready. Every probe in this
+            // loop records the managed flag, so the startup window never reports
+            // `daemon_managed=false` for a daemon this miner is bringing up.
             for _ in 0..15 {
                 std::thread::sleep(Duration::from_secs(1));
-                if is_running(api_url) {
+                if probe_managed(&stats, &api_url) {
                     log::info!("IPFS daemon ready");
-                    return;
+                    break;
                 }
             }
-            log::warn!("IPFS daemon started but API not ready — inference rewards may be delayed");
         }
-        Err(e) => log::warn!("Failed to start IPFS daemon: {} — inference rewards disabled", e),
+        Err(e) => {
+            log::warn!("Failed to start IPFS daemon: {} — inference rewards disabled", e);
+            stats.set_ipfs_version_probe(false, None, true);
+            stats.set_inference_rewards_enabled(false);
+            return;
+        }
+    }
+
+    // Auto-managed local daemon: preserve ownership while reflecting the final probe state.
+    let reachable = stats.is_ipfs_reachable();
+    stats.set_ipfs_version_probe(reachable, stats.kubo_version(), true);
+    stats.set_inference_rewards_enabled(reachable);
+    if !reachable {
+        log::warn!("IPFS daemon started but API not ready — inference rewards may be delayed");
     }
 }
 
@@ -283,4 +414,300 @@ fn extract_ipfs_binary(archive: &std::path::Path, dest_dir: &std::path::Path) ->
         }
     }
     Err(anyhow::anyhow!("ipfs binary not found in kubo archive"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    /// Protocol-faithful `/api/v0/add`/`/api/v0/version` bodies used below.
+    const VERSION_BODY: &str =
+        r#"{"Version":"0.41.0","Commit":"f3bbdf958","Repo":"17","System":"amd64/linux","Golang":"go1.24.3"}"#;
+    const ADD_BODY: &str =
+        r#"{"Name":"result.txt","Hash":"QmVC672p5SEjPGkMb9ztkVjxpYYmfG8e3oV39wAjzKtgU8","Size":"11"}"#;
+    const ADD_CID: &str = "QmVC672p5SEjPGkMb9ztkVjxpYYmfG8e3oV39wAjzKtgU8";
+
+    /// Bind an ephemeral port and serve one HTTP response with the given JSON
+    /// body for whichever `/api/v0/*` path the client probes. Fully offline:
+    /// exercises the real ureq client against protocol-faithful Kubo responses.
+    fn serve_kubo(json_body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept test client");
+            let mut buf = [0u8; 8192];
+            let mut total = 0;
+            // Read until end of headers so ureq's request (and multipart body
+            // for /add) is fully consumed before we answer.
+            let header_end = loop {
+                let n = stream.read(&mut buf[total..]).expect("read request");
+                if n == 0 {
+                    break total;
+                }
+                total += n;
+                if let Some(off) = buf[..total].windows(4).position(|w| w == b"\r\n\r\n") {
+                    break off;
+                }
+            };
+            // Parse Content-Length from the header section and own it as a
+            // plain usize so no borrow of `buf` outlives the read below.
+            let content_len = {
+                let head = String::from_utf8_lossy(&buf[..header_end]);
+                head.lines()
+                    .find_map(|l| l.to_ascii_lowercase().strip_prefix("content-length:").map(|v| v.trim().to_string()))
+                    .and_then(|len_str| len_str.parse::<usize>().ok())
+            };
+            // Consume exactly header + delimiter + body: body bytes that
+            // arrived with the headers are already counted in `total`, so
+            // only the remainder is read here.
+            if let Some(len) = content_len {
+                let needed = header_end + 4 + len;
+                while total < needed {
+                    let n = stream.read(&mut buf[total..]).expect("read body");
+                    if n == 0 {
+                        break;
+                    }
+                    total += n;
+                }
+            }
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                json_body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            stream.write_all(json_body.as_bytes()).unwrap();
+        });
+        drop(handle); // detached: the response is written before the test proceeds
+        format!("http://{}", addr)
+    }
+
+    /// Real `/api/v0/version` bodies carry "Version", "Commit", "Repo", "System"...
+    #[test]
+    fn parses_kubo_version_response() {
+        assert_eq!(parse_version_response(VERSION_BODY).as_deref(), Some("0.41.0"));
+    }
+
+    #[test]
+    fn rejects_malformed_version_response() {
+        assert_eq!(parse_version_response("not json"), None);
+        assert_eq!(parse_version_response(r#"{"Commit":"x"}"#), None);
+        assert_eq!(parse_version_response(""), None);
+    }
+
+    #[test]
+    fn probe_records_version_from_a_real_version_response() {
+        let url = serve_kubo(VERSION_BODY);
+        let stats = crate::stats::MinerStats::new(false);
+        assert!(probe(&stats, &url));
+        let snapshot = stats.snapshot();
+        assert!(snapshot.ipfs.api_reachable);
+        assert_eq!(snapshot.ipfs.kubo_version.as_deref(), Some("0.41.0"));
+        assert_eq!(snapshot.ipfs.last_error, None);
+    }
+
+    #[test]
+    fn probe_failure_stays_observable_and_non_panicking() {
+        // Nothing listens on this port (TCP_NODELAY loopback, no service):
+        // the probe must fail without panicking and record the diagnostic.
+        let url = "http://127.0.0.1:1";
+        let stats = crate::stats::MinerStats::new(false);
+        assert!(!probe(&stats, url));
+        let snapshot = stats.snapshot();
+        assert!(!snapshot.ipfs.api_reachable);
+        assert!(snapshot.ipfs.last_error.is_some());
+        assert_eq!(snapshot.ipfs.kubo_version, None);
+    }
+
+    /// Managed startup probes must never flicker `daemon_managed` back to false:
+    /// from the moment the miner decides to auto-manage, every probe records the
+    /// managed flag, so a snapshot taken mid-startup still reports `true`.
+    #[test]
+    fn managed_startup_probes_never_flicker_daemon_managed_false() {
+        let stats = crate::stats::MinerStats::new(false);
+
+        // Daemon still starting: the managed probe fails but keeps the flag true.
+        assert!(!probe_managed(&stats, "http://127.0.0.1:1"));
+        let snapshot = stats.snapshot();
+        assert!(!snapshot.ipfs.api_reachable);
+        assert!(snapshot.ipfs.daemon_managed);
+
+        // Next tick the API answers: still managed, version recorded.
+        let url = serve_kubo(VERSION_BODY);
+        assert!(probe_managed(&stats, &url));
+        let snapshot = stats.snapshot();
+        assert!(snapshot.ipfs.api_reachable);
+        assert!(snapshot.ipfs.daemon_managed);
+        assert_eq!(snapshot.ipfs.kubo_version.as_deref(), Some("0.41.0"));
+
+        // An external daemon probe still records the non-managed flag.
+        assert!(!probe(&stats, "http://127.0.0.1:1"));
+        let snapshot = stats.snapshot();
+        assert!(!snapshot.ipfs.daemon_managed);
+    }
+
+    /// A protocol-faithful `/api/v0/add` response with a CIDv0 sha2-256 hash
+    /// (QmVC... = sha2-256 of a fixed test payload, so it passes CID validation).
+    #[test]
+    fn parses_add_response_cidv0() {
+        let cid = parse_add_response(ADD_BODY).expect("valid add response parses");
+        assert_eq!(cid, ADD_CID);
+    }
+
+    #[test]
+    fn rejects_add_response_without_hash() {
+        assert!(parse_add_response(r#"{"Name":"result.txt","Size":"11"}"#).is_err());
+        assert!(parse_add_response("not json").is_err());
+        assert!(parse_add_response("").is_err());
+    }
+
+    /// Parse errors must never embed the response body: a broken gateway or
+    /// proxy may echo the uploaded inference text (or other secrets) inside it.
+    #[test]
+    fn add_parse_errors_never_echo_the_response_body() {
+        let secret = "super secret inference text echoed by a broken gateway";
+        let err = parse_add_response(secret).expect_err("non-JSON body is rejected");
+        assert!(err.to_string().contains("parse error"));
+        assert!(!err.to_string().contains(secret));
+
+        let err = parse_add_response(r#"{"Name":"result.txt","Size":"11","Prompt":"super secret prompt"}"#)
+            .expect_err("missing Hash is rejected");
+        assert!(err.to_string().contains("missing Hash"));
+        assert!(!err.to_string().contains("super secret prompt"));
+    }
+
+    #[test]
+    fn upload_records_cidv0_and_serialized_stats_omit_text() {
+        let url = serve_kubo(ADD_BODY);
+        let stats = crate::stats::MinerStats::new(false);
+        let cid = upload_with_stats("super secret inference text", &url, &stats).expect("upload succeeds");
+        assert_eq!(cid.len(), 34);
+        assert_eq!(cid[0], 0x12);
+        assert_eq!(cid[1], 0x20);
+        let snapshot = stats.snapshot();
+        assert!(snapshot.ipfs.last_upload_success);
+        assert_eq!(snapshot.ipfs.last_upload_cid.as_deref(), Some(ADD_CID));
+        let serialized = serde_json::to_string(&snapshot).unwrap();
+        assert!(serialized.contains(ADD_CID));
+        assert!(!serialized.contains("super secret inference text"));
+        assert!(!serialized.contains("inference text"));
+    }
+
+    /// Inference rewards follow actual upload outcomes: a failed upload turns
+    /// them off, a later success turns them back on, and a fresh upload loss
+    /// disables them again.
+    #[test]
+    fn upload_outcome_drives_inference_rewards() {
+        let stats = crate::stats::MinerStats::new(false);
+        assert!(!stats.snapshot().ipfs.inference_rewards_enabled);
+
+        // Upload loss: nothing listens on this loopback port, so the upload fails
+        // and rewards must go off (even though no probe ran here).
+        let dead_url = "http://127.0.0.1:1";
+        assert!(upload_with_stats("super secret", dead_url, &stats).is_err());
+        let snapshot = stats.snapshot();
+        assert!(!snapshot.ipfs.inference_rewards_enabled);
+        assert!(!snapshot.ipfs.last_upload_success);
+        assert!(snapshot.ipfs.last_error.as_deref().is_some_and(|e| e.starts_with("upload:")));
+
+        // Recovery: a real /api/v0/add success re-enables rewards.
+        let url = serve_kubo(ADD_BODY);
+        upload_with_stats("super secret", &url, &stats).expect("upload succeeds");
+        let snapshot = stats.snapshot();
+        assert!(snapshot.ipfs.inference_rewards_enabled);
+        assert!(snapshot.ipfs.last_upload_success);
+        assert_eq!(snapshot.ipfs.last_error, None);
+
+        // Later upload loss disables rewards again...
+        assert!(upload_with_stats("super secret", dead_url, &stats).is_err());
+        assert!(!stats.snapshot().ipfs.inference_rewards_enabled);
+
+        // ...and one more recovery success re-enables them.
+        let url = serve_kubo(ADD_BODY);
+        upload_with_stats("super secret", &url, &stats).expect("upload succeeds");
+        assert!(stats.snapshot().ipfs.inference_rewards_enabled);
+    }
+
+    /// The grpc JoinError path (spawn_blocking task never ran) records the
+    /// failure via `record_upload_failure`: short diagnostic, rewards disabled,
+    /// no uploaded text ever stored.
+    #[test]
+    fn record_upload_failure_disables_rewards_with_short_diagnostic() {
+        let stats = crate::stats::MinerStats::new(false);
+
+        // Pre-condition: rewards were enabled by an earlier successful upload.
+        let url = serve_kubo(ADD_BODY);
+        upload_with_stats("super secret", &url, &stats).expect("upload succeeds");
+        assert!(stats.snapshot().ipfs.inference_rewards_enabled);
+
+        // The blocking task failed before the upload ran — record it exactly the
+        // way the grpc JoinError arm does.
+        let join_error = "task panicked while running";
+        crate::ipfs::record_upload_failure(&stats, join_error);
+        let snapshot = stats.snapshot();
+        assert!(!snapshot.ipfs.inference_rewards_enabled);
+        assert!(!snapshot.ipfs.last_upload_success);
+        assert!(snapshot.ipfs.last_error.as_deref().is_some_and(|e| e.starts_with("upload:")));
+        let serialized = serde_json::to_string(&snapshot).unwrap();
+        assert!(!serialized.contains("super secret"));
+    }
+
+    /// Arbitrary UTF-8 in error text must never panic the 160-byte truncation:
+    /// the result stays on a char boundary and within the size budget.
+    #[test]
+    fn short_error_is_utf8_safe_and_bounded() {
+        // Pure ASCII: truncated to exactly 160 bytes.
+        let long_ascii = "a".repeat(500);
+        let s = short_error("upload", &long_ascii);
+        assert_eq!(s.len(), 160);
+        assert!(s.starts_with("upload: "));
+        assert!(s.is_char_boundary(s.len()));
+
+        // Multi-byte text where byte 160 lands inside a character: must not
+        // panic, must stay <= 160 bytes, and must remain valid UTF-8.
+        let long_utf8 = "雪".repeat(200); // 3 bytes per char, 600 bytes total
+        let s = short_error("version probe", &long_utf8);
+        assert!(s.len() <= 160);
+        assert!(s.is_char_boundary(s.len()));
+        assert!(std::str::from_utf8(s.as_bytes()).is_ok());
+        assert!(s.starts_with("version probe: "));
+
+        // A boundary-exact 160-byte message with multi-byte characters.
+        let mixed = format!("{}", "é".repeat(200)); // 2 bytes per char, 400 bytes
+        let s = short_error("upload", &mixed);
+        assert!(s.len() <= 160);
+        assert!(s.is_char_boundary(s.len()));
+
+        // Short messages are passed through untouched.
+        assert_eq!(short_error("upload", "boom"), "upload: boom");
+    }
+
+    /// A successful version probe clears the stale probe diagnostic but must
+    /// not erase a newer, unrelated upload failure recorded concurrently.
+    #[test]
+    fn successful_probe_clears_stale_probe_error_only() {
+        let stats = crate::stats::MinerStats::new(false);
+
+        // Failed probe: records its own diagnostic.
+        assert!(!probe(&stats, "http://127.0.0.1:1"));
+        assert!(stats.snapshot().ipfs.last_error.as_deref().unwrap().starts_with("version probe:"));
+
+        // Recovery: the next probe succeeds and the stale probe error is gone.
+        let url = serve_kubo(VERSION_BODY);
+        assert!(probe(&stats, &url));
+        let snapshot = stats.snapshot();
+        assert!(snapshot.ipfs.api_reachable);
+        assert_eq!(snapshot.ipfs.last_error, None);
+
+        // A probe failure followed by an upload failure, then a successful
+        // probe: the upload failure (newest real event) must survive the clear.
+        assert!(!probe(&stats, "http://127.0.0.1:1"));
+        assert!(upload_with_stats("super secret", "http://127.0.0.1:1", &stats).is_err());
+        let url = serve_kubo(VERSION_BODY);
+        assert!(probe(&stats, &url));
+        let snapshot = stats.snapshot();
+        assert!(snapshot.ipfs.api_reachable);
+        assert!(snapshot.ipfs.last_error.as_deref().is_some_and(|e| e.starts_with("upload:")));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -571,6 +571,7 @@ async fn get_client(
     escrow_cert: Option<String>,
     chain_daa: Option<u64>,
     ipfs_url: String,
+    stats: Arc<MinerStats>,
 ) -> Result<Box<dyn Client + 'static>, Error> {
     if keryxd_address.starts_with("stratum+tcp://") {
         let (_schema, address) = keryxd_address.split_once("://").unwrap();
@@ -580,6 +581,7 @@ async fn get_client(
             mine_when_not_synced,
             Some(block_template_ctr.clone()),
             ipfs_url.clone(),
+            stats,
         )
         .await?)
     } else if keryxd_address.starts_with("grpc://") {
@@ -593,6 +595,7 @@ async fn get_client(
             escrow_cert,
             chain_daa,
             ipfs_url,
+            stats,
         )
         .await?)
     } else {
@@ -677,7 +680,13 @@ async fn client_main(
     shutdown_requested: Arc<AtomicBool>,
 ) -> Result<(), Error> {
     let ipfs_url = opt.ipfs_url.clone();
-    tokio::task::spawn_blocking(move || crate::ipfs::ensure_daemon(&ipfs_url)).await.ok();
+    stats.set_ipfs_api_url(ipfs_url.clone());
+    tokio::task::spawn_blocking({
+        let stats = Arc::clone(&stats);
+        move || crate::ipfs::ensure_daemon(ipfs_url, stats)
+    })
+    .await
+    .ok();
 
     let mut client = get_client(
         opt.keryxd_address.clone(),
@@ -689,6 +698,7 @@ async fn client_main(
         escrow_cert,
         chain_daa,
         opt.ipfs_url.clone(),
+        Arc::clone(&stats),
     )
     .await?;
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -63,6 +63,19 @@ pub struct MinerStats {
     gpu_telemetry: Mutex<HashMap<u32, GpuTelemetry>>,
     gpu_memory_temp_supported: Mutex<HashMap<u32, bool>>,
     hiveos: AtomicBool,
+    // ── IPFS health (issue #19) ───────────────────────────────────────────────
+    // Updated at real `/api/v0/version` probes and `/api/v0/add` upload outcomes.
+    // Never holds uploaded inference text, prompts, or secrets — only the CIDv0
+    // string and short error messages.
+    ipfs_api_url: Mutex<Option<String>>,
+    ipfs_reachable: AtomicBool,
+    kubo_version: Mutex<Option<String>>,
+    daemon_managed: AtomicBool,
+    last_upload_epoch_s: AtomicU64,
+    last_upload_success: AtomicBool,
+    last_upload_cid: Mutex<Option<String>>,
+    last_error: Mutex<Option<String>>,
+    inference_rewards_enabled: AtomicBool,
 }
 
 #[derive(Default, Clone, Copy)]
@@ -104,6 +117,22 @@ pub struct MinerStatsSnapshot {
     pub escrow_pending_sompi: u64,
     pub last_update_epoch_s: u64,
     pub devices: Vec<DeviceRate>,
+    pub ipfs: IpfsStats,
+}
+
+/// Nested IPFS health section of the stats snapshot (issue #19).
+/// `last_error` carries a short diagnostic only — never uploaded content or secrets.
+#[derive(Serialize, Default)]
+pub struct IpfsStats {
+    pub api_url: Option<String>,
+    pub api_reachable: bool,
+    pub kubo_version: Option<String>,
+    pub daemon_managed: bool,
+    pub last_upload_epoch_s: u64,
+    pub last_upload_success: bool,
+    pub last_upload_cid: Option<String>,
+    pub last_error: Option<String>,
+    pub inference_rewards_enabled: bool,
 }
 
 impl MinerStats {
@@ -131,6 +160,15 @@ impl MinerStats {
             gpu_telemetry: Mutex::new(HashMap::new()),
             gpu_memory_temp_supported: Mutex::new(HashMap::new()),
             hiveos: AtomicBool::new(hiveos),
+            ipfs_api_url: Mutex::new(None),
+            ipfs_reachable: AtomicBool::new(false),
+            kubo_version: Mutex::new(None),
+            daemon_managed: AtomicBool::new(false),
+            last_upload_epoch_s: AtomicU64::new(0),
+            last_upload_success: AtomicBool::new(false),
+            last_upload_cid: Mutex::new(None),
+            last_error: Mutex::new(None),
+            inference_rewards_enabled: AtomicBool::new(false),
         }
     }
 
@@ -195,6 +233,61 @@ impl MinerStats {
     pub fn set_escrow_pending(&self, outputs: u64, amount_sompi: u64) {
         self.escrow_pending_outputs.store(outputs, Ordering::Release);
         self.escrow_pending_sompi.store(amount_sompi, Ordering::Release);
+    }
+
+    // ── IPFS health (issue #19) ────────────────────────────────────────────────
+
+    /// Record the API URL the miner was configured with. Called once at startup.
+    pub fn set_ipfs_api_url(&self, url: String) {
+        if let Ok(mut slot) = self.ipfs_api_url.lock() {
+            *slot = Some(url);
+        }
+    }
+
+    /// Record the outcome of a `/api/v0/version` probe: reachability, the kubo
+    /// version reported by the node, and whether the daemon is auto-managed.
+    /// Failures must not panic — an unreachable node only flips the flags.
+    pub fn set_ipfs_version_probe(&self, reachable: bool, kubo_version: Option<String>, daemon_managed: bool) {
+        self.ipfs_reachable.store(reachable, Ordering::Release);
+        self.daemon_managed.store(daemon_managed, Ordering::Release);
+        if let Ok(mut slot) = self.kubo_version.lock() {
+            *slot = kubo_version;
+        }
+    }
+
+    /// Record the outcome of a `/api/v0/add` upload: CIDv0 string on success,
+    /// short diagnostic on failure. Never stores uploaded text or secrets.
+    pub fn set_ipfs_upload_outcome(&self, success: bool, cid: Option<String>, error: Option<String>) {
+        self.last_upload_epoch_s.store(now_epoch_s(), Ordering::Release);
+        self.last_upload_success.store(success, Ordering::Release);
+        if let Ok(mut slot) = self.last_upload_cid.lock() {
+            *slot = cid;
+        }
+        if let Ok(mut slot) = self.last_error.lock() {
+            *slot = error;
+        }
+    }
+
+    /// Whether inference rewards are expected to work: the daemon is reachable
+    /// (or locally auto-managed) and the API is configured.
+    pub fn set_inference_rewards_enabled(&self, enabled: bool) {
+        self.inference_rewards_enabled.store(enabled, Ordering::Release);
+    }
+
+    /// Current reachability flag, as last recorded by a `/api/v0/version` probe.
+    pub fn is_ipfs_reachable(&self) -> bool {
+        self.ipfs_reachable.load(Ordering::Acquire)
+    }
+
+    /// Kubo version reported by the last successful `/api/v0/version` probe.
+    pub fn kubo_version(&self) -> Option<String> {
+        self.kubo_version.lock().ok().and_then(|s| s.clone())
+    }
+
+    /// Lock guard for the short last-error diagnostic slot (ipfs.rs uses this
+    /// so probe failures stay non-panicking).
+    pub fn last_error_lock(&self) -> std::sync::MutexGuard<'_, Option<String>> {
+        self.last_error.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     pub fn refresh_gpu_telemetry(&self) {
@@ -422,6 +515,17 @@ impl MinerStats {
             escrow_pending_sompi: self.escrow_pending_sompi.load(Ordering::Acquire),
             last_update_epoch_s: self.last_update_epoch_s.load(Ordering::Acquire),
             devices,
+            ipfs: IpfsStats {
+                api_url: self.ipfs_api_url.lock().ok().and_then(|s| s.clone()),
+                api_reachable: self.ipfs_reachable.load(Ordering::Acquire),
+                kubo_version: self.kubo_version.lock().ok().and_then(|s| s.clone()),
+                daemon_managed: self.daemon_managed.load(Ordering::Acquire),
+                last_upload_epoch_s: self.last_upload_epoch_s.load(Ordering::Acquire),
+                last_upload_success: self.last_upload_success.load(Ordering::Acquire),
+                last_upload_cid: self.last_upload_cid.lock().ok().and_then(|s| s.clone()),
+                last_error: self.last_error.lock().ok().and_then(|s| s.clone()),
+                inference_rewards_enabled: self.inference_rewards_enabled.load(Ordering::Acquire),
+            },
         }
     }
 }
@@ -444,6 +548,91 @@ mod tests {
         let device = snapshot.devices.iter().find(|device| device.id == "GPU0").unwrap();
         assert_eq!(device.blocks_accepted, 1);
         assert_eq!(device.blocks_rejected, 1);
+    }
+
+    #[test]
+    fn ipfs_section_defaults_are_observable_without_a_daemon() {
+        let stats = MinerStats::new(false);
+        let snapshot = stats.snapshot();
+
+        // Pre-existing fields stay intact and the nested ipfs section is present.
+        assert_eq!(snapshot.synced, true);
+        assert_eq!(snapshot.api_port, None);
+        assert_eq!(snapshot.ipfs.api_url, None);
+        assert!(!snapshot.ipfs.api_reachable);
+        assert_eq!(snapshot.ipfs.kubo_version, None);
+        assert!(!snapshot.ipfs.daemon_managed);
+        assert_eq!(snapshot.ipfs.last_upload_epoch_s, 0);
+        assert!(!snapshot.ipfs.last_upload_success);
+        assert_eq!(snapshot.ipfs.last_upload_cid, None);
+        assert_eq!(snapshot.ipfs.last_error, None);
+        assert!(!snapshot.ipfs.inference_rewards_enabled);
+    }
+
+    #[test]
+    fn daemon_managed_flag_distinguishes_auto_started_daemons() {
+        let stats = MinerStats::new(false);
+        // External daemon: reachable, not auto-managed.
+        stats.set_ipfs_version_probe(true, Some("0.41.0".to_string()), false);
+        let snapshot = stats.snapshot();
+        assert!(snapshot.ipfs.api_reachable);
+        assert!(!snapshot.ipfs.daemon_managed);
+
+        // Daemon started by the miner itself: same reachability, managed flag set.
+        stats.set_ipfs_version_probe(true, Some("0.41.0".to_string()), true);
+        let snapshot = stats.snapshot();
+        assert!(snapshot.ipfs.api_reachable);
+        assert!(snapshot.ipfs.daemon_managed);
+
+        // Auto-managed daemon that failed to come up stays observable.
+        stats.set_ipfs_version_probe(false, None, true);
+        let snapshot = stats.snapshot();
+        assert!(!snapshot.ipfs.api_reachable);
+        assert!(snapshot.ipfs.daemon_managed);
+    }
+
+    #[test]
+    fn ipfs_probe_and_upload_outcomes_are_reflected_in_the_snapshot() {
+        let stats = MinerStats::new(false);
+        stats.set_ipfs_api_url("http://127.0.0.1:5001".to_string());
+        stats.set_ipfs_version_probe(true, Some("0.41.0".to_string()), false);
+        stats.set_ipfs_upload_outcome(true, Some("QmXp1ExampleCidv0String".to_string()), None);
+        stats.set_inference_rewards_enabled(true);
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.ipfs.api_url.as_deref(), Some("http://127.0.0.1:5001"));
+        assert!(snapshot.ipfs.api_reachable);
+        assert_eq!(snapshot.ipfs.kubo_version.as_deref(), Some("0.41.0"));
+        assert!(!snapshot.ipfs.daemon_managed);
+        assert!(snapshot.ipfs.last_upload_success);
+        assert_eq!(snapshot.ipfs.last_upload_cid.as_deref(), Some("QmXp1ExampleCidv0String"));
+        assert_eq!(snapshot.ipfs.last_error, None);
+        assert!(snapshot.ipfs.inference_rewards_enabled);
+        assert!(snapshot.ipfs.last_upload_epoch_s > 0);
+
+        // Failure transition: reachability loss and a failed upload stay observable.
+        stats.set_ipfs_version_probe(false, None, false);
+        stats.set_ipfs_upload_outcome(false, None, Some("connection refused".to_string()));
+        let snapshot = stats.snapshot();
+        assert!(!snapshot.ipfs.api_reachable);
+        assert!(!snapshot.ipfs.last_upload_success);
+        assert_eq!(snapshot.ipfs.last_upload_cid, None);
+        assert_eq!(snapshot.ipfs.last_error.as_deref(), Some("connection refused"));
+        // The previous successful CID is gone once a later attempt fails.
+        assert!(snapshot.ipfs.last_upload_epoch_s > 0);
+    }
+
+    #[test]
+    fn serialized_stats_never_contain_uploaded_text() {
+        let stats = MinerStats::new(false);
+        stats.set_ipfs_api_url("http://127.0.0.1:5001".to_string());
+        // Simulate what an upload records — never the text itself.
+        stats.set_ipfs_upload_outcome(true, Some("QmSecretCid".to_string()), None);
+
+        let json = serde_json::to_string(&stats.snapshot()).expect("snapshot serializes");
+        assert!(json.contains("QmSecretCid"));
+        assert!(!json.contains("super secret inference output"));
+        assert!(!json.contains("prompt"));
     }
 }
 


### PR DESCRIPTION
Part of #19.

## Why this is needed

When inference serving stops, operators currently cannot tell from the stats API whether IPFS is unreachable, Kubo failed to start, an upload failed, or the miner is still eligible to advertise inference rewards. Logs may contain the answer, but they are not a stable monitoring interface and should never contain uploaded inference text.

This PR adds the missing observability. It complements #38: #38 makes startup and recovery reliable; this PR makes the resulting IPFS state visible to automation and operators.

## What this PR does

- Adds an `ipfs` object to both `/stats` and `/v1/miner/stats` without removing or renaming existing fields.
- Reports the configured API URL, reachability, whether Kubo is miner-managed, Kubo version, last successful CID, and a short last error.
- Makes `inference_rewards_enabled` follow actual upload outcomes: a failed upload disables readiness and a later successful upload restores it.
- Instruments both gRPC and Stratum inference upload paths, including background task failures.
- Keeps miner-managed ownership stable while Kubo is starting so monitoring does not flicker between managed and external states.
- Parses real Kubo `/api/v0/version` and `/api/v0/add` response shapes and records failure transitions.

## Operator impact

Monitoring can answer "Can this miner publish inference results right now?" without scraping logs. A dashboard can show whether the failure is API reachability, daemon startup, or the latest upload, and can display the last CID without storing the inference content.

## Safety and compatibility

- The stats schema change is additive.
- Stats contain only a CIDv0 value and UTF-8-safe errors capped at 160 bytes.
- Prompts, generated responses, response bodies, escrow secrets, and private keys are never stored in stats.
- Successful version probes do not erase a newer upload error.

## Verification

- `cargo test -p keryx-miner --bin keryx-miner ipfs::tests` — 13 passed
- `cargo test -p keryx-miner --bin keryx-miner stats::tests` — 5 passed
- Protocol-faithful Kubo version and upload fixtures, including malformed and failed responses
- `git diff --check`

Tests ran in an NVIDIA CUDA 12.9.1 development container on a disposable Ubuntu build host. No live miner deployment or mutation was performed.

## Merge note

This PR and #38 both modify the IPFS integration. They are independently reviewable against current `main`; whichever is merged second should be rebased so both reliability and health behavior are preserved.