### PR TITLE
Add PoM Stratum transport and complete devfund removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,16 +174,6 @@ The embedded sound is a trimmed adaptation of "Coin Drop" by Universfield under 
 
 ---
 
-## Dev Fund
-
-2% of mining rewards support development by default.
-
-```bash
---devfund-percent XX.YY
-```
-
----
-
 ## Connect
 
 * **Website:** [keryx-labs.com](https://keryx-labs.com)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,8 +136,11 @@ pub struct Opt {
     #[clap(short = 's', long = "keryxd-address", default_value = "127.0.0.1", help = "The IP of the keryxd instance")]
     pub keryxd_address: String,
 
-    #[clap(long = "devfund-percent", help = "The percentage of blocks to send to the devfund (minimum 2%)", default_value = "2", parse(try_from_str = parse_devfund_percent))]
-    pub devfund_percent: u16,
+    #[clap(long, default_value = "30", help = "Idle interval before a Stratum keepalive")]
+    pub stratum_keepalive_seconds: u64,
+
+    #[clap(long, default_value = "120", help = "Stratum keepalive response timeout in seconds")]
+    pub stratum_keepalive_timeout_seconds: u64,
 
     #[clap(short, long, help = "Keryxd port [default: Mainnet = 22110, Testnet = 22210]")]
     port: Option<u16>,
@@ -166,9 +169,6 @@ pub struct Opt {
     )]
     pub block_celebration: bool,
 
-    #[clap(skip)]
-    pub devfund_address: String,
-
     #[clap(
         long = "stats-bind",
         help = "Stats API bind address (e.g. 0.0.0.0, 127.0.0.1)",
@@ -191,34 +191,6 @@ pub struct Opt {
         help_heading = "Monitoring"
     )]
     pub plain_log_file: Option<String>,
-}
-
-fn parse_devfund_percent(s: &str) -> Result<u16, &'static str> {
-    let err = "devfund-percent should be --devfund-percent=XX.YY up to 2 numbers after the dot";
-    let mut splited = s.split('.');
-    let prefix = splited.next().ok_or(err)?;
-    // if there's no postfix then it's 0.
-    let postfix = splited.next().ok_or(err).unwrap_or("0");
-    // error if there's more than a single dot
-    if splited.next().is_some() {
-        return Err(err);
-    };
-    // error if there are more than 2 numbers before or after the dot
-    if prefix.len() > 2 || postfix.len() > 2 {
-        return Err(err);
-    }
-    let postfix: u16 = postfix.parse().map_err(|_| err)?;
-    let prefix: u16 = prefix.parse().map_err(|_| err)?;
-    // can't be more than 99.99%,
-    if prefix >= 100 || postfix >= 100 {
-        return Err(err);
-    }
-    if prefix < 2 {
-        // Force at least 2 percent
-        return Ok(200u16);
-    }
-    // DevFund is out of 10_000
-    Ok(prefix * 100 + postfix)
 }
 
 impl Opt {
@@ -250,17 +222,6 @@ impl Opt {
             self.num_threads = Some(0);
         }
 
-        let miner_network = self.mining_address.as_deref().and_then(|a| a.split(':').next());
-        self.devfund_address = String::from("keryx:qrxpcusyrxjxghfdumcxm2rqw4dhe3n9hyqpvgn2wfyldltf99w2xhnajuhte");
-        let devfund_network = self.devfund_address.split(':').next();
-        if miner_network.is_some() && devfund_network.is_some() && miner_network != devfund_network {
-            self.devfund_percent = 0;
-            log::info!(
-                "Mining address ({}) and devfund ({}) are not from the same network. Disabling devfund.",
-                miner_network.unwrap(),
-                devfund_network.unwrap()
-            )
-        }
         Ok(())
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,6 @@ use crate::{Error, MinerManager};
 
 #[async_trait(?Send)]
 pub trait Client {
-    fn add_devfund(&mut self, address: String, percent: u16);
     async fn register(&mut self) -> Result<(), Error>;
     async fn listen(&mut self, miner: &mut MinerManager) -> Result<(), Error>;
     fn get_block_channel(&self) -> Sender<BlockSeed>;

--- a/src/client/grpc.rs
+++ b/src/client/grpc.rs
@@ -53,7 +53,7 @@ use futures_util::StreamExt;
 use log::{error, info, warn};
 use rand::{thread_rng, RngCore};
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc::{self, error::SendError, Sender}, oneshot};
 use tokio::task::JoinHandle;
@@ -71,9 +71,6 @@ pub struct KeryxdHandler {
     stream: Streaming<KaspadMessage>,
     miner_address: String,
     mine_when_not_synced: bool,
-    devfund_address: Option<String>,
-    devfund_percent: u16,
-    block_template_ctr: Arc<AtomicU16>,
 
     block_channel: Sender<BlockSeed>,
     block_handle: BlockHandle,
@@ -163,11 +160,6 @@ pub struct KeryxdHandler {
 
 #[async_trait(?Send)]
 impl Client for KeryxdHandler {
-    fn add_devfund(&mut self, address: String, percent: u16) {
-        self.devfund_address = Some(address);
-        self.devfund_percent = percent;
-    }
-
     async fn register(&mut self) -> Result<(), Error> {
         // We actually register in connect
         Ok(())
@@ -229,7 +221,6 @@ impl KeryxdHandler {
         address: D,
         miner_address: String,
         mine_when_not_synced: bool,
-        block_template_ctr: Option<Arc<AtomicU16>>,
         escrow_privkey: Option<String>,
         escrow_state_file: String,
         escrow_cert: Option<String>,
@@ -284,10 +275,6 @@ impl KeryxdHandler {
             send_channel,
             miner_address,
             mine_when_not_synced,
-            devfund_address: None,
-            devfund_percent: 0,
-            block_template_ctr: block_template_ctr
-                .unwrap_or_else(|| Arc::new(AtomicU16::new((thread_rng().next_u64() % 10_000u64) as u16))),
             block_channel,
             block_handle,
             ai_request_queue: VecDeque::new(),
@@ -303,8 +290,6 @@ impl KeryxdHandler {
             challenge_inference_rx: None,
             opoi_challenge_active: None,
             pending_block_submissions,
-            // Seeded from the node so era-gated decisions (devfund payout) are right on the very
-            // first template request, not only once one has been received.
             last_known_daa: chain_daa.unwrap_or(0),
             ipfs_url,
             escrow_pubkey,
@@ -349,18 +334,7 @@ impl KeryxdHandler {
     }
 
     async fn client_get_block_template(&mut self) -> Result<(), SendError<KaspadMessage>> {
-        // From H6 the delegation cert is verified against the block's own pay address, and this
-        // miner can only hold one for its own. A devfund block would be refused at the template.
-        let devfund_payable = self.last_known_daa < keryx_miner::pom::pom_v3_activation_daa();
-        let pay_address = match &self.devfund_address {
-            Some(devfund_address)
-                if devfund_payable && self.block_template_ctr.load(Ordering::SeqCst) <= self.devfund_percent =>
-            {
-                devfund_address.clone()
-            }
-            _ => self.miner_address.clone(),
-        };
-        self.block_template_ctr.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| Some((v + 1) % 10_000)).unwrap();
+        let pay_address = self.miner_address.clone();
         // Append a per-request random nonce so that parallel blocks at the same blue_score
         // get distinct coinbase payloads → distinct tx_ids (avoids DAG coinbase collisions).
         let nonce_hex = format!("{:016x}", thread_rng().next_u64());

--- a/src/client/stratum.rs
+++ b/src/client/stratum.rs
@@ -2,13 +2,16 @@ use futures::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::net::TcpStream;
 use tokio_util::codec::Framed;
 
+mod protocol;
 mod statum_codec;
+
+use protocol::{difficulty_to_target, effective_target, nonce_range, MiningJob};
 
 use crate::client::stratum::statum_codec::{ErrorCode, MiningNotify, MiningSubmit, NewLineJsonCodecError, StratumLine};
 use crate::client::stratum::statum_codec::{
@@ -21,8 +24,6 @@ use crate::{miner::MinerManager, Error, Uint256};
 use async_trait::async_trait;
 use futures_util::TryStreamExt;
 use log::{error, info, warn};
-use num::Float;
-use rand::{thread_rng, RngCore};
 use statum_codec::NewLineJsonCodec;
 use std::sync::OnceLock;
 use tokio::sync::mpsc::{self, Sender};
@@ -32,9 +33,7 @@ use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 use tokio_stream::wrappers::ReceiverStream;
 
-//const DIFFICULTY_1_TARGET: Uint256 = Uint256([0x00000000ffff0000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000]);
-const DIFFICULTY_1_TARGET: (u64, i16) = (0xffffu64, 208); // 0xffff 2^208
-const KERYX_STRATUM_DAA_CAPABILITY: &str = "keryx-stratum-v2";
+const KERYX_STRATUM_DAA_CAPABILITY: &str = "keryx-stratum-v3";
 const LOG_RATE: Duration = Duration::from_secs(30);
 const CHALLENGE_MAX_TOKENS: usize = 128;
 
@@ -78,6 +77,7 @@ struct InferenceCacheInner {
 type InferenceCache = Arc<Mutex<InferenceCacheInner>>;
 
 type BlockHandle = JoinHandle<()>;
+type PendingShares = Arc<Mutex<HashMap<u32, String>>>;
 
 #[derive(Default)]
 pub struct ShareStats {
@@ -85,7 +85,6 @@ pub struct ShareStats {
     pub stale: AtomicU64,
     pub low_diff: AtomicU64,
     pub duplicate: AtomicU64,
-    pub shares_pending: Mutex<HashMap<u32, String>>,
 }
 
 static SHARE_STATS: OnceLock<Arc<ShareStats>> = OnceLock::new();
@@ -94,7 +93,7 @@ impl Display for ShareStats {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Shares: {}{}{}{}Pending: {}",
+            "Shares: {}{}{}{}",
             match self.accepted.load(Ordering::SeqCst) {
                 0 => "".to_string(),
                 v => format!("Accepted: {} ", v),
@@ -111,7 +110,6 @@ impl Display for ShareStats {
                 0 => "".to_string(),
                 v => format!("Duplicate: {} ", v),
             },
-            self.shares_pending.try_lock().unwrap().len()
         )
     }
 }
@@ -119,22 +117,26 @@ impl Display for ShareStats {
 #[allow(dead_code)]
 pub struct StratumHandler {
     log_handler: JoinHandle<()>,
+    write_handle: JoinHandle<Result<(), NewLineJsonCodecError>>,
 
     //client: Framed<TcpStream, NewLineJsonCodec>,
     send_channel: Sender<StratumLine>,
     stream: Pin<Box<dyn Stream<Item = Result<StratumLine, NewLineJsonCodecError>>>>,
     miner_address: String,
     mine_when_not_synced: bool,
-    block_template_ctr: Arc<AtomicU16>,
 
     target_pool: Uint256,
-    target_real: Uint256,
     nonce_mask: u64,
     nonce_fixed: u64,
     extranonce: Option<String>,
     last_stratum_id: Arc<AtomicU32>,
 
     shares_stats: Arc<ShareStats>,
+    shares_pending: PendingShares,
+    keepalive_interval: Duration,
+    keepalive_timeout: Duration,
+    keepalive_pending: Option<(u32, Instant)>,
+    last_activity: Instant,
     block_channel: Sender<BlockSeed>,
     block_handle: BlockHandle,
 
@@ -150,9 +152,6 @@ pub struct StratumHandler {
 
 #[async_trait(?Send)]
 impl Client for StratumHandler {
-    // Devfund is retired from pool mining; solo keeps its own era-gated handling.
-    fn add_devfund(&mut self, _address: String, _percent: u16) {}
-
     async fn register(&mut self) -> Result<(), Error> {
         let mut id = { Some(self.last_stratum_id.fetch_add(1, Ordering::SeqCst)) };
         self.send_channel
@@ -184,18 +183,14 @@ impl Client for StratumHandler {
             .await?;
 
         // Declare loaded SLM models so the bridge can challenge with the right model.
-        let model_ids: Vec<String> = keryx_miner::slm::loaded_model_ids()
-            .into_iter()
-            .map(|id| hex::encode(id))
-            .collect();
+        let model_ids: Vec<String> =
+            keryx_miner::slm::loaded_model_ids().into_iter().map(|id| hex::encode(id)).collect();
         if !model_ids.is_empty() {
             info!("OPoI: declaring {} model(s) to pool bridge", model_ids.len());
             self.send_channel
                 .send(StratumLine {
                     id: None,
-                    payload: StratumLinePayload::StratumCommand(
-                        StratumCommand::MiningDeclareCapabilities(model_ids),
-                    ),
+                    payload: StratumLinePayload::StratumCommand(StratumCommand::MiningDeclareCapabilities(model_ids)),
                     jsonrpc: None,
                     error: None,
                 })
@@ -205,11 +200,23 @@ impl Client for StratumHandler {
     }
 
     async fn listen(&mut self, miner: &mut MinerManager) -> Result<(), Error> {
-        info!("Waiting for stuff");
+        info!("Waiting for Stratum traffic");
+        let mut maintenance = tokio::time::interval(Duration::from_secs(1));
+        maintenance.set_missed_tick_behavior(MissedTickBehavior::Delay);
         loop {
-            match self.stream.try_next().await? {
-                Some(msg) => self.handle_message(msg, miner).await?,
-                None => return Err("stratum message payload is empty".into()),
+            tokio::select! {
+                result = &mut self.write_handle => {
+                    result??;
+                    return Err("Stratum writer closed".into());
+                },
+                message = self.stream.try_next() => match message? {
+                    Some(msg) => {
+                        self.last_activity = Instant::now();
+                        self.handle_message(msg, miner).await?;
+                    }
+                    None => return Err("Stratum connection closed".into()),
+                },
+                _ = maintenance.tick() => self.maintain_keepalive().await?,
             }
         }
     }
@@ -224,47 +231,50 @@ impl StratumHandler {
         address: String,
         miner_address: String,
         mine_when_not_synced: bool,
-        block_template_ctr: Option<Arc<AtomicU16>>,
         ipfs_url: String,
+        keepalive_seconds: u64,
+        keepalive_timeout_seconds: u64,
     ) -> Result<Box<Self>, Error> {
         info!("Connecting to {}", address);
-        let socket = TcpStream::connect(address).await?;
+        let socket = tokio::time::timeout(Duration::from_secs(5), TcpStream::connect(address)).await??;
 
         let client = Framed::new(socket, NewLineJsonCodec::new());
         let (send_channel, recv) = mpsc::channel::<StratumLine>(3);
         let (sink, stream) = client.split();
-        tokio::spawn(async move { ReceiverStream::new(recv).map(Ok).forward(sink).await });
+        let write_handle = tokio::spawn(async move { ReceiverStream::new(recv).map(Ok).forward(sink).await });
 
         let share_state = SHARE_STATS.get_or_init(|| Arc::new(ShareStats::default())).clone();
+        let shares_pending = Arc::new(Mutex::new(HashMap::new()));
         let last_stratum_id = Arc::new(AtomicU32::new(0));
         let current_task_slot: Arc<Mutex<Option<CurrentTask>>> = Arc::new(Mutex::new(None));
-        let inference_cache: InferenceCache = Arc::new(Mutex::new(InferenceCacheInner {
-            results: HashMap::new(),
-            in_progress: HashSet::new(),
-        }));
+        let inference_cache: InferenceCache =
+            Arc::new(Mutex::new(InferenceCacheInner { results: HashMap::new(), in_progress: HashSet::new() }));
         let (block_channel, block_handle) = Self::create_block_channel(
             send_channel.clone(),
             miner_address.clone(),
             last_stratum_id.clone(),
-            share_state.clone(),
+            shares_pending.clone(),
             Arc::clone(&current_task_slot),
             Arc::clone(&inference_cache),
         );
         Ok(Box::new(Self {
-            log_handler: task::spawn(Self::log_shares(share_state.clone())),
+            log_handler: task::spawn(Self::log_shares(share_state.clone(), shares_pending.clone())),
+            write_handle,
             stream: Box::pin(stream),
             send_channel,
             miner_address,
             mine_when_not_synced,
-            block_template_ctr: block_template_ctr
-                .unwrap_or_else(|| Arc::new(AtomicU16::new((thread_rng().next_u64() % 10_000u64) as u16))),
             target_pool: Default::default(),
-            target_real: Default::default(),
             nonce_mask: u64::MAX, // full nonce space until set_extranonce assigns a sub-range
             nonce_fixed: 0,
             extranonce: None,
             last_stratum_id,
             shares_stats: share_state,
+            shares_pending,
+            keepalive_interval: Duration::from_secs(keepalive_seconds.max(1)),
+            keepalive_timeout: Duration::from_secs(keepalive_timeout_seconds.max(1)),
+            keepalive_pending: None,
+            last_activity: Instant::now(),
             block_channel,
             block_handle,
             ipfs_url,
@@ -278,7 +288,7 @@ impl StratumHandler {
         send_channel: Sender<StratumLine>,
         miner_address: String,
         last_stratum_id: Arc<AtomicU32>,
-        share_stats: Arc<ShareStats>,
+        shares_pending: PendingShares,
         current_task_slot: Arc<Mutex<Option<CurrentTask>>>,
         inference_cache: InferenceCache,
     ) -> (Sender<BlockSeed>, BlockHandle) {
@@ -287,12 +297,12 @@ impl StratumHandler {
         let handle = tokio::spawn(async move {
             let mut recv_stream = ReceiverStream::new(recv);
             while let Some(seed) = recv_stream.next().await {
-                let (nonce, job_id) = match seed {
-                    BlockSeed::PartialBlock { nonce, id, .. } => (nonce, id),
+                let (nonce, job_id, pom_proof) = match seed {
+                    BlockSeed::PartialBlock { nonce, id, pom_proof, .. } => (nonce, id, pom_proof),
                     BlockSeed::FullBlock { .. } => unreachable!(),
                 };
                 let msg_id = last_stratum_id.fetch_add(1, Ordering::SeqCst);
-                share_stats.shares_pending.try_lock().unwrap().insert(msg_id, job_id.clone());
+                shares_pending.lock().await.insert(msg_id, job_id.clone());
                 let nonce_hex = format!("{:016x}", nonce);
                 let opoi_tag = keryx_inference::tag_fixed(nonce);
 
@@ -311,7 +321,23 @@ impl StratumHandler {
                     }
                 };
 
-                let line = if let Some(cid) = cid_opt {
+                let line = if !pom_proof.is_empty() {
+                    StratumLine {
+                        id: Some(msg_id),
+                        payload: StratumLinePayload::StratumCommand(StratumCommand::MiningSubmit(
+                            MiningSubmit::MiningSubmitWithPom((
+                                miner_address.clone(),
+                                job_id,
+                                nonce_hex,
+                                opoi_tag,
+                                cid_opt.unwrap_or_default(),
+                                hex::encode(pom_proof),
+                            )),
+                        )),
+                        jsonrpc: None,
+                        error: None,
+                    }
+                } else if let Some(cid) = cid_opt {
                     info!("OPoI Phase 2: submitting share with CID for job {}", job_id);
                     StratumLine {
                         id: Some(msg_id),
@@ -331,12 +357,7 @@ impl StratumHandler {
                     StratumLine {
                         id: Some(msg_id),
                         payload: StratumLinePayload::StratumCommand(StratumCommand::MiningSubmit(
-                            MiningSubmit::MiningSubmitWithTag((
-                                miner_address.clone(),
-                                job_id,
-                                nonce_hex,
-                                opoi_tag,
-                            )),
+                            MiningSubmit::MiningSubmitWithTag((miner_address.clone(), job_id, nonce_hex, opoi_tag)),
                         )),
                         jsonrpc: None,
                         error: None,
@@ -344,6 +365,7 @@ impl StratumHandler {
                 };
 
                 if send_channel.send(line).await.is_err() {
+                    shares_pending.lock().await.remove(&msg_id);
                     break;
                 }
             }
@@ -352,6 +374,13 @@ impl StratumHandler {
     }
 
     async fn handle_message(&mut self, msg: StratumLine, miner: &mut MinerManager) -> Result<(), Error> {
+        if self.keepalive_pending.map(|(id, _)| Some(id)) == Some(msg.id) {
+            self.keepalive_pending = None;
+            return match (&msg.payload, &msg.error) {
+                (StratumLinePayload::StratumResult { result: StratumResult::Plain(Some(true)) }, None) => Ok(()),
+                _ => Err("Stratum keepalive rejected".into()),
+            };
+        }
         match msg.clone() {
             StratumLine { id, payload, error: None, .. } => {
                 match payload {
@@ -359,10 +388,9 @@ impl StratumHandler {
                         match result {
                             StratumResult::Plain(Some(true)) | StratumResult::Eth((true, _)) => {
                                 if let Some(_jobid) = self
-                                    .shares_stats
                                     .shares_pending
-                                    .try_lock()
-                                    .unwrap()
+                                    .lock()
+                                    .await
                                     .remove(&id.expect("We checked id is not none"))
                                 {
                                     self.shares_stats.accepted.fetch_add(1, Ordering::SeqCst);
@@ -392,104 +420,31 @@ impl StratumHandler {
                             ref nonce_size,
                         ))) => self.set_extranonce(extranonce.as_str(), nonce_size),
                         StratumCommand::MiningSetDifficulty((ref difficulty,)) => self.set_difficulty(difficulty),
-                        // Phase 2 OPoI: bridge dispatches an AiRequest task alongside the block.
-                        StratumCommand::MiningNotify(MiningNotify::MiningNotifyWithTask((
-                            id,
-                            header_hash,
-                            timestamp,
-                            daa_score,
-                            task_json,
-                        ))) => {
-                            self.block_template_ctr
-                                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| Some((v + 1) % 10_000))
-                                .unwrap();
-                            // OPoI hard gate (mirrors solo grpc.rs): no models ready = no mining.
+                        StratumCommand::MiningNotify(notify) => {
+                            let job = MiningJob::try_from(notify)?;
                             if keryx_miner::slm::loaded_model_ids().is_empty() {
-                                if self.block_template_ctr.load(Ordering::SeqCst) % 200 == 0 {
-                                    warn!("OPoI: no models ready — mining suspended (no inference = no mining)");
-                                }
                                 return miner.process_block(None).await;
                             }
-                            let inference_started =
-                                self.handle_ai_task(id.clone(), task_json, miner).await;
-                            if inference_started {
-                                // PoW already paused inside handle_ai_task — do NOT feed a new
-                                // block template or the GPU immediately resumes hashing.
-                                Ok(())
+                            let target = effective_target(self.target_pool, job.block_bits)?;
+                            if let Some(task_json) = job.task_json {
+                                if self.handle_ai_task(job.id.clone(), task_json, miner).await {
+                                    return Ok(());
+                                }
                             } else {
-                                miner
-                                    .process_block(Some(PartialBlock {
-                                        id,
-                                        header_hash,
-                                        timestamp,
-                                        daa_score,
-                                        nonce: 0,
-                                        target: self.target_pool,
-                                        nonce_mask: self.nonce_mask,
-                                        nonce_fixed: self.nonce_fixed,
-                                        hash: None,
-                                    }))
-                                    .await
+                                *self.current_task_slot.lock().await = None;
                             }
-                        }
-                        StratumCommand::MiningNotify(MiningNotify::MiningNotifyShortV2((
-                            id,
-                            header_hash,
-                            timestamp,
-                            daa_score,
-                        ))) => {
-                            self.block_template_ctr
-                                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| Some((v + 1) % 10_000))
-                                .unwrap();
-                            // OPoI hard gate (mirrors solo grpc.rs): no models ready = no mining.
-                            if keryx_miner::slm::loaded_model_ids().is_empty() {
-                                if self.block_template_ctr.load(Ordering::SeqCst) % 200 == 0 {
-                                    warn!("OPoI: no models ready — mining suspended (no inference = no mining)");
-                                }
-                                return miner.process_block(None).await;
-                            }
-                            // No AiRequest in this job — clear the task slot.
-                            *self.current_task_slot.lock().await = None;
                             miner
                                 .process_block(Some(PartialBlock {
-                                    id,
-                                    header_hash,
-                                    timestamp,
-                                    daa_score,
+                                    id: job.id,
+                                    header_hash: job.header_hash,
+                                    timestamp: job.timestamp,
+                                    daa_score: job.daa_score,
                                     nonce: 0,
-                                    target: self.target_pool,
+                                    target,
                                     nonce_mask: self.nonce_mask,
                                     nonce_fixed: self.nonce_fixed,
                                     hash: None,
-                                }))
-                                .await
-                        }
-                        StratumCommand::MiningNotify(MiningNotify::MiningNotifyShort((id, header_hash, timestamp))) => {
-                            self.block_template_ctr
-                                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| Some((v + 1) % 10_000))
-                                .unwrap();
-                            // OPoI hard gate (mirrors solo grpc.rs): no models ready = no mining.
-                            if keryx_miner::slm::loaded_model_ids().is_empty() {
-                                if self.block_template_ctr.load(Ordering::SeqCst) % 200 == 0 {
-                                    warn!("OPoI: no models ready — mining suspended (no inference = no mining)");
-                                }
-                                return miner.process_block(None).await;
-                            }
-                            *self.current_task_slot.lock().await = None;
-                            miner
-                                .process_block(Some(PartialBlock {
-                                    id,
-                                    header_hash,
-                                    timestamp,
-                                    // Short stratum notify carries no daa_score; pin it to the
-                                    // current salt era so the host generates the right matrix.
-                                    // Post-relaunch the chain is on SALT v4, so force v4.
-                                    daa_score: crate::pow::heavy_hash::pow_salt_v4_activation_daa(),
-                                    nonce: 0,
-                                    target: self.target_pool,
-                                    nonce_mask: self.nonce_mask,
-                                    nonce_fixed: self.nonce_fixed,
-                                    hash: None,
+                                    pom_proof: Vec::new(),
                                 }))
                                 .await
                         }
@@ -508,7 +463,9 @@ impl StratumHandler {
                 error: Some(StratumError(code, error, _)),
                 ..
             } => {
-                let jobid = { self.shares_stats.shares_pending.try_lock().unwrap().remove(&id) }.unwrap();
+                let Some(jobid) = self.shares_pending.lock().await.remove(&id) else {
+                    return Err(format!("Stratum request {} rejected: {}", id, error).into());
+                };
                 match code {
                     ErrorCode::Unknown => {
                         // Match solo-mining behaviour (grpc.rs SubmitBlockResponse): a rejected
@@ -547,42 +504,49 @@ impl StratumHandler {
         }
     }
 
-    fn set_difficulty(&mut self, difficulty: &f32) -> Result<(), Error> {
-        let mut buf = [0u64, 0u64, 0u64, 0u64];
-        let (mantissa, exponent, _) = difficulty.recip().integer_decode();
-        let new_mantissa = mantissa * DIFFICULTY_1_TARGET.0;
-        let new_exponent = (DIFFICULTY_1_TARGET.1 + exponent) as u64;
-        let start = (new_exponent / 64) as usize;
-        let remainder = new_exponent % 64;
-
-        buf[start] = new_mantissa << remainder; // bottom
-        if start < 3 {
-            buf[start + 1] = new_mantissa >> (64 - remainder); // top
-        } else if new_mantissa.leading_zeros() < remainder as u32 {
-            return Err("Target is too big".into());
+    async fn maintain_keepalive(&mut self) -> Result<(), Error> {
+        let now = Instant::now();
+        if let Some((_, since)) = self.keepalive_pending {
+            if now.duration_since(since) >= self.keepalive_timeout {
+                return Err("Stratum keepalive timed out".into());
+            }
+        } else if now.duration_since(self.last_activity) >= self.keepalive_interval {
+            let id = self.last_stratum_id.fetch_add(1, Ordering::SeqCst);
+            self.send_channel
+                .send(StratumLine {
+                    id: Some(id),
+                    payload: StratumLinePayload::StratumCommand(StratumCommand::MiningKeepalive([])),
+                    jsonrpc: Some("2.0".into()),
+                    error: None,
+                })
+                .await?;
+            self.keepalive_pending = Some((id, now));
         }
+        Ok(())
+    }
 
-        self.target_pool = Uint256::new(buf);
+    fn set_difficulty(&mut self, difficulty: &f32) -> Result<(), Error> {
+        self.target_pool = difficulty_to_target(*difficulty)?;
         info!("Difficulty: {:?}, Target: 0x{}", difficulty, hex::encode(self.target_pool.to_be_bytes()));
         Ok(())
     }
 
     fn set_extranonce(&mut self, extranonce: &str, nonce_size: &u32) -> Result<(), Error> {
+        let (mask, fixed) = nonce_range(extranonce, *nonce_size)?;
         self.extranonce = Some(extranonce.to_string());
-        info!("Extra! {:?}", extranonce);
-        self.nonce_fixed = u64::from_str_radix(extranonce, 16)? << (nonce_size * 8);
-        info!("Extra Done!");
-        self.nonce_mask = (1 << (nonce_size * 8)) - 1;
+        self.nonce_mask = mask;
+        self.nonce_fixed = fixed;
         Ok(())
     }
 
-    async fn log_shares(shares_info: Arc<ShareStats>) {
+    async fn log_shares(shares_info: Arc<ShareStats>, shares_pending: PendingShares) {
         let mut ticker = tokio::time::interval(LOG_RATE);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
         let mut _last_instant = ticker.tick().await;
         loop {
             let _now = ticker.tick().await;
-            info!("{}", shares_info)
+            let pending_count = shares_pending.lock().await.len();
+            info!("{}Pending: {}", shares_info, pending_count)
         }
     }
 
@@ -637,7 +601,11 @@ impl StratumHandler {
             if text.is_empty() {
                 warn!("OPoI challenge: inference returned empty text for model {:.8}", model_id_hex);
             } else {
-                info!("OPoI challenge: done for model {:.8} ({} chars) — PoW resumes on next notify", model_id_hex, text.len());
+                info!(
+                    "OPoI challenge: done for model {:.8} ({} chars) — PoW resumes on next notify",
+                    model_id_hex,
+                    text.len()
+                );
             }
             let line = make_challenge_response_line(&model_id_hex, &nonce_hex, &text);
             if send_channel.blocking_send(line).is_err() {
@@ -730,6 +698,7 @@ impl StratumHandler {
 impl Drop for StratumHandler {
     fn drop(&mut self) {
         self.log_handler.abort();
+        self.write_handle.abort();
         self.block_handle.abort()
     }
 }

--- a/src/client/stratum/protocol.rs
+++ b/src/client/stratum/protocol.rs
@@ -1,0 +1,84 @@
+use super::statum_codec::MiningNotify;
+use crate::{Error, Uint256};
+use num::Float;
+
+pub(super) struct MiningJob {
+    pub id: String,
+    pub header_hash: [u64; 4],
+    pub timestamp: u64,
+    pub daa_score: u64,
+    pub block_bits: Option<u32>,
+    pub task_json: Option<String>,
+}
+
+impl TryFrom<MiningNotify> for MiningJob {
+    type Error = Error;
+
+    fn try_from(notify: MiningNotify) -> Result<Self, Error> {
+        let (id, header_hash, timestamp, daa_score, block_bits, task_json) = match notify {
+            MiningNotify::MiningNotifyWithTaskV3((id, hash, time, daa, bits, task)) => {
+                (id, hash, time, daa, Some(bits), Some(task))
+            }
+            MiningNotify::MiningNotifyShortV3((id, hash, time, daa, bits)) => (id, hash, time, daa, Some(bits), None),
+            MiningNotify::MiningNotifyWithTask((id, hash, time, daa, task)) => (id, hash, time, daa, None, Some(task)),
+            MiningNotify::MiningNotifyShortV2((id, hash, time, daa)) => (id, hash, time, daa, None, None),
+            _ => return Err("Keryx mining.notify must include the actual DAA score".into()),
+        };
+        Ok(Self { id, header_hash, timestamp, daa_score, block_bits, task_json })
+    }
+}
+
+pub(super) fn difficulty_to_target(difficulty: f32) -> Result<Uint256, Error> {
+    if !difficulty.is_finite() || difficulty <= 0.0 || !difficulty.recip().is_finite() {
+        return Err("Invalid pool difficulty".into());
+    }
+    let (mantissa, exponent, _) = difficulty.recip().integer_decode();
+    let mantissa = mantissa * 0xffff;
+    let exponent = 208i32 + i32::from(exponent);
+    if exponent < 0 {
+        return Err("Target is too small".into());
+    }
+    let start = exponent as usize / 64;
+    let remainder = exponent as usize % 64;
+    let mut words = [0u64; 4];
+    if start >= words.len() || (start == 3 && mantissa.leading_zeros() < remainder as u32) {
+        return Err("Target is too big".into());
+    }
+    words[start] = mantissa << remainder;
+    if remainder != 0 && start < 3 {
+        words[start + 1] = mantissa >> (64 - remainder);
+    }
+    Ok(Uint256::new(words))
+}
+
+pub(super) fn effective_target(pool_target: Uint256, block_bits: Option<u32>) -> Result<Uint256, Error> {
+    let Some(bits) = block_bits else {
+        return Ok(pool_target);
+    };
+    let size = bits >> 24;
+    let mantissa = bits & 0x007fffff;
+    if bits & 0x00800000 != 0 || size > 34 || (size > 33 && mantissa > 0xff) || (size > 32 && mantissa > 0xffff) {
+        return Err("Invalid block target".into());
+    }
+    let target = crate::target::u256_from_compact_target(bits);
+    if target == Uint256::default() {
+        return Err("Invalid block target".into());
+    }
+    Ok(pool_target.max(target))
+}
+
+pub(super) fn nonce_range(extranonce: &str, nonce_size: u32) -> Result<(u64, u64), Error> {
+    if nonce_size > 8
+        || extranonce.len() > (8 - nonce_size) as usize * 2
+        || !extranonce.bytes().all(|c| c.is_ascii_hexdigit())
+    {
+        return Err("Invalid Stratum extranonce range".into());
+    }
+    let prefix = if extranonce.is_empty() { 0 } else { u64::from_str_radix(extranonce, 16)? };
+    if nonce_size == 8 {
+        Ok((u64::MAX, 0))
+    } else {
+        let bits = nonce_size * 8;
+        Ok(((1u64 << bits) - 1, prefix << bits))
+    }
+}

--- a/src/client/stratum/statum_codec.rs
+++ b/src/client/stratum/statum_codec.rs
@@ -1,6 +1,6 @@
 use bytes::BytesMut;
 use log::error;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use serde_repr::*;
 use std::fmt::{Display, Formatter};
@@ -31,12 +31,43 @@ impl Display for ErrorCode {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Debug, Clone)]
 pub(crate) struct StratumError(pub(crate) ErrorCode, pub(crate) String, #[serde(default)] pub(crate) Option<Value>);
+
+impl<'de> Deserialize<'de> for StratumError {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum WireError {
+            Tuple(i64, String, #[serde(default)] Option<Value>),
+            Object {
+                code: i64,
+                message: String,
+                #[serde(default)]
+                data: Option<Value>,
+            },
+        }
+        let (code, message, data) = match WireError::deserialize(deserializer)? {
+            WireError::Tuple(code, message, data) => (code, message, data),
+            WireError::Object { code, message, data } => (code, message, data),
+        };
+        let code = match code {
+            21 => ErrorCode::JobNotFound,
+            22 => ErrorCode::DuplicateShare,
+            23 => ErrorCode::LowDifficultyShare,
+            24 => ErrorCode::Unauthorized,
+            25 => ErrorCode::NotSubscribed,
+            _ => ErrorCode::Unknown,
+        };
+        Ok(Self(code, message, data))
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub(crate) enum MiningNotify {
+    MiningNotifyWithTaskV3((String, [u64; 4], u64, u64, u32, String)),
+    MiningNotifyShortV3((String, [u64; 4], u64, u64, u32)),
     // 5-element: job_id, header_hash, timestamp, daa_score, task_json (AiRequest payload)
     MiningNotifyWithTask((String, [u64; 4], u64, u64, String)),
     MiningNotifyShortV2((String, [u64; 4], u64, u64)),
@@ -47,6 +78,7 @@ pub(crate) enum MiningNotify {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum MiningSubmit {
+    MiningSubmitWithPom((String, String, String, String, String, String)),
     // 5-element: address, job_id, nonce, opoi_tag, ipfs_cid (Phase 2 full inference submit)
     MiningSubmitWithCID((String, String, String, String, String)),
     MiningSubmitWithTag((String, String, String, String)), // address, job_id, nonce, opoi_tag
@@ -80,6 +112,8 @@ pub(crate) enum StratumCommand {
     Subscribe(MiningSubscribe),
     #[serde(rename = "mining.authorize")]
     Authorize((String, String)),
+    #[serde(rename = "mining.keepalive")]
+    MiningKeepalive([(); 0]),
     #[serde(rename = "mining.submit")]
     MiningSubmit(MiningSubmit),
     // Phase 2 OPoI: miner → bridge — declare loaded SLM model IDs (sent after authorize)

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,8 @@ use std::os::fd::AsRawFd;
 use clap::{App, FromArgMatches, IntoApp};
 use keryx_miner::PluginManager;
 use log::{error, info, warn};
-use rand::{thread_rng, RngCore};
 use std::fs;
-use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -567,12 +566,13 @@ async fn get_client(
     keryxd_address: String,
     mining_address: String,
     mine_when_not_synced: bool,
-    block_template_ctr: Arc<AtomicU16>,
     escrow_privkey: Option<String>,
     escrow_state_file: String,
     escrow_cert: Option<String>,
     chain_daa: Option<u64>,
     ipfs_url: String,
+    keepalive_seconds: u64,
+    keepalive_timeout_seconds: u64,
 ) -> Result<Box<dyn Client + 'static>, Error> {
     if keryxd_address.starts_with("stratum+tcp://") {
         let (_schema, address) = keryxd_address.split_once("://").unwrap();
@@ -580,8 +580,9 @@ async fn get_client(
             address.to_string().clone(),
             mining_address.clone(),
             mine_when_not_synced,
-            Some(block_template_ctr.clone()),
             ipfs_url.clone(),
+            keepalive_seconds,
+            keepalive_timeout_seconds,
         )
         .await?)
     } else if keryxd_address.starts_with("grpc://") {
@@ -589,7 +590,6 @@ async fn get_client(
             keryxd_address.clone(),
             mining_address.clone(),
             mine_when_not_synced,
-            Some(block_template_ctr.clone()),
             escrow_privkey,
             escrow_state_file,
             escrow_cert,
@@ -670,7 +670,6 @@ fn recovered_escrow_state(api_entries: Vec<ApiEscrowEntry>) -> Result<(escrow::E
 
 async fn client_main(
     opt: &Opt,
-    block_template_ctr: Arc<AtomicU16>,
     plugin_manager: &PluginManager,
     escrow_privkey: Option<String>,
     escrow_cert: Option<String>,
@@ -682,18 +681,16 @@ async fn client_main(
         opt.keryxd_address.clone(),
         opt.mining_address.clone().unwrap_or_default(),
         opt.mine_when_not_synced,
-        block_template_ctr.clone(),
         escrow_privkey,
         opt.escrow_state_file.clone(),
         escrow_cert,
         chain_daa,
         opt.ipfs_url.clone(),
+        opt.stratum_keepalive_seconds,
+        opt.stratum_keepalive_timeout_seconds,
     )
     .await?;
 
-    if opt.devfund_percent > 0 {
-        client.add_devfund(opt.devfund_address.clone(), opt.devfund_percent);
-    }
     client.register().await?;
     let mut miner_manager = MinerManager::new(client.get_block_channel(), opt.num_threads, plugin_manager, stats);
     let listen_result = tokio::select! {
@@ -1229,15 +1226,6 @@ async fn run() -> Result<(), Error> {
         .await
         .map_err(|e| format!("IPFS startup task failed: {}", e))??;
 
-    let block_template_ctr = Arc::new(AtomicU16::new((thread_rng().next_u64() % 10_000u64) as u16));
-    if opt.devfund_percent > 0 {
-        info!(
-            "devfund enabled, mining {}.{}% of the time to devfund address: {} ",
-            opt.devfund_percent / 100,
-            opt.devfund_percent % 100,
-            opt.devfund_address
-        );
-    }
     loop {
         if shutdown_requested.load(Ordering::Acquire) {
             info!("Shutdown requested, exiting miner main loop");
@@ -1245,7 +1233,6 @@ async fn run() -> Result<(), Error> {
         }
         match client_main(
             &opt,
-            block_template_ctr.clone(),
             &plugin_manager,
             escrow_privkey.clone(),
             escrow_cert.clone(),

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -39,6 +39,7 @@ pub enum BlockSeed {
         nonce_mask: u64,
         nonce_fixed: u64,
         hash: Option<String>,
+        pom_proof: Vec<u8>,
     },
 }
 
@@ -226,7 +227,7 @@ impl State {
     /// Proof-of-Model possession mining (slice 3a, CPU). If the memory-hard walk over
     /// `index` (the resident tier weights) yields `pom_pow_value <= target` for `nonce`,
     /// build the possession proof, set the nonce, attach the borsh-encoded proof, and return
-    /// the full block to submit. Solo only: a pool `PartialBlock` cannot carry a per-miner proof.
+    /// the block or share to submit.
     pub fn generate_block_if_pom(&self, nonce: u64, index: &WeightIndex, tier: u8, device_id: u32) -> Option<BlockSeed> {
         let mut pph = [0u8; 32];
         pph.copy_from_slice(&self.pow_hash_header[0..32]);
@@ -362,7 +363,10 @@ impl State {
                 }
                 block.pom_proof = proof_bytes; // plain bytes field (empty = none on the wire)
             }
-            BlockSeed::PartialBlock { .. } => return None,
+            BlockSeed::PartialBlock { nonce: header_nonce, pom_proof, .. } => {
+                *header_nonce = nonce;
+                *pom_proof = proof_bytes;
+            }
         }
         Some(block_seed)
     }


### PR DESCRIPTION
## Protocol

Adds the PoM pool transport reviewed in https://github.com/neuropool/keryx-miner-neuropool/pull/1.

```text
mining.submit = [worker, job_id, nonce_hex16, opoi_tag_hex16, cid_or_empty, pom_proof_hex]
mining.notify = [job_id, header_hash, timestamp, daa_score, block_bits, optional_task_json]
```

The complete canonical PoM proof is sent as hex without re-serialization. The pool validates every paid share. The `keryx-stratum-v3` subscription extension requests DAA-aware jobs and the compact block target.

## Compatibility and features

- DAA-aware jobs without `block_bits` remain supported. Jobs without DAA are rejected rather than guessing the consensus era.
- Legacy submit variants remain available; PoM networks still require the proof. Valid block candidates are preserved when the pool share target is harder.
- Validate difficulty and extranonce, accept array/object RPC errors, and limit JSON lines to 2 MiB.
- Add idle `mining.keepalive`, response timeout, five-second connection timeout and writer-failure detection. Pools must answer keepalives.
- Keep pending shares local to each connection while retaining cumulative counters across reconnects.
- Complete the devfund removal started by cc319ca: remove the CLI option/parser, hardcoded address, trait method, scheduler, solo/gRPC switching and README section. Mining always uses the configured user address.
- CUDA kernels, consensus calculations and escrow delegation are unchanged. No release-version bump is included.

AI inference will follow in a separate PR after this one is merged.