### PR TITLE
Add pool-dispatched AI inference

### DIFF
--- a/src/client/stratum.rs
+++ b/src/client/stratum.rs
@@ -8,8 +8,12 @@ use std::time::{Duration, Instant};
 use tokio::net::TcpStream;
 use tokio_util::codec::Framed;
 
+mod ai;
 mod protocol;
 mod statum_codec;
+
+use ai::{AiRequest, InferenceGuard};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 
 use protocol::{difficulty_to_target, effective_target, nonce_range, MiningJob};
 
@@ -132,6 +136,7 @@ pub struct StratumHandler {
     last_stratum_id: Arc<AtomicU32>,
 
     shares_stats: Arc<ShareStats>,
+    ai_response: Arc<Mutex<Option<(u32, Instant)>>>,
     shares_pending: PendingShares,
     keepalive_interval: Duration,
     keepalive_timeout: Duration,
@@ -191,7 +196,7 @@ impl Client for StratumHandler {
                 .send(StratumLine {
                     id: None,
                     payload: StratumLinePayload::StratumCommand(StratumCommand::MiningDeclareCapabilities(model_ids)),
-                    jsonrpc: None,
+                    jsonrpc: Some("2.0".into()),
                     error: None,
                 })
                 .await?;
@@ -270,6 +275,7 @@ impl StratumHandler {
             extranonce: None,
             last_stratum_id,
             shares_stats: share_state,
+            ai_response: Arc::new(Mutex::new(None)),
             shares_pending,
             keepalive_interval: Duration::from_secs(keepalive_seconds.max(1)),
             keepalive_timeout: Duration::from_secs(keepalive_timeout_seconds.max(1)),
@@ -374,6 +380,19 @@ impl StratumHandler {
     }
 
     async fn handle_message(&mut self, msg: StratumLine, miner: &mut MinerManager) -> Result<(), Error> {
+        {
+            let mut pending = self.ai_response.lock().await;
+            if pending.map(|(id, _)| Some(id)) == Some(msg.id) {
+                *pending = None;
+                match (&msg.payload, &msg.error) {
+                    (StratumLinePayload::StratumResult { result: StratumResult::Plain(Some(true)) }, None) => {
+                        info!("AI response accepted")
+                    }
+                    _ => warn!("AI response rejected: {:?}", msg.error),
+                }
+                return Ok(());
+            }
+        }
         if self.keepalive_pending.map(|(id, _)| Some(id)) == Some(msg.id) {
             self.keepalive_pending = None;
             return match (&msg.payload, &msg.error) {
@@ -426,6 +445,9 @@ impl StratumHandler {
                                 return miner.process_block(None).await;
                             }
                             let target = effective_target(self.target_pool, job.block_bits)?;
+                            if self.challenge_in_flight.load(Ordering::SeqCst) {
+                                return miner.process_block(None).await;
+                            }
                             if let Some(task_json) = job.task_json {
                                 if self.handle_ai_task(job.id.clone(), task_json, miner).await {
                                     return Ok(());
@@ -447,6 +469,10 @@ impl StratumHandler {
                                     pom_proof: Vec::new(),
                                 }))
                                 .await
+                        }
+                        StratumCommand::MiningAiRequest(fields) => {
+                            self.handle_ai_request(fields, miner).await;
+                            Ok(())
                         }
                         StratumCommand::MiningChallenge((model_id_hex, nonce_hex)) => {
                             self.handle_challenge(model_id_hex, nonce_hex, miner).await;
@@ -506,6 +532,15 @@ impl StratumHandler {
 
     async fn maintain_keepalive(&mut self) -> Result<(), Error> {
         let now = Instant::now();
+        if self
+            .ai_response
+            .lock()
+            .await
+            .as_ref()
+            .is_some_and(|(_, since)| now.duration_since(*since) >= self.keepalive_timeout)
+        {
+            return Err("AI response acknowledgement timed out".into());
+        }
         if let Some((_, since)) = self.keepalive_pending {
             if now.duration_since(since) >= self.keepalive_timeout {
                 return Err("Stratum keepalive timed out".into());
@@ -550,8 +585,54 @@ impl StratumHandler {
         }
     }
 
-    /// Parse the task JSON from a `MiningNotifyWithTask`, store it in `current_task_slot`,
-    /// and spawn a background inference+IPFS upload if the result is not already cached.
+    async fn handle_ai_request(
+        &mut self,
+        fields: (String, String, String, String, String, u32, String),
+        miner: &mut MinerManager,
+    ) {
+        let request = match AiRequest::parse(fields) {
+            Ok(request) => request,
+            Err(error) => {
+                warn!("Invalid AI request: {}", error);
+                return;
+            }
+        };
+        if !keryx_miner::slm::is_model_ready(&request.model_id) {
+            warn!("AI request {}: model is not ready", request.task_id);
+            return;
+        }
+        if self.ai_response.lock().await.is_some() || self.challenge_in_flight.swap(true, Ordering::SeqCst) {
+            warn!("AI request {}: inference is busy", request.task_id);
+            return;
+        }
+        let guard = InferenceGuard::new(miner.opoi_challenge_flag(), self.challenge_in_flight.clone());
+        if let Err(error) = miner.process_block(None).await {
+            warn!("Could not pause mining for AI request: {}", error);
+            return;
+        }
+        let sender = self.send_channel.clone();
+        let worker = self.miner_address.clone();
+        let pending = self.ai_response.clone();
+        let last_id = self.last_stratum_id.clone();
+        tokio::task::spawn_blocking(move || {
+            let _guard = guard;
+            let result =
+                keryx_miner::slm::load_and_run_inference(&request.model_id, &request.prompt, request.max_tokens)
+                    .unwrap_or_default();
+            let id = last_id.fetch_add(1, Ordering::SeqCst);
+            match request.response(id, worker, &result) {
+                Ok(line) => {
+                    *pending.blocking_lock() = Some((id, Instant::now()));
+                    if sender.blocking_send(line).is_err() {
+                        *pending.blocking_lock() = None;
+                        warn!("AI response {}: connection closed", request.task_id);
+                    }
+                }
+                Err(error) => warn!("AI request {}: {}", request.task_id, error),
+            }
+        });
+    }
+
     /// Handle a `mining.challenge` from the bridge.
     ///
     /// The bridge relays the node's periodic capability challenge: the miner must prove
@@ -595,9 +676,8 @@ impl StratumHandler {
         tokio::task::spawn_blocking(move || {
             let result = keryx_miner::slm::load_and_run_inference(&model_id, &prompt, CHALLENGE_MAX_TOKENS);
             let text = result.unwrap_or_default();
-            // Clear both flags — PoW resumes on the next mining.notify from the bridge.
+            // PoW resumes on the next mining.notify from the bridge.
             miner_flag.store(false, Ordering::SeqCst);
-            challenge_flag.store(false, Ordering::SeqCst);
             if text.is_empty() {
                 warn!("OPoI challenge: inference returned empty text for model {:.8}", model_id_hex);
             } else {
@@ -611,6 +691,7 @@ impl StratumHandler {
             if send_channel.blocking_send(line).is_err() {
                 warn!("OPoI challenge: send_channel closed, could not deliver response");
             }
+            challenge_flag.store(false, Ordering::SeqCst);
         });
     }
 
@@ -733,9 +814,9 @@ fn make_challenge_response_line(model_id_hex: &str, nonce_hex: &str, result: &st
         payload: StratumLinePayload::StratumCommand(StratumCommand::MiningChallengeResponse((
             model_id_hex.to_string(),
             nonce_hex.to_string(),
-            result.to_string(),
+            BASE64.encode(result.as_bytes()),
         ))),
-        jsonrpc: None,
+        jsonrpc: Some("2.0".into()),
         error: None,
     }
 }

--- a/src/client/stratum/ai.rs
+++ b/src/client/stratum/ai.rs
@@ -1,0 +1,80 @@
+use super::statum_codec::{StratumCommand, StratumLine, StratumLinePayload};
+use crate::Error;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+const MAX_PAYLOAD_BYTES: usize = 1_048_576;
+
+pub(super) struct AiRequest {
+    pub task_id: String,
+    pub request_hash: String,
+    pub model_hex: String,
+    pub model_id: [u8; 32],
+    pub prompt: String,
+    pub max_tokens: usize,
+}
+
+impl AiRequest {
+    pub fn parse(fields: (String, String, String, String, String, u32, String)) -> Result<Self, Error> {
+        let (task_id, txid, request_hash, model_hex, prompt_b64, max_tokens, reward) = fields;
+        if !task_id.eq_ignore_ascii_case(&request_hash) || max_tokens == 0 || max_tokens > i32::MAX as u32 {
+            return Err("Invalid AI task metadata".into());
+        }
+        for value in [&task_id, &txid, &request_hash, &model_hex] {
+            if value.len() != 64 || !value.bytes().all(|c| c.is_ascii_hexdigit()) {
+                return Err("Invalid AI task identifier".into());
+            }
+        }
+        reward.parse::<u64>()?;
+        if prompt_b64.len() > MAX_PAYLOAD_BYTES.div_ceil(3) * 4 {
+            return Err("AI prompt is too large".into());
+        }
+        let prompt = String::from_utf8(BASE64.decode(prompt_b64)?)?;
+        if prompt.len() > MAX_PAYLOAD_BYTES || prompt.contains('\0') {
+            return Err("Invalid AI prompt".into());
+        }
+        let mut model_id = [0; 32];
+        hex::decode_to_slice(&model_hex, &mut model_id)?;
+        Ok(Self { task_id, request_hash, model_hex, model_id, prompt, max_tokens: max_tokens as usize })
+    }
+
+    pub fn response(&self, id: u32, worker: String, result: &str) -> Result<StratumLine, Error> {
+        if result.is_empty() || result.len() > MAX_PAYLOAD_BYTES {
+            return Err("Invalid AI result size".into());
+        }
+        Ok(StratumLine {
+            id: Some(id),
+            payload: StratumLinePayload::StratumCommand(StratumCommand::MiningAiResponse((
+                worker,
+                self.task_id.clone(),
+                self.request_hash.clone(),
+                self.model_hex.clone(),
+                BASE64.encode(result.as_bytes()),
+            ))),
+            jsonrpc: Some("2.0".into()),
+            error: None,
+        })
+    }
+}
+
+pub(super) struct InferenceGuard {
+    miner: Arc<AtomicBool>,
+    busy: Arc<AtomicBool>,
+}
+
+impl InferenceGuard {
+    pub fn new(miner: Arc<AtomicBool>, busy: Arc<AtomicBool>) -> Self {
+        miner.store(true, Ordering::SeqCst);
+        Self { miner, busy }
+    }
+}
+
+impl Drop for InferenceGuard {
+    fn drop(&mut self) {
+        self.miner.store(false, Ordering::SeqCst);
+        self.busy.store(false, Ordering::SeqCst);
+    }
+}

--- a/src/client/stratum/statum_codec.rs
+++ b/src/client/stratum/statum_codec.rs
@@ -119,10 +119,14 @@ pub(crate) enum StratumCommand {
     // Phase 2 OPoI: miner → bridge — declare loaded SLM model IDs (sent after authorize)
     #[serde(rename = "mining.declare_capabilities")]
     MiningDeclareCapabilities(Vec<String>),
+    #[serde(rename = "mining.ai_request")]
+    MiningAiRequest((String, String, String, String, String, u32, String)),
+    #[serde(rename = "mining.ai_response")]
+    MiningAiResponse((String, String, String, String, String)),
     // Phase 2 OPoI: bridge → miner — "model_id_hex:nonce_hex" capability challenge
     #[serde(rename = "mining.challenge")]
     MiningChallenge((String, String)),
-    // Phase 2 OPoI: miner → bridge — [model_id_hex, nonce_hex, result_text] challenge
+    // Capability response: [model_id_hex, nonce_hex, result_b64].
     // response. The nonce is echoed back so the bridge can reject replayed/stale responses.
     #[serde(rename = "mining.challenge_response")]
     MiningChallengeResponse((String, String, String)),
@@ -193,7 +197,7 @@ pub(crate) struct NewLineJsonCodec {
 
 impl NewLineJsonCodec {
     pub fn new() -> Self {
-        Self { lines_codec: LinesCodec::new() }
+        Self { lines_codec: LinesCodec::new_with_max_length(2 * 1024 * 1024) }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -974,14 +974,19 @@ async fn run() -> Result<(), Error> {
     };
 
     // Resolve OPoI escrow private key (once, before the reconnect loop).
-    let escrow_privkey: Option<String> = match escrow::load_or_generate_key(&opt.escrow_key_file) {
-        Ok(k) => {
-            info!("OPoI: escrow key loaded from '{}'.", opt.escrow_key_file);
-            Some(k)
-        }
-        Err(e) => {
-            error!("Failed to load/generate OPoI escrow key: {}", e);
-            return Err(e.into());
+    let pool_mode = opt.keryxd_address.starts_with("stratum+tcp://");
+    let escrow_privkey: Option<String> = if pool_mode {
+        None
+    } else {
+        match escrow::load_or_generate_key(&opt.escrow_key_file) {
+            Ok(k) => {
+                info!("OPoI: escrow key loaded from '{}'.", opt.escrow_key_file);
+                Some(k)
+            }
+            Err(e) => {
+                error!("Failed to load/generate OPoI escrow key: {}", e);
+                return Err(e.into());
+            }
         }
     };
 
@@ -1221,10 +1226,12 @@ async fn run() -> Result<(), Error> {
     // spinning reconnect attempts, and the miner never advertises/serves inference it cannot
     // publish. `ensure_daemon` returns only when the API is reachable (waiting up to 60
     // seconds, failing immediately if the child exits).
-    let ipfs_url = opt.ipfs_url.clone();
-    tokio::task::spawn_blocking(move || crate::ipfs::ensure_daemon(&ipfs_url))
-        .await
-        .map_err(|e| format!("IPFS startup task failed: {}", e))??;
+    if !pool_mode {
+        let ipfs_url = opt.ipfs_url.clone();
+        tokio::task::spawn_blocking(move || crate::ipfs::ensure_daemon(&ipfs_url))
+            .await
+            .map_err(|e| format!("IPFS startup task failed: {}", e))??;
+    }
 
     loop {
         if shutdown_requested.load(Ordering::Acquire) {


### PR DESCRIPTION
## Protocol

Adds the pool-dispatched inference layer reviewed in https://github.com/neuropool/keryx-miner-neuropool/pull/2.

```text
mining.declare_capabilities = [model_id, ...]
mining.ai_request = [task_id, request_txid, request_hash, model_id, prompt_b64, max_tokens, inference_reward_sompi]
mining.ai_response = [worker, task_id, request_hash, model_id, result_b64]
```

Identifiers are 64-character hex strings; the current layout requires `task_id == request_hash`. The pool supplies the era-correct request identity (transaction ID after H8). Reward is a decimal string in sompi. Prompt and result are Base64-encoded UTF-8.

## Responsibilities and compatibility

- The worker advertises models, runs inference and returns the exact result bytes. The pool owns IPFS pinning, signing, on-chain submission and escrow.
- The six-field PoM share format is unchanged. AI acknowledgements are tracked separately from shares.
- No worker escrow key/certificate or local IPFS startup is needed for the pool protocol. Solo/gRPC inference is unchanged.
- Legacy job-attached tasks/CID handling remains available and still needs worker-side IPFS. Capability challenge responses carry Base64 results.
- Strict metadata validation, 1 MiB payload limits, single-flight inference and PoW suspension protect the worker.

This PR contains only the AI layer on top of the merged Stratum changes. Explicit inference-failure responses are deferred; existing timeout behavior is unchanged.

Follows the merged Stratum PR: https://github.com/Keryx-Labs/keryx-miner/pull/44