### PR TITLE
Add standalone escrow setup and validation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,24 @@ Escrow keys and claim state are written through a same-directory temporary file,
 
 On HiveOS, the durable files live outside the replaceable miner package at `/hive/miners/custom/keryx-miner-state/escrow.key` and `/hive/miners/custom/keryx-miner-state/escrow_state.json`, with directory mode `0700` and file mode `0600`. Back up both files together before an upgrade or manual recovery. Never delete an invalid key to generate another one: restore the original backup because it controls existing rewards. See [`integrations/hiveos/HIVEOS_README.md`](integrations/hiveos/HIVEOS_README.md) for verified migration and rollback steps.
 
+### Standalone escrow setup
+
+Create or inspect the escrow key without starting CUDA, models, keryxd, stats, or mining:
+
+```bash
+keryx-miner escrow init --key-file /path/escrow.key --json
+keryx-miner escrow validate \
+    --mining-address keryx:... \
+    --key-file /path/escrow.key \
+    --cert-file /path/escrow.cert \
+    --json
+```
+
+JSON is written only to stdout; diagnostics use stderr. The private key is never printed.
+Exit codes are stable for scripts: `0` success, `1` operational failure, `2` invalid
+credentials, and `3` missing, malformed, unsafe, or invalid command input. `init` is
+idempotent and never replaces a malformed existing key.
+
 ### All options
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,6 +125,13 @@ pub struct Opt {
     )]
     pub recover_escrow_api: String,
 
+    // ── Standalone administration subcommands ────────────────────────────────
+    // Non-mining administration surface (`keryx-miner escrow init|validate`). Runs
+    // before any node/model/CUDA/stats/mining initialization and exits by itself.
+
+    #[clap(subcommand)]
+    pub command: Option<Command>,
+
     // ── Mining ────────────────────────────────────────────────────────────────
 
     #[clap(short, long, help = "Enable debug logging level")]
@@ -183,6 +190,62 @@ pub struct Opt {
         help_heading = "Monitoring"
     )]
     pub plain_log_file: Option<String>,
+}
+
+/// Top-level standalone administration commands.
+#[derive(clap::Subcommand, Debug)]
+pub enum Command {
+    /// Manage the OPoI escrow key and delegation certificate
+    Escrow(EscrowCommand),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct EscrowCommand {
+    #[clap(subcommand)]
+    pub action: Escrow,
+}
+
+/// Non-mining escrow administration subcommands.
+///
+/// These run standalone — before node connection, model download, CUDA/plugin
+/// initialization, the stats server, or mining — and exit on their own. JSON output
+/// (with `--json`) is the only thing ever written to stdout; diagnostics go to stderr.
+#[derive(clap::Subcommand, Debug)]
+pub enum Escrow {
+    /// Create (or load, if present) the OPoI escrow private key file
+    Init(EscrowInit),
+    /// Verify the escrow key and its delegation cert against a mining address
+    Validate(EscrowValidate),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct EscrowInit {
+    /// Path to the OPoI escrow private key file (created if absent, never overwritten)
+    #[clap(long, value_name = "PATH")]
+    pub key_file: String,
+
+    /// Emit the machine-readable result as JSON on stdout (diagnostics stay on stderr)
+    #[clap(long)]
+    pub json: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct EscrowValidate {
+    /// The Keryx address the escrow delegation must be bound to
+    #[clap(long = "mining-address", value_name = "ADDRESS")]
+    pub mining_address: String,
+
+    /// Path to the OPoI escrow private key file
+    #[clap(long, value_name = "PATH")]
+    pub key_file: String,
+
+    /// Path to the escrow delegation cert file (128 hex chars)
+    #[clap(long, value_name = "PATH")]
+    pub cert_file: String,
+
+    /// Emit the machine-readable result as JSON on stdout (diagnostics stay on stderr)
+    #[clap(long)]
+    pub json: bool,
 }
 
 fn parse_devfund_percent(s: &str) -> Result<u16, &'static str> {
@@ -278,5 +341,38 @@ mod tests {
     fn model_tier_conflicts_reference_valid_arguments() {
         Opt::command().debug_assert();
         assert!(Opt::try_parse_from(["keryx-miner", "--very-light", "--very-high"]).is_err());
+    }
+
+    #[test]
+    fn escrow_subcommands_parse_and_require_their_arguments() {
+        let init = Opt::try_parse_from(["keryx-miner", "escrow", "init", "--key-file", "k.key", "--json"]).unwrap();
+        match init.command {
+            Some(Command::Escrow(EscrowCommand { action: Escrow::Init(args) })) => {
+                assert_eq!(args.key_file, "k.key");
+                assert!(args.json);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+
+        let validate =
+            Opt::try_parse_from(["keryx-miner", "escrow", "validate", "--mining-address", "keryx:x", "--key-file", "k.key", "--cert-file", "c.cert"]).unwrap();
+        match validate.command {
+            Some(Command::Escrow(EscrowCommand { action: Escrow::Validate(args) })) => {
+                assert_eq!(args.mining_address, "keryx:x");
+                assert_eq!(args.key_file, "k.key");
+                assert_eq!(args.cert_file, "c.cert");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+
+        // Both subcommands require their paths.
+        assert!(Opt::try_parse_from(["keryx-miner", "escrow", "init"]).is_err());
+        assert!(Opt::try_parse_from(["keryx-miner", "escrow", "validate"]).is_err());
+        assert!(Opt::try_parse_from(["keryx-miner", "escrow", "validate", "--mining-address", "keryx:x"]).is_err());
+        // Unknown subcommand is rejected.
+        assert!(Opt::try_parse_from(["keryx-miner", "escrow", "frobnicate"]).is_err());
+        // The mining CLI (no subcommand) is unchanged.
+        assert!(Opt::try_parse_from(["keryx-miner", "--mining-address", "keryx:x"]).is_ok());
+        assert!(Opt::try_parse_from(["keryx-miner"]).unwrap().command.is_none());
     }
 }

--- a/src/escrow.rs
+++ b/src/escrow.rs
@@ -1260,10 +1260,20 @@ pub fn load_key(path: &str) -> Result<String, String> {
 /// Load the OPoI escrow private key from `path`, generating a new one if absent.
 /// The file contains exactly 64 lowercase hex characters (32-byte Schnorr private key).
 pub fn load_or_generate_key(path: &str) -> Result<String, String> {
+    load_or_generate_key_created(path).map(|(key, _created)| key)
+}
+
+/// Create-or-load the escrow private key at `path`, reporting whether this invocation
+/// created the file (false when it was already present, including under the concurrent
+/// first-start race, where the winning file wins). Creation is atomic (temp file +
+/// no-clobber install + parent fsync): a partially-written key file is never visible,
+/// and an existing file — even a malformed one — is never replaced.
+fn load_or_generate_key_created(path: &str) -> Result<(String, bool), String> {
     use rand::RngCore;
     let p = std::path::Path::new(path);
     if p.exists() {
         return load_key(path)
+            .map(|k| (k, false))
             .map_err(|e| format!("{}. Restore the correct key; do not delete a key that may control rewards.", e));
     }
 
@@ -1294,21 +1304,25 @@ pub fn load_or_generate_key(path: &str) -> Result<String, String> {
     match install_temp_noclobber(temporary, p) {
         Ok(()) => sync_parent(parent)
             .map_err(|e| format!("Failed to sync escrow key directory '{}': {}", parent.display(), e))?,
-        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => return load_key(path),
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => return load_key(path).map(|k| (k, false)),
         Err(e) => return Err(format!("Failed to install escrow key file '{}': {}", path, e)),
     }
 
     info!("OPoI escrow keypair generated — saved to '{}'", path);
     info!("  Escrow pubkey : {}", pubkey_hex);
     info!("  Keep '{}' safe — needed to claim your OPoI escrow rewards.", path);
-    Ok(privkey_hex)
+    Ok((privkey_hex, true))
 }
 
 /// Derive the x-only public key hex (64 hex chars) from a hex-encoded private key.
+/// The error is prefixed with `INVALID_SECRET_KEY_SCALAR:` (never the key bytes) when
+/// the input parses as hex but is not a valid curve scalar; any other failure is a
+/// hex-decode error. Callers classify the scalar case as unsafe input.
 pub fn pubkey_hex_from_privkey(privkey_hex: &str) -> Result<String, String> {
     let privkey_bytes = hex::decode(privkey_hex).map_err(|e| format!("Invalid privkey hex: {}", e))?;
     let secp = secp256k1::Secp256k1::new();
-    let sk = secp256k1::SecretKey::from_slice(&privkey_bytes).map_err(|e| format!("Invalid private key: {}", e))?;
+    let sk = secp256k1::SecretKey::from_slice(&privkey_bytes)
+        .map_err(|_| "INVALID_SECRET_KEY_SCALAR: privkey is not a valid curve scalar".to_string())?;
     let kp = secp256k1::Keypair::from_secret_key(&secp, &sk);
     let (xonly, _) = kp.x_only_public_key();
     Ok(hex::encode(xonly.serialize()))
@@ -1630,6 +1644,190 @@ pub fn save_cert(path: &str, cert_hex: &str) -> std::io::Result<bool> {
     Ok(true)
 }
 
+// ── Escrow subcommands (issue #19) ────────────────────────────────────────────
+
+/// Stable process exit codes for the non-mining `escrow init` / `escrow validate`
+/// subcommands. Documented contract for scripting:
+///   EXIT_OK                   = 0 — command succeeded
+///   EXIT_OPERATIONAL          = 1 — operational failure of the command's own
+///                                   output: stdout/serialization (a broken pipe or
+///                                   closed stdout while printing `--json`, or JSON
+///                                   serialization). File-creation/read failures and
+///                                   unsafe paths are deliberately NOT operational:
+///                                   they are EXIT_UNSAFE_INPUT (3)
+///   EXIT_INVALID_CREDENTIALS  = 2 — key/cert/address present but invalid: wrong
+///                                   key, wrong mining address, malformed cert, or
+///                                   an address version that cannot carry a delegation
+///   EXIT_UNSAFE_INPUT         = 3 — input or key file missing, unreadable, or unsafe
+///                                   (malformed existing key, empty argument, a key
+///                                   file that cannot be created)
+pub const EXIT_OK: i32 = 0;
+pub const EXIT_OPERATIONAL: i32 = 1;
+pub const EXIT_INVALID_CREDENTIALS: i32 = 2;
+pub const EXIT_UNSAFE_INPUT: i32 = 3;
+
+/// Classification of an escrow subcommand failure, mapped to the exit-code contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExitCode {
+    Ok,
+    Operational,
+    InvalidCredentials,
+    UnsafeInput,
+}
+
+impl ExitCode {
+    pub fn as_i32(self) -> i32 {
+        match self {
+            ExitCode::Ok => EXIT_OK,
+            ExitCode::Operational => EXIT_OPERATIONAL,
+            ExitCode::InvalidCredentials => EXIT_INVALID_CREDENTIALS,
+            ExitCode::UnsafeInput => EXIT_UNSAFE_INPUT,
+        }
+    }
+}
+
+/// A failed `escrow init` / `escrow validate` invocation: human message plus the
+/// stable exit-code class. The message never contains private key bytes.
+#[derive(Debug)]
+pub struct EscrowCommandError {
+    pub kind: ExitCode,
+    pub message: String,
+}
+
+impl std::fmt::Display for EscrowCommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for EscrowCommandError {}
+
+fn unsafe_input(message: String) -> EscrowCommandError {
+    EscrowCommandError { kind: ExitCode::UnsafeInput, message }
+}
+
+fn invalid_credentials(message: String) -> EscrowCommandError {
+    EscrowCommandError { kind: ExitCode::InvalidCredentials, message }
+}
+
+fn operational(message: String) -> EscrowCommandError {
+    EscrowCommandError { kind: ExitCode::Operational, message }
+}
+
+/// Result of the `escrow init` subcommand.
+#[derive(Debug)]
+pub struct InitOutcome {
+    /// Whether this invocation created the key file (false = already present).
+    pub key_created: bool,
+    /// Path of the key file, exactly as passed.
+    pub key_file: String,
+    /// x-only public key hex (64 hex chars) derived from the key file.
+    pub public_key: String,
+}
+
+/// Result of the `escrow validate` subcommand.
+#[derive(Debug)]
+pub struct ValidateOutcome {
+    pub valid: bool,
+    pub public_key: String,
+    pub mining_address: String,
+    pub certificate_valid: bool,
+}
+
+/// Run `escrow init`: atomically create the key file when absent, otherwise load it.
+/// A malformed existing file is reported as an error and left untouched. On success
+/// returns the outcome plus the exact JSON line to print on stdout when `json` is set;
+/// callers own stdout/stderr and exit-code policy.
+pub fn run_init(key_file: &str, json: bool) -> Result<(InitOutcome, Option<String>), EscrowCommandError> {
+    if key_file.trim().is_empty() {
+        return Err(unsafe_input("--key-file must not be empty".to_string()));
+    }
+    let (privkey, key_created) = load_or_generate_key_created(key_file).map_err(unsafe_input)?;
+    // A key file that loads as 64 hex chars but is not a valid curve scalar is still
+    // an unsafe key file: report it as unsafe input rather than an invalid credential.
+    let public_key = pubkey_hex_from_privkey(&privkey).map_err(unsafe_input)?;
+    // The private key is only ever used in memory here; nothing below prints it.
+    let json_line = if json {
+        // One compact JSON line; every string field is escaped by serde_json rather than
+        // interpolated by hand (a key_file path may contain quotes, backslashes or
+        // control characters, and the public key must never be unescaped either).
+        let line = serde_json::to_string(&serde_json::json!({
+            "key_created": key_created,
+            "key_file": key_file,
+            "public_key": public_key,
+            "authorization_required": true,
+        }))
+        .map_err(|e| operational(format!("Failed to serialize init result: {e}")))?;
+        Some(line)
+    } else {
+        None
+    };
+    Ok((InitOutcome { key_created, key_file: key_file.to_string(), public_key }, json_line))
+}
+
+/// Run `escrow validate`: check the key file, the mining address, and the delegation
+/// cert exactly the way the node does. On success returns the outcome plus the JSON
+/// line to print on stdout (`--json`); callers own stdout/stderr and exit-code policy.
+pub fn run_validate(
+    mining_address: &str,
+    key_file: &str,
+    cert_file: &str,
+    json: bool,
+) -> Result<(ValidateOutcome, Option<String>), EscrowCommandError> {
+    if mining_address.trim().is_empty() {
+        return Err(unsafe_input("--mining-address must not be empty".to_string()));
+    }
+    if key_file.trim().is_empty() {
+        return Err(unsafe_input("--key-file must not be empty".to_string()));
+    }
+    if cert_file.trim().is_empty() {
+        return Err(unsafe_input("--cert-file must not be empty".to_string()));
+    }
+    // A structurally invalid address is unsafe input, not a credential mismatch.
+    if let Err(e) = decode_address(mining_address) {
+        return Err(unsafe_input(format!("Invalid mining address: {e}")));
+    }
+    let privkey = load_key(key_file).map_err(unsafe_input)?;
+    let public_key = pubkey_hex_from_privkey(&privkey).map_err(|e| {
+        // Hex-shaped but not a valid curve scalar is unsafe input, not a credential
+        // mismatch; the message never contains the key bytes.
+        if e.starts_with("INVALID_SECRET_KEY_SCALAR:") {
+            unsafe_input(e)
+        } else {
+            invalid_credentials(e)
+        }
+    })?;
+    // The private key is only ever used in memory; nothing below prints it.
+    // The cert is public (a signature over the pubkey↔address binding); validating it
+    // against this exact address+key is what the node does before accepting a block.
+    load_cert(cert_file, mining_address, &public_key).map_err(|e| {
+        // A cert file that cannot be read is unsafe input; anything else (wrong key,
+        // wrong address, malformed cert, non-delegatable address version) is an
+        // invalid credential.
+        if e.starts_with("Cannot read escrow delegation cert") {
+            unsafe_input(e)
+        } else {
+            invalid_credentials(e)
+        }
+    })?;
+    let json_line = if json {
+        // One compact JSON line; every string field (mining_address especially) is
+        // escaped by serde_json rather than interpolated by hand, so an accepted
+        // address can never inject invalid JSON.
+        let line = serde_json::to_string(&serde_json::json!({
+            "valid": true,
+            "public_key": public_key,
+            "mining_address": mining_address,
+            "certificate_valid": true,
+        }))
+        .map_err(|e| operational(format!("Failed to serialize validate result: {e}")))?;
+        Some(line)
+    } else {
+        None
+    };
+    Ok((ValidateOutcome { valid: true, public_key, mining_address: mining_address.to_string(), certificate_valid: true }, json_line))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1774,6 +1972,333 @@ mod tests {
             assert_eq!(csv_window_for_daa(gate - 1), CHALLENGE_WINDOW_BLOCKS);
         }
         assert_eq!(csv_window_for_daa(gate), SERVICE_BOND_CSV_WINDOW_BLOCKS);
+    }
+}
+
+#[cfg(test)]
+mod command_tests {
+    use super::*;
+    use serde_json::Value;
+
+    /// Payout address of the private key `0x11..11` — the same fixture the escrow
+    /// module tests sign with.
+    const PAYOUT_ADDRESS: &str = "keryx:qp8n2k7uklxq4aegau7vawtptkgxsja4kt99lpv6krctwpq8tpc65uyeddvzr";
+
+    /// Deterministic test keypair: private key 0x11..11.
+    fn fixture_privkey() -> &'static str {
+        "1111111111111111111111111111111111111111111111111111111111111111"
+    }
+
+    fn fixture_pubkey() -> String {
+        pubkey_hex_from_privkey(fixture_privkey()).unwrap()
+    }
+
+    /// Delegation cert for the escrow key in `fixture_privkey()` (0x11..11) signed by
+    /// PAYOUT_ADDRESS's key (also 0x11..11): a wallet-issued cert binding the escrow
+    /// key to the payout address.
+    fn fixture_cert() -> String {
+        let secp = secp256k1::Secp256k1::new();
+        let sk = secp256k1::SecretKey::from_slice(&[0x11u8; 32]).unwrap();
+        let kp = secp256k1::Keypair::from_secret_key(&secp, &sk);
+        let escrow_pubkey = fixture_pubkey();
+        let mut pk = [0u8; 32];
+        hex::decode_to_slice(&escrow_pubkey, &mut pk).unwrap();
+        let msg = secp256k1::Message::from_digest_slice(&escrow_delegation_message(&pk)).unwrap();
+        hex::encode(secp.sign_schnorr_no_aux_rand(&msg, &kp).as_ref())
+    }
+
+    fn tempdir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    // ── escrow init ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn init_creates_key_and_reports_creation() {
+        let dir = tempdir();
+        let path = dir.path().join("escrow.key");
+        let (outcome, json) = run_init(path.to_str().unwrap(), true).unwrap();
+        assert!(outcome.key_created);
+        assert_eq!(outcome.key_file, path.to_str().unwrap());
+        // The generated key is random: the file must hold exactly 64 lowercase hex
+        // chars, and the reported public key must derive from the on-disk key.
+        let on_disk = fs::read_to_string(&path).unwrap();
+        assert_eq!(on_disk.len(), 64);
+        assert!(on_disk.bytes().all(|b| b.is_ascii_hexdigit()));
+        assert_eq!(outcome.public_key, pubkey_hex_from_privkey(&on_disk).unwrap());
+        // The private key never appears anywhere on stdout.
+        let json = json.expect("json requested");
+        let value: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["key_created"], true);
+        assert_eq!(value["key_file"], path.to_str().unwrap());
+        assert_eq!(value["public_key"], outcome.public_key);
+        assert_eq!(value["authorization_required"], true);
+        assert!(!json.contains(&on_disk), "private key leaked into JSON output");
+    }
+
+    #[test]
+    fn init_is_idempotent_and_preserves_existing_key() {
+        let dir = tempdir();
+        let path = dir.path().join("escrow.key");
+        fs::write(&path, fixture_privkey()).unwrap();
+
+        let (outcome, _json) = run_init(path.to_str().unwrap(), false).unwrap();
+        assert!(!outcome.key_created);
+        assert_eq!(outcome.public_key, fixture_pubkey());
+        assert_eq!(fs::read_to_string(&path).unwrap(), fixture_privkey());
+    }
+
+    #[test]
+    fn init_rejects_malformed_existing_key_without_replacing_it() {
+        let dir = tempdir();
+        let path = dir.path().join("escrow.key");
+        let malformed = b"not-a-private-key";
+        fs::write(&path, malformed).unwrap();
+
+        let error = run_init(path.to_str().unwrap(), true).unwrap_err();
+        assert!(error.message.contains("64 hex chars"), "error: {}", error.message);
+        assert_eq!(error.kind, ExitCode::UnsafeInput);
+        assert_eq!(fs::read(&path).unwrap(), malformed, "malformed key must not be replaced");
+    }
+
+    #[test]
+    fn init_missing_parent_dir_creates_it() {
+        let dir = tempdir();
+        let path = dir.path().join("nested").join("escrow.key");
+        let (outcome, json) = run_init(path.to_str().unwrap(), false).unwrap();
+        assert!(outcome.key_created);
+        assert!(path.exists());
+        assert!(json.is_none());
+    }
+
+    #[test]
+    fn init_refuses_empty_key_file_path() {
+        assert!(run_init("", true).is_err());
+        assert!(run_init("   ", true).is_err());
+    }
+
+    // ── escrow validate ────────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_accepts_valid_cert() {
+        let dir = tempdir();
+        let key = dir.path().join("escrow.key");
+        fs::write(&key, fixture_privkey()).unwrap();
+        let cert = dir.path().join("escrow.cert");
+        fs::write(&cert, fixture_cert()).unwrap();
+
+        let (outcome, json) =
+            run_validate(PAYOUT_ADDRESS, key.to_str().unwrap(), cert.to_str().unwrap(), true).unwrap();
+        assert!(outcome.valid);
+        assert_eq!(outcome.public_key, fixture_pubkey());
+        assert_eq!(outcome.mining_address, PAYOUT_ADDRESS);
+        assert!(outcome.certificate_valid);
+
+        let json = json.expect("json requested");
+        let value: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["valid"], true);
+        assert_eq!(value["public_key"], outcome.public_key);
+        assert_eq!(value["mining_address"], PAYOUT_ADDRESS);
+        assert_eq!(value["certificate_valid"], true);
+        assert!(!json.contains(fixture_privkey()), "private key leaked in JSON output");
+    }
+
+    #[test]
+    fn validate_rejects_wrong_key() {
+        let dir = tempdir();
+        let key = dir.path().join("escrow.key");
+        // Different private key (0x22..22) than the escrow key the cert binds (0x11..11).
+        fs::write(&key, "22".repeat(32)).unwrap();
+        let cert = dir.path().join("escrow.cert");
+        fs::write(&cert, fixture_cert()).unwrap();
+
+        let error = run_validate(PAYOUT_ADDRESS, key.to_str().unwrap(), cert.to_str().unwrap(), true).unwrap_err();
+        assert!(error.message.contains("does not match"), "error: {}", error.message);
+        assert_eq!(error.kind, ExitCode::InvalidCredentials);
+    }
+
+    #[test]
+    fn validate_rejects_wrong_address() {
+        let dir = tempdir();
+        let key = dir.path().join("escrow.key");
+        fs::write(&key, fixture_privkey()).unwrap();
+        let cert = dir.path().join("escrow.cert");
+        fs::write(&cert, fixture_cert()).unwrap();
+
+        // The devfund address is a valid Keryx address, but not the cert's signer.
+        let error = run_validate(
+            "keryx:qrxpcusyrxjxghfdumcxm2rqw4dhe3n9hyqpvgn2wfyldltf99w2xhnajuhte",
+            key.to_str().unwrap(),
+            cert.to_str().unwrap(),
+            true,
+        )
+        .unwrap_err();
+        assert!(error.message.contains("does not match"), "error: {}", error.message);
+        assert_eq!(error.kind, ExitCode::InvalidCredentials);
+    }
+
+    #[test]
+    fn validate_rejects_malformed_cert() {
+        let dir = tempdir();
+        let key = dir.path().join("escrow.key");
+        fs::write(&key, fixture_privkey()).unwrap();
+        let cert = dir.path().join("escrow.cert");
+        fs::write(&cert, "deadbeef").unwrap();
+
+        let error = run_validate(PAYOUT_ADDRESS, key.to_str().unwrap(), cert.to_str().unwrap(), true).unwrap_err();
+        assert!(error.message.contains("128 hex chars"), "error: {}", error.message);
+        assert_eq!(error.kind, ExitCode::InvalidCredentials);
+    }
+
+    #[test]
+    fn validate_missing_files_fail() {
+        let dir = tempdir();
+        let missing_key = dir.path().join("missing.key");
+        let missing_cert = dir.path().join("missing.cert");
+        let key = dir.path().join("escrow.key");
+        fs::write(&key, fixture_privkey()).unwrap();
+        let cert = dir.path().join("escrow.cert");
+        fs::write(&cert, fixture_cert()).unwrap();
+
+        let error =
+            run_validate(PAYOUT_ADDRESS, missing_key.to_str().unwrap(), cert.to_str().unwrap(), true).unwrap_err();
+        assert!(error.message.contains("not found"), "error: {}", error.message);
+        assert_eq!(error.kind, ExitCode::UnsafeInput);
+        let error = run_validate(PAYOUT_ADDRESS, key.to_str().unwrap(), missing_cert.to_str().unwrap(), true).unwrap_err();
+        assert!(error.message.contains("Cannot read"), "error: {}", error.message);
+        assert_eq!(error.kind, ExitCode::UnsafeInput);
+    }
+
+    #[test]
+    fn validate_refuses_unsafe_address() {
+        let dir = tempdir();
+        let key = dir.path().join("escrow.key");
+        fs::write(&key, fixture_privkey()).unwrap();
+        let cert = dir.path().join("escrow.cert");
+        fs::write(&cert, fixture_cert()).unwrap();
+
+        // A version-1 address cannot carry a delegation: the bech32 data (53 5-bit
+        // groups: version 1 = 'q','y' prefix, then a zero key) decodes to bytes[0] = 1.
+        let error = run_validate(
+            &format!("keryx:qy{}qqqqqqqq", "q".repeat(51)),
+            key.to_str().unwrap(),
+            cert.to_str().unwrap(),
+            true,
+        )
+        .unwrap_err();
+        assert!(error.message.contains("cannot carry a delegation"), "error: {}", error.message);
+        assert_eq!(error.kind, ExitCode::InvalidCredentials);
+    }
+
+    #[test]
+    fn validate_refuses_empty_arguments() {
+        let dir = tempdir();
+        let key = dir.path().join("escrow.key");
+        fs::write(&key, fixture_privkey()).unwrap();
+        for (address, key_file, cert_file) in [
+            ("", key.to_str().unwrap(), "c"),
+            (PAYOUT_ADDRESS, "", "c"),
+            (PAYOUT_ADDRESS, key.to_str().unwrap(), ""),
+        ] {
+            let error = run_validate(address, key_file, cert_file, true).unwrap_err();
+            assert_eq!(error.kind, ExitCode::UnsafeInput);
+        }
+    }
+
+    /// An accepted address may carry JSON-special characters in its prefix: address
+    /// decoding only consumes the payload after the first ':', so the prefix is never
+    /// validated. The JSON line must escape them instead of interpolating them raw.
+    #[test]
+    fn validate_escapes_json_special_characters_in_address() {
+        let dir = tempdir();
+        let key = dir.path().join("escrow.key");
+        fs::write(&key, fixture_privkey()).unwrap();
+        let cert = dir.path().join("escrow.cert");
+        fs::write(&cert, fixture_cert()).unwrap();
+
+        let prefix = "ker\"yx\\line\"; inject";
+        let (outcome, json) =
+            run_validate(&format!("{prefix}:{}", PAYOUT_ADDRESS.split_once(':').unwrap().1), key.to_str().unwrap(), cert.to_str().unwrap(), true)
+                .unwrap();
+        assert!(outcome.valid);
+        let json = json.expect("json requested");
+        assert_eq!(json.lines().count(), 1, "JSON output must stay on one line");
+        let value: Value = serde_json::from_str(&json).expect("escaped JSON must parse");
+        assert_eq!(value["mining_address"], format!("{prefix}:{}", PAYOUT_ADDRESS.split_once(':').unwrap().1));
+        assert_eq!(value["public_key"], outcome.public_key);
+        assert_eq!(value["certificate_valid"], true);
+        assert_eq!(value["valid"], true);
+        assert!(!json.contains(fixture_privkey()), "private key leaked in JSON output");
+    }
+
+    /// The init JSON line must escape every string field the same way, with a path
+    /// containing JSON-special characters.
+    #[test]
+    fn init_escapes_json_special_characters_in_path() {
+        let dir = tempdir();
+        let path = dir.path().join("we\"ird\\name").join("esc\"ow.key");
+        let (outcome, json) = run_init(path.to_str().unwrap(), true).unwrap();
+        assert!(outcome.key_created);
+        let json = json.expect("json requested");
+        assert_eq!(json.lines().count(), 1, "JSON output must stay on one line");
+        let value: Value = serde_json::from_str(&json).expect("escaped JSON must parse");
+        assert_eq!(value["key_file"], path.to_str().unwrap());
+        assert_eq!(value["public_key"], outcome.public_key);
+        assert_eq!(value["key_created"], true);
+        assert_eq!(value["authorization_required"], true);
+        let on_disk = fs::read_to_string(&path).unwrap();
+        assert!(!json.contains(&on_disk), "private key leaked into JSON output");
+    }
+
+    /// A hex-shaped key that is not a valid curve scalar is unsafe input in both
+    /// validate and init, never an invalid credential; the error never contains the key.
+    #[test]
+    fn hex_shaped_invalid_scalar_is_unsafe_input_in_validate_and_init() {
+        let dir = tempdir();
+        let invalid_scalar = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        let key = dir.path().join("escrow.key");
+        fs::write(&key, invalid_scalar).unwrap();
+        let cert = dir.path().join("escrow.cert");
+        fs::write(&cert, fixture_cert()).unwrap();
+
+        let error = run_validate(PAYOUT_ADDRESS, key.to_str().unwrap(), cert.to_str().unwrap(), true).unwrap_err();
+        assert_eq!(error.kind, ExitCode::UnsafeInput);
+        assert!(!error.message.contains(invalid_scalar), "key content leaked in error: {}", error.message);
+
+        let error = run_init(key.to_str().unwrap(), true).unwrap_err();
+        assert_eq!(error.kind, ExitCode::UnsafeInput);
+        assert!(!error.message.contains(invalid_scalar), "key content leaked in error: {}", error.message);
+        // The unsafe file must not be replaced.
+        assert_eq!(fs::read_to_string(&key).unwrap(), invalid_scalar);
+    }
+
+    /// The pubkey helper itself must expose the scalar-vs-decode distinction so callers
+    /// can classify, and never echo the key bytes.
+    #[test]
+    fn pubkey_derivation_distinguishes_invalid_scalar_without_leaking_bytes() {
+        let invalid_scalar = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+        let error = pubkey_hex_from_privkey(invalid_scalar).unwrap_err();
+        assert!(error.contains("INVALID_SECRET_KEY_SCALAR"), "error: {}", error);
+        assert!(!error.contains(invalid_scalar), "key content leaked in error: {}", error);
+        // Malformed hex stays a decode failure (no scalar marker).
+        assert!(pubkey_hex_from_privkey("zz").is_err());
+        assert!(!pubkey_hex_from_privkey("zz").unwrap_err().contains("INVALID_SECRET_KEY_SCALAR"));
+        // A valid scalar still derives.
+        assert!(pubkey_hex_from_privkey(fixture_privkey()).is_ok());
+    }
+
+    // ── exit-code contract ─────────────────────────────────────────────────────
+
+    #[test]
+    fn exit_codes_are_stable_and_distinct() {
+        assert_eq!(EXIT_OK, 0);
+        assert_eq!(EXIT_OPERATIONAL, 1);
+        assert_eq!(EXIT_INVALID_CREDENTIALS, 2);
+        assert_eq!(EXIT_UNSAFE_INPUT, 3);
+        assert_eq!(ExitCode::Ok.as_i32(), 0);
+        assert_eq!(ExitCode::Operational.as_i32(), 1);
+        assert_eq!(ExitCode::InvalidCredentials.as_i32(), 2);
+        assert_eq!(ExitCode::UnsafeInput.as_i32(), 3);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::io::IsTerminal;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 
-use clap::{App, FromArgMatches, IntoApp};
+use clap::{App, CommandFactory, FromArgMatches};
 use keryx_miner::PluginManager;
 use log::{error, info, warn};
 use rand::{thread_rng, RngCore};
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::cli::Opt;
+use crate::cli::{Command, Escrow, Opt};
 use crate::client::grpc::KeryxdHandler;
 use crate::client::stratum::StratumHandler;
 use crate::client::Client;
@@ -228,6 +228,119 @@ fn adjust_console() -> Result<(), Error> {
         | win32console::console::ConsoleMode::ENABLE_EXTENDED_FLAGS;
     console.set_mode(mode)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod escrow_cli_tests {
+    use super::*;
+
+    /// Help and version requests render to stdout and exit 0 — never 3 (unsafe input)
+    /// nor 2 (invalid credentials).
+    #[test]
+    fn help_and_version_exit_ok() {
+        for argv in [
+            vec!["keryx-miner", "escrow", "--help"],
+            vec!["keryx-miner", "escrow", "--version"],
+            vec!["keryx-miner", "escrow", "init", "--help"],
+            vec!["keryx-miner", "escrow", "init", "--version"],
+            vec!["keryx-miner", "escrow", "validate", "--help"],
+            vec!["keryx-miner", "escrow", "validate", "--version"],
+        ] {
+            let command = Opt::command().propagate_version(true);
+            let matches = command.try_get_matches_from(argv.iter().copied());
+            let error = matches.expect_err("help/version must be a clap error, not a parse");
+            assert_eq!(escrow_cli_exit_code(&error), escrow::EXIT_OK, "argv: {argv:?}");
+        }
+    }
+
+    /// Malformed, missing, and unknown CLI usage maps to unsafe input (3), so it can
+    /// never collide with invalid credentials (2). Diagnostics stay on stderr.
+    #[test]
+    fn malformed_usage_exits_unsafe_input_on_stderr() {
+        for argv in [
+            vec!["keryx-miner", "escrow", "frobnicate"],                                     // unknown subcommand
+            vec!["keryx-miner", "escrow", "--bogus"],                                        // unknown option
+            vec!["keryx-miner", "escrow", "init", "--key-file"],                             // missing value
+            vec!["keryx-miner", "escrow", "init"],                                           // missing required arg
+            vec!["keryx-miner", "escrow", "validate"],                                       // missing required args
+            vec!["keryx-miner", "escrow", "validate", "--mining-address", "keryx:x"],        // incomplete
+            vec!["keryx-miner", "escrow", "init", "--key-file", "k.key", "junk"],            // unexpected positional
+        ] {
+            let command = Opt::command().propagate_version(true);
+            let matches = command.try_get_matches_from(argv.iter().copied());
+            let error = matches.expect_err("bad usage must be a clap error");
+            assert!(error.use_stderr(), "usage diagnostics must go to stderr: {argv:?}");
+            assert_eq!(escrow_cli_exit_code(&error), escrow::EXIT_UNSAFE_INPUT, "argv: {argv:?}");
+        }
+    }
+
+    /// Valid escrow invocations still parse — the command surface is unchanged.
+    #[test]
+    fn valid_escrow_usage_still_parses() {
+        let command = Opt::command().propagate_version(true);
+        let matches = command
+            .try_get_matches_from([
+                "keryx-miner",
+                "escrow",
+                "validate",
+                "--mining-address",
+                "keryx:x",
+                "--key-file",
+                "k.key",
+                "--cert-file",
+                "c.cert",
+            ])
+            .unwrap();
+        let opt = Opt::from_arg_matches(&matches).unwrap();
+        match opt.command {
+            Some(Command::Escrow(command)) => match command.action {
+                Escrow::Validate(args) => {
+                    assert_eq!(args.mining_address, "keryx:x");
+                    assert_eq!(args.key_file, "k.key");
+                    assert_eq!(args.cert_file, "c.cert");
+                }
+                other => panic!("unexpected action: {other:?}"),
+            },
+            None => panic!("escrow subcommand missing"),
+        }
+    }
+
+    /// A writer that fails on the very first write, standing in for a broken pipe or a
+    /// closed stdout. The failure carries no payload, so the diagnostic cannot leak it.
+    #[derive(Debug)]
+    struct FailingWriter {
+        err: std::io::Error,
+    }
+
+    impl std::io::Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(self.err.kind(), self.err.to_string()))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A broken pipe / closed stdout on a JSON write must surface as an operational
+    /// failure with a diagnostic that never contains the JSON payload — the same
+    /// contract the `--json` subcommands enforce through their stable exit codes
+    /// (Operational = 1, never a panicking 101).
+    #[test]
+    fn json_write_failure_is_operational_and_does_not_leak_payload() {
+        let payload = r#"{"key_created":true,"key_file":"/tmp/some/key","public_key":"deadbeef"}"#;
+        let mut failing = FailingWriter { err: std::io::Error::new(std::io::ErrorKind::BrokenPipe, "broken pipe") };
+        let error = write_json_line(&mut failing, payload).unwrap_err();
+        assert!(
+            error.contains("Failed to write JSON to stdout"),
+            "diagnostic must name the failed channel: {error}"
+        );
+        assert!(
+            !error.contains(payload) && !error.contains("deadbeef"),
+            "diagnostic must not contain the JSON payload: {error}"
+        );
+        assert_eq!(escrow::ExitCode::Operational.as_i32(), escrow::EXIT_OPERATIONAL);
+    }
 }
 
 #[cfg(test)]
@@ -753,7 +866,128 @@ fn tokio_blocking_threads() -> Option<usize> {
     std::env::var("KERYX_BLOCKING_THREADS").ok().and_then(|s| s.parse::<usize>().ok()).map(|n| n.clamp(2, 64))
 }
 
+/// Exit code for a Clap error on the standalone `escrow` CLI surface. Help/version
+/// requests are rendered by Clap to stdout and exit 0; every other failure (unknown
+/// option, missing or malformed argument, missing or unknown subcommand) is a usage
+/// error that prints to stderr and exits EXIT_UNSAFE_INPUT (3) — never Clap's own
+/// exit code 2, which belongs to EXIT_INVALID_CREDENTIALS.
+fn escrow_cli_exit_code(error: &clap::Error) -> i32 {
+    if error.use_stderr() {
+        escrow::EXIT_UNSAFE_INPUT
+    } else {
+        escrow::EXIT_OK
+    }
+}
+
+/// Write `line` plus a newline to `out` — the exact stdout contract of the escrow
+/// `--json` subcommands. Fallible on purpose: a broken pipe or closed stdout
+/// surfaces as an operational failure instead of a panicking `println!` (which
+/// would exit 101 and break the documented 0/1/2/3 exit-code contract). The error
+/// text never contains the JSON payload or any key material.
+fn write_json_line(out: &mut dyn std::io::Write, line: &str) -> Result<(), String> {
+    out.write_all(line.as_bytes())
+        .and_then(|()| out.write_all(b"\n"))
+        .and_then(|()| out.flush())
+        .map_err(|e| format!("Failed to write JSON to stdout: {e}"))
+}
+
+/// Run an `escrow` subcommand to completion and exit with its documented exit code.
+/// Called from `main` before any node connection, model download, CUDA/plugin
+/// initialization, stats server, or mining setup. JSON (when `--json` was passed) is
+/// printed to stdout; everything else goes to stderr; private key bytes are never
+/// printed. Never returns.
+fn run_escrow_subcommand(subcommand: &Escrow) -> ! {
+    let exit_code = match subcommand {
+        Escrow::Init(args) => match escrow::run_init(&args.key_file, args.json) {
+            Ok((outcome, json_line)) => {
+                if let Some(line) = json_line {
+                    // A broken pipe / closed stdout is an operational failure, not a
+                    // panic (101). The diagnostic never contains the JSON or key bytes.
+                    if let Err(e) = write_json_line(&mut std::io::stdout().lock(), &line) {
+                        eprintln!("escrow init failed: {e}");
+                        escrow::ExitCode::Operational.as_i32()
+                    } else {
+                        escrow::ExitCode::Ok.as_i32()
+                    }
+                } else {
+                    // Diagnostics-only (no --json): summarize on stderr. The public key
+                    // is safe to print; private key bytes never are.
+                    eprintln!(
+                        "{} OPoI escrow key '{}' — public key {}",
+                        if outcome.key_created { "Created" } else { "Loaded" },
+                        outcome.key_file,
+                        outcome.public_key
+                    );
+                    eprintln!("Authorize this public key in your wallet to receive OPoI escrow rewards.");
+                    escrow::ExitCode::Ok.as_i32()
+                }
+            }
+            Err(e) => {
+                eprintln!("escrow init failed: {e}");
+                e.kind.as_i32()
+            }
+        },
+        Escrow::Validate(args) => {
+            match escrow::run_validate(&args.mining_address, &args.key_file, &args.cert_file, args.json) {
+                Ok((outcome, json_line)) => {
+                    if let Some(line) = json_line {
+                        // A broken pipe / closed stdout is an operational failure, not a
+                        // panic (101). The diagnostic never contains the JSON or key bytes.
+                        if let Err(e) = write_json_line(&mut std::io::stdout().lock(), &line) {
+                            eprintln!("escrow validate failed: {e}");
+                            escrow::ExitCode::Operational.as_i32()
+                        } else {
+                            escrow::ExitCode::Ok.as_i32()
+                        }
+                    } else {
+                        eprintln!(
+                            "valid: public key {} — mining address {} — certificate valid: {}",
+                            outcome.public_key, outcome.mining_address, outcome.certificate_valid
+                        );
+                        escrow::ExitCode::Ok.as_i32()
+                    }
+                }
+                Err(e) => {
+                    eprintln!("escrow validate failed: {e}");
+                    e.kind.as_i32()
+                }
+            }
+        }
+    };
+    std::process::exit(exit_code);
+}
+
 fn main() -> Result<(), Error> {
+    // Non-mining escrow administration runs standalone — before node connection, model
+    // download, CUDA/plugin initialization, the stats server, or mining. The `escrow`
+    // subcommand is detected by its leading token (the mining CLI has no positional
+    // arguments, so a mining invocation can never start with it); it is parsed without
+    // plugin augmentation and exits with a documented exit code. `run_escrow_subcommand`
+    // prints JSON to stdout (only with --json); diagnostics go to stderr.
+    if std::env::args_os().nth(1).as_deref() == Some(std::ffi::OsStr::new("escrow")) {
+        // Fallible parse so help/version still exit 0 (Clap renders them to stdout) but
+        // any malformed/missing/unknown CLI usage exits EXIT_UNSAFE_INPUT (3) instead of
+        // colliding with EXIT_INVALID_CREDENTIALS (2). Diagnostics stay on stderr.
+        let command = Opt::command().propagate_version(true);
+        let matches = match command.try_get_matches() {
+            Ok(matches) => matches,
+            Err(e) => {
+                let _ = e.print();
+                std::process::exit(escrow_cli_exit_code(&e));
+            }
+        };
+        let opt: Opt = match Opt::from_arg_matches(&matches) {
+            Ok(opt) => opt,
+            Err(e) => {
+                let _ = e.print();
+                std::process::exit(escrow_cli_exit_code(&e));
+            }
+        };
+        if let Some(Command::Escrow(command)) = &opt.command {
+            run_escrow_subcommand(&command.action);
+        }
+    }
+
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.worker_threads(tokio_worker_threads()).enable_all();
     if let Some(n) = tokio_blocking_threads() {


### PR DESCRIPTION
Part of #19.

## Why this is needed

Escrow identity controls inference rewards. A wrong key, certificate, or payout address should be discovered before the miner downloads models, initializes CUDA, connects to keryxd, or begins mining. Manual setup is error-prone, and replacing a malformed existing key can permanently disconnect an operator from rewards already tied to that identity.

The miner therefore needs a small, safe administration surface that can create or inspect escrow state without starting the mining runtime.

## What this PR does

- Adds `keryx-miner escrow init` to create or inspect the escrow private key.
- Makes key creation atomic and idempotent: an existing valid key is reused, while an unreadable or malformed key is rejected and never replaced.
- Adds `keryx-miner escrow validate` to check the certificate signature, public-key binding, payout address, and protocol identity used by the node.
- Dispatches these commands before model download, CUDA/plugin initialization, stats startup, keryxd connection, and mining.
- Produces strict one-line JSON with `--json`; normal diagnostics remain on stderr.
- Defines stable process exit codes: `0` success, `1` operational failure, `2` invalid credentials, and `3` missing, malformed, or unsafe input.
- Handles closed stdout and broken pipes as exit code `1` rather than panicking with an undocumented code.

## Operator impact

An operator or installation script can prepare and validate escrow independently, fail early on a wrong certificate or address, and safely rerun initialization. This is suitable for HiveOS package setup and automated deployment checks.

## Safety and compatibility

- Private-key bytes are never printed in JSON, diagnostics, or errors.
- New key files use mode `0600`; parent state directories use mode `0700` where created by the command.
- Existing malformed key files are preserved for recovery instead of being overwritten.
- The existing mining CLI remains unchanged. Standalone usage is `keryx-miner escrow ...`, as shown in the README.

## Verification

- `cargo test -p keryx-miner --bin keryx-miner cli::tests` — 2 passed
- `cargo test -p keryx-miner --bin keryx-miner escrow::command_tests` — 17 passed
- `cargo test -p keryx-miner --bin keryx-miner escrow_cli_tests` — 4 passed
- `cargo build -p keryx-miner --bin keryx-miner`
- Disposable CLI smoke: JSON initialization, key mode `0600`, and invalid validation usage returning exit `3` with stderr-only output
- `git diff --check`

Tests ran in an NVIDIA CUDA 12.9.1 development container on a disposable Ubuntu build host. No live miner deployment or mutation was performed.