### PR TITLE
PoC: shard-possession PoM (network-fatia) — incomplete, exploratory

### DIFF
--- a/SHARD_POSSESSION_POC.md
+++ b/SHARD_POSSESSION_POC.md
@@ -1,0 +1,152 @@
+# Shard-Possession PoM PoC ("network-fatia")
+
+Status: **PROOF OF CONCEPT — incomplete, exploratory.** Not activated on Mainnet or Testnet.
+Only exercised on an isolated, private Simnet build created for this work. Nothing in this
+branch changes consensus on any shared network; `shard_poc_activation` is `never()` everywhere
+except the private `SIMNET_PARAMS` added here.
+Branch: `shard-poc` in both `keryx-miner` and `keryx-node`.
+Companion repo: this document is duplicated verbatim in both `keryx-node` and `keryx-miner`
+(the two halves of the PoC live in separate repos and have to be read together).
+
+## 1. Motivation
+
+PoM tiers currently require one GPU to hold and walk an entire model's weights. As served
+models grow (e.g. a 48B-parameter tier), that stops fitting on a single consumer GPU. This PoC
+explores an alternative: split a model into fixed-byte-size **shards** along layer boundaries,
+and let a GPU prove possession of only its own shard instead of the whole model — so a model
+too large for any one card can still be mined, cooperatively, across several cards.
+
+This is a possession-proof question, not a serving question: it does **not** attempt to make a
+shard device capable of running real OPoI inference over the full model (see §6, "Not done").
+
+## 2. What changed — miner side (`keryx-miner`, branch `shard-poc`)
+
+- `src/shard.rs`: `ShardManifest { index: u16, layer_lo: u32, layer_hi: u32, tensor_names:
+  Vec<String> }` and `pack_shards(meta, target_bytes) -> Vec<ShardManifest>` — splits a GGUF's
+  tensors into layer-range shards, each close to `target_bytes` on disk.
+- `src/pom.rs`: `WeightIndex::build_from_gguf_subset(...)` — builds a host chunk index (the same
+  Merkle-style structure used for a whole-tier index) over only a shard's tensor subset.
+- `src/pom_gpu.rs`:
+  - `load_raw_subset(...)` — raw GPU upload restricted to a shard's tensor subset only. Shard
+    devices never run the llama engine and never zero-dup against a resident whole-model tree —
+    always a raw scoped upload.
+  - Per-device shard registry (`set_shard_for_device` / `shard_for_device`) and
+    `ensure_shard_installed_inner`, which contains the **N-guard**: after installing, it compares
+    the GPU gather's chunk count against the host index's chunk count and refuses to install a
+    miner (`"gather N != shard index N — refusing to mine"`) on any mismatch, rather than
+    silently producing a proof over the wrong data. Verified live on real hardware — see §5.
+- `src/models.rs`: `pom_shard_tier_index(model_id, target_bytes, shard_index, daa)` — maps a
+  shard assignment to a PoM tier index. In this PoC: `5 + shard_index` for a 4-shard, 8 GB split
+  of the `very-high` tier (tiers 5, 6, 7, 8). This offset is a **hand-kept convention**, not
+  negotiated by any protocol — see §6.
+- `src/cli.rs` / `src/main.rs`: `--shard TIER:TARGET_GIB:IDX[,...]` (mine one fixed-size shard
+  instead of the whole tier) and `--print-shards TIER:TARGET_GIB` (compute and print a shard
+  manifest, then exit — used to produce the exact values pasted into the node's shard tier
+  table; see §3).
+- Two real defects found and fixed while running this live (`src/client/grpc.rs`):
+  1. The existing "OPoI is mandatory: refuse to mine with no model loaded" gate had no exemption
+     for shard-only devices, which never load a full model by design. Fixed with
+     `pom_gpu::any_shard_devices_active()` and a gate exemption for processes that only run
+     shard devices — no change for ordinary whole-tier mining.
+  2. A sole-producer / idle chain (this PoC's Simnet, with zero peers) never re-requested a
+     fresh block template outside of an in-flight inference cycle, so mining stalled at DAA 0
+     indefinitely. Fixed with an unconditional ~500ms fallback re-poll.
+- `examples/shard_walk_poc.rs` and `examples/shard_guard_poc.rs` — see §5.
+
+## 3. What changed — node side (`keryx-node`, branch `shard-poc`)
+
+- `consensus/core/src/config/params.rs`:
+  - `POM_SHARDS_POC`: a shard tier table (`crate::pom::PomTier { model_id, root, chunks }` per
+    shard) — real, measured values pasted verbatim from `keryx-miner --print-shards
+    very-high:8` run against the real model file (see §4). Gated behind `shard_poc_activation`.
+  - `shard_poc_activation`: a new fork-activation gate. `never()` on `MAINNET_PARAMS` and the
+    shared public `TESTNET_PARAMS` — this PoC never touches either. Set to `new(1)` only on
+    `SIMNET_PARAMS`, alongside a full, internally-consistent PoM/OPoI/H-series activation
+    profile built specifically for a from-genesis private Simnet (every field's reasoning is
+    documented inline in the diff, including one corrected discrepancy against the public
+    `TESTNET_PARAMS`'s `pom_v4_activation`/`h10_activation` values — the real miner binary gates
+    those at DAA 500 under `--testnet`, not DAA 1 as `TESTNET_PARAMS` currently says; that
+    pre-existing drift is dormant on the real Testnet only because its tip is already past DAA
+    500, and is not copied into `SIMNET_PARAMS`).
+
+## 4. Environment used for validation
+
+- Hardware: 2x NVIDIA GPU on one rig — CUDA ordinal 0 = RTX 3090 (24 GB), CUDA ordinal 1 = RTX
+  4090 (24 GB). This rig's CUDA driver ordinal does not match the `nvidia-smi` device index by
+  default; validation used `CUDA_DEVICE_ORDER=PCI_BUS_ID` to pin them.
+- Model: Kimi-Linear-48B, Q4_K_M quantization, ~29.7 GB GGUF on disk — too large to fit whole on
+  either single card in this rig.
+- Split: 8 GB target per shard → 4 shards. Real manifest (captured via `--print-shards
+  very-high:8`):
+
+  | Shard | Layers | Chunks | Merkle root |
+  |---|---|---|---|
+  | 0 | [0, 7) | 219,852,216 | `a73a38fe1ef0cddc6e108eca25eb1de1adcdc7a65c01f87058530ac06df669b4` |
+  | 1 | [7, 14) | 238,829,076 | `db22407efc04f5d261498afc7acb397c87e692699484a9bcf2a747636adda9e5` |
+  | 2 | [14, 21) | 243,638,100 | `9c3aed4cc240baea0928f8282ea91ce6b0cd275f8286c45c440017c457f8cb8d` |
+  | 3 | [21, 27) | 225,674,672 | `233fdb1f9b551bb7895a0fca931ce5eddd16d87a12980f7e4361e020cfe29ff2` |
+
+- Network: a private, isolated Simnet instance (no DNS seeders, own genesis) — never the shared
+  public Testnet or Mainnet.
+- Build: Windows, MSVC toolchain via the Visual Studio Developer Shell;
+  `KERYX_LLAMA_SKIP=1` (skips only the llama.cpp CMake library build used for OPoI inference
+  serving — irrelevant to the PoM CUDA kernel path this PoC exercises).
+
+## 5. Results — proven on real hardware
+
+1. **In-process concept proof** (`keryx-miner/examples/shard_walk_poc.rs`): both GPUs
+   independently packed their shard's manifest, installed it (real raw scoped upload), ran a
+   real GPU PoM walk against a synthetic (trivially easy) target, built a real `PomProofV3`
+   witness from the walk, and self-verified it with the same `verify_proof_v3` function a node
+   uses — no live node needed for this step. Both self-verified `true`.
+2. **Live network acceptance** (real gRPC mining loop, against the private Simnet node running
+   the `SIMNET_PARAMS` profile from §3): the node genuinely accepted shard-tier PoM blocks over
+   the real block-submission path, sustained, with zero rejections — 817 blocks on shard 0
+   (GPU0/3090, ~1.05M h/s, `v4 tensor-core` kernel) and 413 blocks on shard 1 (GPU1/4090, ~1.68M
+   h/s), 1,230 combined, 0 rejected.
+3. **Guard regression check** (`keryx-miner/examples/shard_guard_poc.rs`): installs a shard with
+   its correct manifest (succeeds), then reinstalls after dropping one tensor name from the
+   manifest — the cached host index still reflects the correct (larger) chunk count, so the
+   second gather's chunk count diverges and the N-guard correctly refuses to install a miner,
+   confirming a corrupted/wrong manifest cannot silently produce an acceptable proof.
+
+## 6. Explicitly NOT done — open, incomplete by design
+
+This is a concept proof, not a finished feature. In particular:
+
+- **No distributed OPoI inference serving.** A shard device still cannot itself serve real
+  inference over the full model — the OPoI-mandatory-mining gate exemption in §2 only lets a
+  shard-only process skip that requirement for *mining*; it does not make inference work. A
+  real ggml-rpc-style pipeline across shards (already scoped separately as spec §3.3–3.5) is
+  future work, not part of this PoC.
+- **The pre-PoM bootstrap block still needs a whole model.** A fresh chain's very first block
+  (below `pom_activation`) must be mined under the legacy kHeavyHash+OPoI path, which needs one
+  device holding the *entire* model — a pure shard-only rig has no path through that block on
+  its own.
+- **The shard→tier offset (`5 + shard_index`) is a hand-kept convention**, not negotiated by any
+  protocol. The node's `POM_SHARDS_POC` row order must match the miner's shard numbering by
+  agreement, not by any on-chain mechanism. A mismatch here is silently wrong, not rejected —
+  this is a real weakness a production design would need to close.
+- **Not tested beyond this exact configuration**: 2 GPUs, 4 shards, one model
+  (Kimi-Linear-48B), one rig. Behavior with more shards, more devices, a different model, or
+  cross-machine (rather than cross-GPU-on-one-machine) sharding is unexplored.
+- **No reward/economics design.** A shard-only miner's partial possession currently just reuses
+  the ordinary tier-based reward table positionally. Whether that's fair or game-theoretically
+  sound versus a whole-tier miner's possession was not evaluated.
+- **`SIMNET_PARAMS` activation is deliberately Simnet-only.** Extending any of this to a shared
+  network (Testnet or Mainnet) is a separate, much larger decision — governance, rollout timing,
+  and backward compatibility are all out of scope here.
+
+## 7. Where to look / how to reproduce
+
+- `keryx-node`, branch `shard-poc`: commit `76aa3c6f` (shard tier table + gating scaffold, then
+  a placeholder row), commit `ecb0f09e` (real manifest data + the `SIMNET_PARAMS` activation
+  profile from §3).
+- `keryx-miner`, branch `shard-poc`: commits `3cf1bd4` (shard registry + install path), `15649ec`
+  (`--shard`/`--print-shards` CLI), `ba2aa2f` (wiring into tier assignment and the mining loop),
+  `b9c0990` (OPoI-gate exemption for shard devices), `183d3e5` (idle-chain template re-poll
+  fix), `645fd5d` (the two diagnostic examples in §5).
+- To rerun the in-process proof or the guard check: `cargo run --example shard_walk_poc
+  --features cuda` / `cargo run --example shard_guard_poc --features cuda` from the miner repo
+  (both accept `--gguf-path`, `--target-bytes`, and `--mainnet` flags; default to the
+  Kimi-Linear-48B path and testnet-style DAA gates used above).

--- a/SHARD_POSSESSION_POC.md
+++ b/SHARD_POSSESSION_POC.md
@@ -142,10 +142,10 @@ This is a concept proof, not a finished feature. In particular:
 - `keryx-node`, branch `shard-poc`: commit `76aa3c6f` (shard tier table + gating scaffold, then
   a placeholder row), commit `ecb0f09e` (real manifest data + the `SIMNET_PARAMS` activation
   profile from §3).
-- `keryx-miner`, branch `shard-poc`: commits `3cf1bd4` (shard registry + install path), `15649ec`
-  (`--shard`/`--print-shards` CLI), `ba2aa2f` (wiring into tier assignment and the mining loop),
-  `b9c0990` (OPoI-gate exemption for shard devices), `183d3e5` (idle-chain template re-poll
-  fix), `645fd5d` (the two diagnostic examples in §5).
+- `keryx-miner`, branch `shard-poc`: commits `3aa1598` (shard registry + install path), `177a33a`
+  (`--shard`/`--print-shards` CLI), `79099bd` (wiring into tier assignment and the mining loop),
+  `fba09c8` (OPoI-gate exemption for shard devices), `af7ebee` (idle-chain template re-poll
+  fix), `7136086` (the two diagnostic examples in §5).
 - To rerun the in-process proof or the guard check: `cargo run --example shard_walk_poc
   --features cuda` / `cargo run --example shard_guard_poc --features cuda` from the miner repo
   (both accept `--gguf-path`, `--target-bytes`, and `--mainnet` flags; default to the

--- a/SHARD_POSSESSION_POC.pt-BR.md
+++ b/SHARD_POSSESSION_POC.pt-BR.md
@@ -1,0 +1,171 @@
+# PoC de Posse por Fatia (Shard) para o PoM ("network-fatia")
+
+Status: **PROVA DE CONCEITO — incompleta, exploratória.** Não ativada na Mainnet nem na
+Testnet. Só foi exercitada numa Simnet privada e isolada, criada especificamente para este
+trabalho. Nada nesta branch altera o consenso de nenhuma rede compartilhada;
+`shard_poc_activation` é `never()` em todo lugar, exceto no `SIMNET_PARAMS` privado adicionado
+aqui.
+Branch: `shard-poc` tanto em `keryx-miner` quanto em `keryx-node`.
+Repositório companheiro: este documento é duplicado, na íntegra, em `keryx-node` e em
+`keryx-miner` (as duas metades do PoC vivem em repositórios separados e precisam ser lidas
+juntas).
+
+## 1. Motivação
+
+Hoje, os tiers de PoM exigem que uma única GPU segure e percorra (walk) o modelo inteiro. À
+medida que os modelos servidos crescem (ex.: um tier de 48B parâmetros), isso deixa de caber
+numa única GPU de consumidor. Este PoC explora uma alternativa: dividir um modelo em **fatias
+(shards)** de tamanho fixo em bytes, ao longo de faixas de camadas (layers), e deixar que cada
+GPU prove posse apenas da sua própria fatia, em vez do modelo inteiro — assim, um modelo grande
+demais para qualquer placa isolada ainda pode ser minerado, cooperativamente, por várias placas.
+
+Isso é uma questão de prova de posse, não de servir inferência: **não** se tenta tornar um
+dispositivo de fatia capaz de rodar inferência OPoI real sobre o modelo completo (ver §6,
+"O que não foi feito").
+
+## 2. O que mudou — lado do miner (`keryx-miner`, branch `shard-poc`)
+
+- `src/shard.rs`: `ShardManifest { index: u16, layer_lo: u32, layer_hi: u32, tensor_names:
+  Vec<String> }` e `pack_shards(meta, target_bytes) -> Vec<ShardManifest>` — divide os tensores
+  de um GGUF em fatias por faixa de camadas, cada uma próxima do `target_bytes` em disco.
+- `src/pom.rs`: `WeightIndex::build_from_gguf_subset(...)` — constrói um índice de chunks no
+  host (a mesma estrutura estilo Merkle usada num índice de tier inteiro), mas só sobre o
+  subconjunto de tensores de uma fatia.
+- `src/pom_gpu.rs`:
+  - `load_raw_subset(...)` — upload bruto pra GPU restrito ao subconjunto de tensores de uma
+    fatia. Dispositivos de fatia nunca rodam o motor llama e nunca fazem zero-dup contra uma
+    árvore residente do modelo inteiro — é sempre um upload bruto e escopado (raw scoped
+    upload).
+  - Registro por dispositivo de qual fatia ele minera (`set_shard_for_device` /
+    `shard_for_device`) e `ensure_shard_installed_inner`, que contém o **N-guard**: depois de
+    instalar, compara a contagem de chunks obtida pela GPU contra a contagem do índice do host e
+    recusa instalar um miner (`"gather N != shard index N — refusing to mine"`) em qualquer
+    divergência, em vez de produzir silenciosamente uma prova sobre os dados errados. Verificado
+    ao vivo em hardware real — ver §5.
+- `src/models.rs`: `pom_shard_tier_index(model_id, target_bytes, shard_index, daa)` — mapeia uma
+  atribuição de fatia pra um índice de tier de PoM. Neste PoC: `5 + shard_index` pra uma divisão
+  em 4 fatias de 8 GB do tier `very-high` (tiers 5, 6, 7, 8). Esse deslocamento é uma
+  **convenção mantida manualmente**, não negociada por nenhum protocolo — ver §6.
+- `src/cli.rs` / `src/main.rs`: `--shard TIER:TARGET_GIB:IDX[,...]` (minerar uma fatia de
+  tamanho fixo em vez do tier inteiro) e `--print-shards TIER:TARGET_GIB` (calcular e imprimir o
+  manifest de uma fatia, depois sair — usado pra produzir os valores exatos colados na tabela de
+  fatias do node; ver §3).
+- Dois defeitos reais encontrados e corrigidos rodando isso ao vivo (`src/client/grpc.rs`):
+  1. O gate existente "OPoI é obrigatório: recusar minerar sem nenhum modelo carregado" não
+     tinha isenção para dispositivos que só minam fatia, que por design nunca carregam o modelo
+     inteiro. Corrigido com `pom_gpu::any_shard_devices_active()` e uma isenção do gate para
+     processos que só rodam dispositivos de fatia — nenhuma mudança para a mineração normal de
+     tier inteiro.
+  2. Uma chain com produtor único / ociosa (a Simnet deste PoC, com zero peers) nunca voltava a
+     pedir um template de bloco fresco fora de um ciclo de inferência em andamento, então a
+     mineração travava indefinidamente na DAA 0. Corrigido com um re-poll de fallback
+     incondicional de ~500ms.
+- `examples/shard_walk_poc.rs` e `examples/shard_guard_poc.rs` — ver §5.
+
+## 3. O que mudou — lado do node (`keryx-node`, branch `shard-poc`)
+
+- `consensus/core/src/config/params.rs`:
+  - `POM_SHARDS_POC`: uma tabela de tiers de fatia (`crate::pom::PomTier { model_id, root,
+    chunks }` por fatia) — valores reais, medidos, colados literalmente da saída de
+    `keryx-miner --print-shards very-high:8` rodado contra o arquivo de modelo real (ver §4).
+    Protegida atrás de `shard_poc_activation`.
+  - `shard_poc_activation`: um novo gate de ativação de fork. `never()` no `MAINNET_PARAMS` e no
+    `TESTNET_PARAMS` público compartilhado — este PoC nunca encosta em nenhum dos dois. Definido
+    como `new(1)` só no `SIMNET_PARAMS`, junto com um perfil de ativação PoM/OPoI/série-H
+    completo e internamente consistente, construído especificamente para uma Simnet privada
+    partindo do genesis (o raciocínio de cada campo está documentado inline no diff, incluindo
+    uma divergência corrigida contra os valores de `pom_v4_activation`/`h10_activation` do
+    `TESTNET_PARAMS` público — o binário real do miner ativa esses gates na DAA 500 sob
+    `--testnet`, não na DAA 1 como o `TESTNET_PARAMS` diz atualmente; esse desvio pré-existente
+    está dormente na Testnet real só porque seu tip já está bem além da DAA 500, e não foi
+    copiado pro `SIMNET_PARAMS`).
+
+## 4. Ambiente usado na validação
+
+- Hardware: 2 GPUs NVIDIA na mesma máquina — ordinal CUDA 0 = RTX 3090 (24 GB), ordinal CUDA 1 =
+  RTX 4090 (24 GB). Nesta máquina, o ordinal do driver CUDA não bate com o índice do
+  `nvidia-smi` por padrão; a validação usou `CUDA_DEVICE_ORDER=PCI_BUS_ID` pra fixar isso.
+- Modelo: Kimi-Linear-48B, quantização Q4_K_M, ~29,7 GB de GGUF em disco — grande demais pra
+  caber inteiro numa única placa desta máquina.
+- Divisão: alvo de 8 GB por fatia → 4 fatias. Manifest real (capturado via `--print-shards
+  very-high:8`):
+
+  | Fatia | Camadas | Chunks | Raiz Merkle |
+  |---|---|---|---|
+  | 0 | [0, 7) | 219.852.216 | `a73a38fe1ef0cddc6e108eca25eb1de1adcdc7a65c01f87058530ac06df669b4` |
+  | 1 | [7, 14) | 238.829.076 | `db22407efc04f5d261498afc7acb397c87e692699484a9bcf2a747636adda9e5` |
+  | 2 | [14, 21) | 243.638.100 | `9c3aed4cc240baea0928f8282ea91ce6b0cd275f8286c45c440017c457f8cb8d` |
+  | 3 | [21, 27) | 225.674.672 | `233fdb1f9b551bb7895a0fca931ce5eddd16d87a12980f7e4361e020cfe29ff2` |
+
+- Rede: uma instância Simnet privada e isolada (sem DNS seeders, genesis próprio) — nunca a
+  Testnet ou a Mainnet públicas e compartilhadas.
+- Build: Windows, toolchain MSVC via Visual Studio Developer Shell; `KERYX_LLAMA_SKIP=1` (pula
+  só o build da biblioteca CMake do llama.cpp usada pra servir inferência OPoI — irrelevante pro
+  caminho do kernel CUDA de PoM que este PoC exercita).
+
+## 5. Resultados — comprovados em hardware real
+
+1. **Prova de conceito em processo único** (`keryx-miner/examples/shard_walk_poc.rs`): cada GPU,
+   independentemente, empacotou o manifest da sua fatia, instalou (upload bruto e escopado
+   real), rodou um walk de PoM real na GPU contra um alvo sintético (trivialmente fácil),
+   construiu uma testemunha `PomProofV3` real a partir do walk, e se auto-verificou com a mesma
+   função `verify_proof_v3` que um node usa — sem precisar de node ao vivo nesta etapa. As duas
+   se auto-verificaram como `true`.
+2. **Aceitação real na rede** (loop de mineração gRPC real, contra o node Simnet privado rodando
+   o perfil de `SIMNET_PARAMS` do §3): o node genuinamente aceitou blocos de PoM em nível de
+   fatia pelo caminho real de submissão de blocos, de forma sustentada, com zero rejeições — 817
+   blocos na fatia 0 (GPU0/3090, ~1,05M h/s, kernel `v4 tensor-core`) e 413 blocos na fatia 1
+   (GPU1/4090, ~1,68M h/s), 1.230 no total combinado, 0 rejeitados.
+3. **Checagem de regressão do guard** (`keryx-miner/examples/shard_guard_poc.rs`): instala uma
+   fatia com o manifest correto (funciona), depois tenta reinstalar após remover um nome de
+   tensor do manifest — o índice do host, já em cache, continua refletindo a contagem de chunks
+   correta (maior), então a contagem do segundo gather diverge e o N-guard corretamente recusa
+   instalar um miner, confirmando que um manifest corrompido ou errado não consegue produzir
+   silenciosamente uma prova aceitável.
+
+## 6. O que explicitamente NÃO foi feito — em aberto, incompleto por design
+
+Isto é uma prova de conceito, não uma funcionalidade terminada. Em particular:
+
+- **Nenhuma inferência OPoI distribuída.** Um dispositivo de fatia ainda não consegue, por si
+  só, servir inferência real sobre o modelo completo — a isenção do gate de mineração
+  obrigatória por OPoI (§2) só deixa um processo que só roda fatias pular essa exigência pra
+  *minerar*; ela não faz a inferência funcionar. Um pipeline real estilo ggml-rpc entre fatias
+  (já escopado separadamente como spec §3.3–3.5) é trabalho futuro, fora deste PoC.
+- **O bloco de bootstrap pré-PoM ainda precisa do modelo inteiro.** O primeiríssimo bloco de uma
+  chain nova (abaixo de `pom_activation`) precisa ser minerado pelo caminho legado
+  kHeavyHash+OPoI, que exige um dispositivo segurando o modelo *inteiro* — uma máquina que só
+  tenha dispositivos de fatia não tem, sozinha, caminho pra passar desse bloco.
+- **O deslocamento fatia→tier (`5 + shard_index`) é uma convenção mantida manualmente**, não
+  negociada por nenhum protocolo. A ordem das linhas de `POM_SHARDS_POC` no node precisa bater
+  com a numeração de fatias do miner por acordo, não por nenhum mecanismo on-chain. Uma
+  divergência aqui fica silenciosamente errada, não é rejeitada — essa é uma fraqueza real que um
+  design de produção precisaria fechar.
+- **Não testado além desta configuração exata**: 2 GPUs, 4 fatias, um modelo
+  (Kimi-Linear-48B), uma máquina. O comportamento com mais fatias, mais dispositivos, um modelo
+  diferente, ou fatiamento entre máquinas (em vez de entre GPUs na mesma máquina) não foi
+  explorado.
+- **Nenhum design de recompensa/economia.** A posse parcial de um miner que só minera fatia hoje
+  simplesmente reaproveita, posicionalmente, a tabela de recompensa comum baseada em tier. Se
+  isso é justo ou sólido do ponto de vista da teoria dos jogos, comparado à posse de um miner de
+  tier inteiro, não foi avaliado.
+- **A ativação em `SIMNET_PARAMS` é deliberadamente exclusiva da Simnet.** Estender qualquer
+  parte disso pra uma rede compartilhada (Testnet ou Mainnet) é uma decisão separada e bem
+  maior — governança, tempo de lançamento e compatibilidade retroativa estão todos fora do
+  escopo aqui.
+
+## 7. Onde olhar / como reproduzir
+
+- `keryx-node`, branch `shard-poc`: commit `76aa3c6f` (tabela de tiers de fatia + esqueleto do
+  gate, com uma linha placeholder), commit `ecb0f09e` (dados reais do manifest + o perfil de
+  ativação do `SIMNET_PARAMS` do §3).
+- `keryx-miner`, branch `shard-poc`: commits `3cf1bd4` (registro de fatia + caminho de
+  instalação), `15649ec` (CLI `--shard`/`--print-shards`), `ba2aa2f` (integração na atribuição de
+  tiers e no loop de mineração), `b9c0990` (isenção do gate de OPoI pra dispositivos de fatia),
+  `183d3e5` (correção do re-poll de template em chain ociosa), `645fd5d` (os dois exemplos de
+  diagnóstico do §5).
+- Pra rodar de novo a prova em processo único ou a checagem do guard: `cargo run --example
+  shard_walk_poc --features cuda` / `cargo run --example shard_guard_poc --features cuda` a
+  partir do repositório do miner (ambos aceitam as flags `--gguf-path`, `--target-bytes` e
+  `--mainnet`; usam por padrão o caminho do Kimi-Linear-48B e os gates de DAA estilo testnet
+  usados acima).

--- a/SHARD_POSSESSION_POC.pt-BR.md
+++ b/SHARD_POSSESSION_POC.pt-BR.md
@@ -159,10 +159,10 @@ Isto é uma prova de conceito, não uma funcionalidade terminada. Em particular:
 - `keryx-node`, branch `shard-poc`: commit `76aa3c6f` (tabela de tiers de fatia + esqueleto do
   gate, com uma linha placeholder), commit `ecb0f09e` (dados reais do manifest + o perfil de
   ativação do `SIMNET_PARAMS` do §3).
-- `keryx-miner`, branch `shard-poc`: commits `3cf1bd4` (registro de fatia + caminho de
-  instalação), `15649ec` (CLI `--shard`/`--print-shards`), `ba2aa2f` (integração na atribuição de
-  tiers e no loop de mineração), `b9c0990` (isenção do gate de OPoI pra dispositivos de fatia),
-  `183d3e5` (correção do re-poll de template em chain ociosa), `645fd5d` (os dois exemplos de
+- `keryx-miner`, branch `shard-poc`: commits `3aa1598` (registro de fatia + caminho de
+  instalação), `177a33a` (CLI `--shard`/`--print-shards`), `79099bd` (integração na atribuição de
+  tiers e no loop de mineração), `fba09c8` (isenção do gate de OPoI pra dispositivos de fatia),
+  `af7ebee` (correção do re-poll de template em chain ociosa), `7136086` (os dois exemplos de
   diagnóstico do §5).
 - Pra rodar de novo a prova em processo único ou a checagem do guard: `cargo run --example
   shard_walk_poc --features cuda` / `cargo run --example shard_guard_poc --features cuda` a

--- a/docs/superpowers/plans/2026-09-09-shard-possession-poc.md
+++ b/docs/superpowers/plans/2026-09-09-shard-possession-poc.md
@@ -1,0 +1,1034 @@
+# Shard Possession PoC Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a fixed-size, fingerprinted slice ("shard") of a model's GGUF independently mineable via PoM on one GPU, and accepted by a testnet node — without changing `PomProof`/consensus wire format.
+
+**Architecture:** A shard is a deterministic, layer-aligned byte-range of the canonical GGUF with its own Merkle root (built with the same chunk/tree machinery the miner already uses for whole models, `WeightIndex`, just over a name subset). A shard device skips the miner's existing whole-model/llama-engine machinery entirely and takes a new, simpler path: raw upload of only its own tensors (`load_raw_subset`), its own possession index, its own tier index (5, 6, …, additive to the existing 5-tier table). The node accepts shard blocks by adding rows to its tier table behind a fork gate that is `never()` outside a private testnet — zero new verification code.
+
+**Tech Stack:** Rust (miner: CUDA via `cudarc`; node: existing consensus pipeline). No new external dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-09-09-network-fatia-shard-poc-design.md` (this plan implements sections 1–4 and Testing-plan Phase A only; §3.5 ggml-rpc pipeline and Phase B are a separate follow-up plan).
+
+## Global Constraints
+
+- No change to `PomProof`, block header format (beyond using an already-`u8` `pom_tier`/`proof.tier` field with a higher value), difficulty, cohorts, strikes, or escrow. (Spec §"Explicitly not doing".)
+- The node change is gated behind a new `ForkActivation` that is `never()` on `MAINNET_PARAMS`/`DEVNET`/`SIMNET`; only the user's private testnet params activate it. (Spec §4.)
+- Miner repo root for this plan: `C:\Testnet\keryx-miner\.worktrees\shard-poc` (branch `shard-poc`, off `main`).
+- Node repo root for this plan: `C:\Testnet\keryx-node\.claude\worktrees\shard-poc` (branch `shard-poc`, off `feature/watchdog-relay-v160` — NOT `master`, which is stale at v1.4.5).
+- Every new/modified function below was checked against the actual code in these two worktrees on 2026-09-09 (not the stale `tensor-split` worktree, not `master`). Two corrections vs. the spec doc, found during this planning pass — trust this plan over the spec doc where they differ:
+  1. **`POM_INDICES` (miner `src/pom.rs:1602`) is keyed by `model_id: [u8; 32]`, not by tier.** A shard shares its parent model's `model_id`, so a shard's index cannot live in that map (it would either collide with, or masquerade as, the whole-model index). This plan adds a **separate, device-keyed** shard index store instead (Task 4).
+  2. Line numbers in the spec doc (e.g. `pom_gpu.rs:1533`, `body_validation_in_isolation.rs:222-330`) were read on a slightly different point in history; this plan re-cites the exact lines as they stand in the two `shard-poc` worktrees today. Re-check with `grep -n` before editing if any drift further during execution — other work may land on these branches concurrently.
+
+---
+
+## File Structure
+
+**Miner (`C:\Testnet\keryx-miner\.worktrees\shard-poc`):**
+- Create `src/shard.rs` — shard packing (pure function, no I/O in the packing logic itself beyond the caller-supplied `GgufMeta`).
+- Modify `src/pom.rs` — add `WeightIndex::build_from_gguf_subset`, a device-keyed shard index store.
+- Modify `src/pom_gpu.rs` — add `load_raw_subset`, shard device registry, shard-aware `ensure_installed_inner` branch, shard-aware `current_tier`/index lookup.
+- Modify `src/models.rs` — add `pom_shard_tier_index`.
+- Modify `src/cli.rs` — add `--shard`, `--print-shards` flags.
+- Modify `src/main.rs` — parse `--shard`, register shard devices, handle `--print-shards`.
+- Modify `src/miner.rs` — swap one call site to the new shard-aware index lookup.
+
+**Node (`C:\Testnet\keryx-node\.claude\worktrees\shard-poc`):**
+- Modify `consensus/core/src/config/params.rs` — add `POM_SHARDS_POC`, `shard_poc_activation` field + wiring, extend `pom_tiers()`.
+- Modify `consensus/src/pipeline/body_processor/body_validation_in_isolation.rs` — pass the new activation flag into `pom_tiers(...)`.
+
+---
+
+### Task 1: Shard packing (`src/shard.rs`)
+
+**Files:**
+- Create: `src/shard.rs`
+- Modify: `src/lib.rs` (add `pub mod shard;` — check the existing `pub mod pom;`-style list near the top and insert alongside it, alphabetically or matching the existing convention)
+- Test: inline `#[cfg(test)] mod tests` in `src/shard.rs`
+
+**Interfaces:**
+- Consumes: `crate::gguf::GgufMeta { tensors: HashMap<String, TensorMeta>, tensor_data_offset: u64 }`, `crate::gguf::TensorMeta { offset: u64, nbytes: u64 }`, `GgufMeta::sorted_names(&self) -> Vec<String>` (all already exist, unchanged).
+- Produces: `pub struct ShardManifest { pub index: u16, pub layer_lo: u32, pub layer_hi: u32, pub tensor_names: Vec<String> }`, `pub fn pack_shards(meta: &crate::gguf::GgufMeta, target_bytes: u64) -> anyhow::Result<Vec<ShardManifest>>` — consumed by Task 2 (fingerprint) and Task 6 (CLI/`--print-shards`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+// src/shard.rs
+use std::collections::HashMap;
+use anyhow::{anyhow, Result};
+use crate::gguf::{GgufMeta, TensorMeta};
+
+/// One fixed-size, layer-aligned slice of a model's canonical GGUF. Fully determined by the
+/// GGUF's own tensor directory plus `target_bytes` — no operator choice enters the boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShardManifest {
+    /// Position of this shard among its siblings, 0-based, in ascending layer order.
+    pub index: u16,
+    /// Transformer layer range this shard owns, `[layer_lo, layer_hi)`. Non-layer tensors are
+    /// attached to shard 0 (input side) or the last shard (output side) — see `pack_shards`.
+    pub layer_lo: u32,
+    pub layer_hi: u32,
+    /// Tensor names in this shard, already in canonical (sorted) order.
+    pub tensor_names: Vec<String>,
+}
+
+/// Split a GGUF's tensors into fixed-byte-target, layer-aligned shards.
+///
+/// Grouping rule: tensors named `blk.<N>.*` belong to layer `N`; everything else is
+/// "non-layer" (`token_embd.*` → shard 0, `output*` → last shard). Layers are walked in
+/// numeric order and packed greedily: a shard closes when adding the next layer would push it
+/// over `target_bytes`, unless the shard has no layers yet (a single layer bigger than
+/// `target_bytes` is a hard error — the caller must raise the target). Layer ranges are
+/// contiguous and cover every layer in the GGUF exactly once.
+pub fn pack_shards(meta: &GgufMeta, target_bytes: u64) -> Result<Vec<ShardManifest>> {
+    if target_bytes == 0 {
+        return Err(anyhow!("shard: target_bytes must be > 0"));
+    }
+
+    // Bucket every tensor by layer index; collect non-layer names separately.
+    let mut by_layer: HashMap<u32, Vec<String>> = HashMap::new();
+    let mut input_side: Vec<String> = Vec::new(); // token_embd.*
+    let mut output_side: Vec<String> = Vec::new(); // output*, output_norm.*
+    let mut max_layer: Option<u32> = None;
+
+    for name in meta.sorted_names() {
+        if let Some(rest) = name.strip_prefix("blk.") {
+            let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if !digits.is_empty() && rest.as_bytes().get(digits.len()) == Some(&b'.') {
+                let layer: u32 = digits.parse().map_err(|e| anyhow!("shard: bad layer index in '{name}': {e}"))?;
+                max_layer = Some(max_layer.map_or(layer, |m| m.max(layer)));
+                by_layer.entry(layer).or_default().push(name);
+                continue;
+            }
+        }
+        if name.starts_with("output") {
+            output_side.push(name);
+        } else {
+            input_side.push(name);
+        }
+    }
+    let Some(max_layer) = max_layer else {
+        return Err(anyhow!("shard: GGUF has no 'blk.<N>.*' tensors to shard"));
+    };
+    let n_layers = max_layer + 1;
+
+    let tensor_bytes = |name: &str| -> Result<u64> {
+        meta.tensors.get(name).map(|t: &TensorMeta| t.nbytes).ok_or_else(|| anyhow!("shard: tensor '{name}' missing from GgufMeta"))
+    };
+    let layer_bytes = |l: u32| -> Result<u64> {
+        by_layer.get(&l).ok_or_else(|| anyhow!("shard: layer {l} has no tensors (gap in blk.N numbering)"))?
+            .iter().map(|n| tensor_bytes(n)).sum::<Result<u64>>()
+    };
+
+    let mut shards: Vec<ShardManifest> = Vec::new();
+    let mut cur_names: Vec<String> = input_side.clone();
+    let mut cur_bytes: u64 = input_side.iter().map(|n| tensor_bytes(n)).sum::<Result<u64>>()?;
+    let mut cur_lo: u32 = 0;
+
+    for l in 0..n_layers {
+        let lb = layer_bytes(l)?;
+        if lb > target_bytes {
+            return Err(anyhow!("shard: layer {l} alone is {lb} bytes, over target_bytes={target_bytes} — raise the target"));
+        }
+        let would_be = cur_bytes + lb;
+        let shard_has_layers = cur_lo < l; // at least one layer already accepted into this shard
+        if shard_has_layers && would_be > target_bytes {
+            shards.push(ShardManifest { index: shards.len() as u16, layer_lo: cur_lo, layer_hi: l, tensor_names: { let mut v = cur_names.clone(); v.sort(); v } });
+            cur_names = Vec::new();
+            cur_bytes = 0;
+            cur_lo = l;
+        }
+        cur_names.extend(by_layer[&l].iter().cloned());
+        cur_bytes += lb;
+    }
+    cur_names.extend(output_side.iter().cloned());
+    shards.push(ShardManifest { index: shards.len() as u16, layer_lo: cur_lo, layer_hi: n_layers, tensor_names: { let mut v = cur_names; v.sort(); v } });
+
+    Ok(shards)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(layers: u32, bytes_per_layer: u64, extra: &[(&str, u64)]) -> GgufMeta {
+        let mut tensors = HashMap::new();
+        for l in 0..layers {
+            tensors.insert(format!("blk.{l}.attn.weight"), TensorMeta { offset: 0, nbytes: bytes_per_layer });
+        }
+        for (name, nbytes) in extra {
+            tensors.insert((*name).to_string(), TensorMeta { offset: 0, nbytes: *nbytes });
+        }
+        GgufMeta { tensors, tensor_data_offset: 0 }
+    }
+
+    #[test]
+    fn packs_by_fixed_byte_target() {
+        // 10 layers x 100 bytes, target 250 -> 2 layers per shard except a possible remainder.
+        let m = meta(10, 100, &[("token_embd.weight", 10), ("output.weight", 10)]);
+        let shards = pack_shards(&m, 250).unwrap();
+        // Every layer covered exactly once, ranges contiguous, ranges cover 0..10.
+        let mut lo = 0u32;
+        for s in &shards {
+            assert_eq!(s.layer_lo, lo);
+            assert!(s.layer_hi > s.layer_lo);
+            lo = s.layer_hi;
+        }
+        assert_eq!(lo, 10);
+        // input tensor is in shard 0, output tensor is in the last shard.
+        assert!(shards[0].tensor_names.contains(&"token_embd.weight".to_string()));
+        assert!(shards.last().unwrap().tensor_names.contains(&"output.weight".to_string()));
+    }
+
+    #[test]
+    fn deterministic_same_input_same_output() {
+        let m = meta(7, 50, &[]);
+        let a = pack_shards(&m, 130).unwrap();
+        let b = pack_shards(&m, 130).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_target_gives_different_boundaries() {
+        let m = meta(7, 50, &[]);
+        let small = pack_shards(&m, 60).unwrap();
+        let big = pack_shards(&m, 400).unwrap();
+        assert!(small.len() > big.len());
+    }
+
+    #[test]
+    fn single_layer_too_big_is_an_error() {
+        let m = meta(3, 500, &[]);
+        let err = pack_shards(&m, 100).unwrap_err();
+        assert!(err.to_string().contains("over target_bytes"));
+    }
+
+    #[test]
+    fn tensor_names_within_a_shard_are_sorted() {
+        let m = meta(3, 10, &[]);
+        let shards = pack_shards(&m, 1000).unwrap();
+        for s in &shards {
+            let mut sorted = s.tensor_names.clone();
+            sorted.sort();
+            assert_eq!(s.tensor_names, sorted);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the module and run the tests to verify they fail to compile (module doesn't exist yet), then pass**
+
+Find the module list in `src/lib.rs` (`grep -n "^pub mod " src/lib.rs`) and add `pub mod shard;` alongside the existing entries (e.g. next to `pub mod pom;`).
+
+Run: `cargo test --lib shard::tests -- --nocapture`
+Expected: 5 tests pass (`packs_by_fixed_byte_target`, `deterministic_same_input_same_output`, `different_target_gives_different_boundaries`, `single_layer_too_big_is_an_error`, `tensor_names_within_a_shard_are_sorted`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shard.rs src/lib.rs
+git commit -m "feat(shard): add fixed-size, layer-aligned shard packing"
+```
+
+---
+
+### Task 2: Shard-scoped `WeightIndex` (`src/pom.rs`)
+
+**Files:**
+- Modify: `src/pom.rs` (functions `open_existing_tree` at line 926, `WeightIndex::build_from_gguf` at line 1021 — verify with `grep -n "fn open_existing_tree\|pub fn build_from_gguf\b" src/pom.rs` before editing, in case line numbers drifted)
+- Test: extend the existing `#[cfg(test)] mod tests` in `src/pom.rs` (already has a `synth_index`-style helper per the design doc — search for it with `grep -n "fn synth_index\|ChunkSource::Ram" src/pom.rs` and reuse its pattern)
+
+**Interfaces:**
+- Consumes: `crate::gguf::GgufMeta`, existing `WeightIndex` fields/methods (all unchanged).
+- Produces: `pub fn WeightIndex::build_from_gguf_subset(path: &str, model_id: [u8; 32], tensor_names: &[String], tree_filename: &str) -> Result<Self>` — consumed by Task 4's shard install path.
+
+This task **refactors** `open_existing_tree` and `build_from_gguf` to accept an optional tensor-name filter and an explicit tree filename, without changing behavior for existing callers (they keep calling the unchanged `build_from_gguf(path, model_id)`, which becomes a thin wrapper).
+
+- [ ] **Step 1: Write the failing test** (subset root matches a manually-built dense tree over the same subset)
+
+Add to `src/pom.rs`'s existing test module:
+
+```rust
+    #[test]
+    fn build_from_gguf_subset_root_matches_full_dense_tree_over_same_leaves() {
+        // Build a tiny synthetic GGUF-like fixture on disk (reuse whatever helper the existing
+        // `build_from_gguf`-based tests in this file already use to write a real temp GGUF —
+        // search this file for an existing test that calls `WeightIndex::build_from_gguf` with a
+        // real path, e.g. near line 1751/1851, and copy its fixture-writing helper verbatim).
+        // With that helper (call it `write_synthetic_gguf(path, tensor_sizes: &[(&str, u64)])`):
+        let dir = tempfile::tempdir().unwrap();
+        let gguf_path = dir.path().join("model.gguf");
+        write_synthetic_gguf(&gguf_path, &[
+            ("blk.0.a", 320), ("blk.0.b", 320), ("blk.1.a", 320), ("output.weight", 320),
+        ]);
+        let model_id = [7u8; 32];
+
+        // Full index over everything.
+        let full = WeightIndex::build_from_gguf(gguf_path.to_str().unwrap(), model_id).unwrap();
+
+        // Subset index over just layer 0's tensors + output (skip blk.1.a).
+        let subset_names = vec!["blk.0.a".to_string(), "blk.0.b".to_string(), "output.weight".to_string()];
+        let subset = WeightIndex::build_from_gguf_subset(
+            gguf_path.to_str().unwrap(), model_id, &subset_names, "pom-tree.shard0-test.bin",
+        ).unwrap();
+
+        // Subset root must differ from the full root (fewer leaves) but subset n_chunks must
+        // equal exactly the chunk count of the 3 included tensors (320*3/32 = 30).
+        assert_ne!(subset.r_t, full.r_t);
+        assert_eq!(subset.n_chunks, 30);
+    }
+```
+
+If no existing `write_synthetic_gguf`-style helper exists in this file, write one now (a minimal GGUF writer matching whatever `GgufMeta::read` expects — check `src/gguf.rs`'s reader for the exact header format before writing it, since this must round-trip through the real parser, not a mock).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib pom::tests::build_from_gguf_subset_root_matches_full_dense_tree_over_same_leaves`
+Expected: FAIL — `build_from_gguf_subset` not found.
+
+- [ ] **Step 3: Implement — thread an optional subset through `open_existing_tree` and `build_from_gguf`**
+
+In `src/pom.rs`, change the signature of `open_existing_tree` (currently `fn open_existing_tree(tree_path: &Path, gguf_path: &str, expected_model_id: [u8; 32]) -> Result<WeightIndex>`, line 926) to add a subset parameter, and filter `names` right after it's computed (line 929: `let names = meta.sorted_names();`):
+
+```rust
+fn open_existing_tree(
+    tree_path: &Path,
+    gguf_path: &str,
+    expected_model_id: [u8; 32],
+    subset: Option<&[String]>,
+) -> Result<WeightIndex> {
+    let mut file = File::open(gguf_path)?;
+    let meta = crate::gguf::GgufMeta::read(&mut file)?;
+    let names: Vec<String> = match subset {
+        Some(s) => {
+            let want: std::collections::HashSet<&str> = s.iter().map(|x| x.as_str()).collect();
+            meta.sorted_names().into_iter().filter(|n| want.contains(n.as_str())).collect()
+        }
+        None => meta.sorted_names(),
+    };
+    // ...rest of the function body is UNCHANGED from here on (n_chunks/table loop, checkpoint
+    // math, mmap, WeightIndex construction) — it already only depends on `names`, not on
+    // "all tensors in the file".
+```
+
+The one call site of `open_existing_tree` (inside `build_from_gguf`, line 1039) becomes `open_existing_tree(&tree_path, path, model_id, subset)` once `build_from_gguf` itself gains the parameter (next).
+
+Rename the existing `pub fn build_from_gguf(path: &str, model_id: [u8; 32]) -> Result<Self>` body to a private `fn build_from_gguf_impl(path: &str, model_id: [u8; 32], subset: Option<&[String]>, tree_filename: &str) -> Result<Self>`, with exactly two changes inside the existing body:
+
+1. Line ~1023, `let tree_path = dir.join("pom-tree.bin");` → `let tree_path = dir.join(tree_filename);`
+2. Line ~1054, `let names = meta.sorted_names(); // canonical order` → the same subset-filtering snippet as above (`match subset { Some(s) => ..., None => meta.sorted_names() }`).
+3. The `open_existing_tree(&tree_path, path, model_id)` call (in the "reuse existing checkpoint tree" branch, ~line 1039) becomes `open_existing_tree(&tree_path, path, model_id, subset)`.
+
+Then add two thin public wrappers where the old `pub fn build_from_gguf` used to be:
+
+```rust
+    pub fn build_from_gguf(path: &str, model_id: [u8; 32]) -> Result<Self> {
+        Self::build_from_gguf_impl(path, model_id, None, "pom-tree.bin")
+    }
+
+    /// Same as `build_from_gguf`, but over only `tensor_names` (already sorted or not — this
+    /// re-sorts). `tree_filename` must be unique per (model, shard) pair so different shards'
+    /// checkpoint trees never collide on disk next to the same GGUF.
+    pub fn build_from_gguf_subset(
+        path: &str,
+        model_id: [u8; 32],
+        tensor_names: &[String],
+        tree_filename: &str,
+    ) -> Result<Self> {
+        Self::build_from_gguf_impl(path, model_id, Some(tensor_names), tree_filename)
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test --lib pom::tests -- --nocapture`
+Expected: all existing `pom::tests` still pass (unchanged behavior for `build_from_gguf`/whole-model callers), plus the new subset test passes.
+
+- [ ] **Step 5: Add a device-keyed shard index store** (needed by Task 4; belongs in `pom.rs` next to `POM_INDICES` at line 1602)
+
+```rust
+/// Possession index for a SHARD, keyed by the CUDA device mining it (not by model_id — a shard
+/// shares its parent model's model_id, so keying by model_id would collide with or shadow the
+/// whole-model entry in `POM_INDICES`). This phase is one shard per device per process, so
+/// device-keying is sufficient; a future multi-shard-per-device design would need a composite key.
+static POM_SHARD_INDICES: OnceLock<Mutex<HashMap<u32, Arc<WeightIndex>>>> = OnceLock::new();
+
+fn pom_shard_indices() -> &'static Mutex<HashMap<u32, Arc<WeightIndex>>> {
+    POM_SHARD_INDICES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn set_shard_index(device_id: u32, index: WeightIndex) {
+    if let Ok(mut g) = pom_shard_indices().lock() {
+        g.insert(device_id, Arc::new(index));
+    }
+}
+
+pub fn active_shard_index(device_id: u32) -> Option<Arc<WeightIndex>> {
+    pom_shard_indices().lock().ok()?.get(&device_id).cloned()
+}
+```
+
+(Mirror the exact style of `set_index`/`active_index_for_model`/`clear_index` at lines 1609/1616/1623 — read them first with `grep -n -A6 "pub fn set_index" src/pom.rs` so the new functions match the codebase's existing locking idiom exactly.)
+
+- [ ] **Step 6: Run full pom.rs test suite, then commit**
+
+Run: `cargo test --lib pom::`
+Expected: PASS, no regressions.
+
+```bash
+git add src/pom.rs
+git commit -m "feat(pom): add WeightIndex::build_from_gguf_subset + device-keyed shard index store"
+```
+
+---
+
+### Task 3: Scoped raw upload (`src/pom_gpu.rs`)
+
+**Files:**
+- Modify: `src/pom_gpu.rs` (new method next to `pub fn load_raw` at line 635 — re-verify line with `grep -n "pub fn load_raw\b" src/pom_gpu.rs`)
+
+**Interfaces:**
+- Consumes: `crate::gguf::GgufMeta`, existing `PomGpuMiner` struct/fields (unchanged), `select_pom_kernel` (unchanged).
+- Produces: `pub fn PomGpuMiner::load_raw_subset(gguf_path: &str, device_id: usize, tensor_names: &[String]) -> Result<Self>` — consumed by Task 4.
+
+This is not independently unit-testable (it opens a real CUDA device) — same category as the existing `load_raw`/`load_llama`, which have no unit tests either (search confirms: `grep -n "fn load_raw\|#\[test\]" src/pom_gpu.rs` shows no test directly exercising `load_raw`). Verification for this task is the Task 4 guard-order test (compile-time / mock-level) plus the Task 8 hardware integration pass.
+
+- [ ] **Step 1: Implement, mirroring `load_raw` exactly except for a name filter**
+
+Read the existing `load_raw` body first (`src/pom_gpu.rs:635-681`) to copy it precisely, then add, directly below it:
+
+```rust
+    /// Same as `load_raw`, but uploads only `tensor_names` instead of every tensor in the GGUF.
+    /// Used for a shard: the walk gathers over exactly this device's own slice of the canonical
+    /// bytes, so no cross-GPU pointer dependency exists and no other GPU needs to be involved.
+    pub fn load_raw_subset(gguf_path: &str, device_id: usize, tensor_names: &[String]) -> Result<Self> {
+        let ctx = CudaContext::new(device_id)?;
+        ctx.bind_to_thread()?;
+        let stream = ctx.default_stream();
+
+        let mut file = std::fs::File::open(gguf_path)?;
+        let meta = crate::gguf::GgufMeta::read(&mut file)?;
+        let want: std::collections::HashSet<&str> = tensor_names.iter().map(|s| s.as_str()).collect();
+        let names: Vec<String> = meta.sorted_names().into_iter().filter(|n| want.contains(n.as_str())).collect();
+        if names.len() != tensor_names.len() {
+            return Err(anyhow!(
+                "PoM GPU: shard subset requested {} tensors, but only {} were found in the GGUF — manifest/GGUF mismatch",
+                tensor_names.len(), names.len()
+            ));
+        }
+
+        let mut uploads: Vec<CudaSlice<u8>> = Vec::with_capacity(names.len());
+        let mut bases: Vec<u64> = Vec::new();
+        let mut prefix: Vec<u64> = vec![0];
+        let mut host_buf: Vec<u8> = Vec::new();
+        for name in &names {
+            let t = &meta.tensors[name];
+            let chunks = t.nbytes / CHUNK_BYTES as u64;
+            if chunks == 0 {
+                continue;
+            }
+            host_buf.resize(t.nbytes as usize, 0);
+            crate::pom::read_exact_at(&file, &mut host_buf, meta.tensor_data_offset + t.offset)?;
+            let dev = stream.clone_htod(host_buf.as_slice())?;
+            bases.push(dev.device_ptr(&stream).0 as u64);
+            uploads.push(dev);
+            prefix.push(prefix.last().unwrap() + chunks);
+        }
+        let n_total_chunks = *prefix.last().unwrap();
+        if n_total_chunks == 0 {
+            return Err(anyhow!("PoM GPU: shard produced 0 chunks"));
+        }
+
+        let bases_dev = stream.clone_htod(bases.as_slice())?;
+        let prefix_dev = stream.clone_htod(prefix.as_slice())?;
+        let kernel = select_pom_kernel(device_id)?;
+
+        Ok(Self {
+            ctx,
+            stream,
+            kernel,
+            bases_dev,
+            prefix_dev,
+            t_count: bases.len() as u32,
+            n_total_chunks,
+            _uploads: uploads,
+        })
+    }
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cargo build --features cuda 2>&1 | tail -50`
+Expected: clean build (this function has no callers yet, so it must compile standalone — check for unused-function warnings, which are expected and fine until Task 4 wires a caller).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pom_gpu.rs
+git commit -m "feat(pom_gpu): add load_raw_subset for shard-scoped raw upload"
+```
+
+---
+
+### Task 4: Shard device registry + install path (`src/pom_gpu.rs`)
+
+**Files:**
+- Modify: `src/pom_gpu.rs` — add shard registry next to `MINING_TIERS` (line 1045), branch `ensure_installed_inner` (line 1434), branch `current_tier` (line 1301), add `active_index_for_device` helper.
+
+**Interfaces:**
+- Consumes: `Task 1`'s `crate::shard::ShardManifest`, `Task 2`'s `crate::pom::{WeightIndex::build_from_gguf_subset, set_shard_index, active_shard_index}`, `Task 3`'s `PomGpuMiner::load_raw_subset`, `Task 5`'s `crate::models::pom_shard_tier_index`.
+- Produces:
+  - `pub fn set_shard_for_device(device_id: u32, model_id: [u8; 32], gguf_path: String, target_bytes: u64, shard: crate::shard::ShardManifest)`
+  - `pub fn shard_for_device(device_id: u32) -> Option<ShardAssignment>` (new `pub struct ShardAssignment { model_id: [u8;32], gguf_path: String, target_bytes: u64, manifest: crate::shard::ShardManifest }`)
+  - `pub fn active_index_for_device(device_id: u32, model_id: [u8; 32]) -> Option<Arc<crate::pom::WeightIndex>>` — consumed by Task 7 (miner.rs call site).
+
+- [ ] **Step 1: Add the shard registry, next to `MINING_TIERS`/`mining_tiers()` (line 1045)**
+
+```rust
+/// A device's shard assignment (from `--shard`). Disjoint from `MINING_TIERS`: a device is
+/// either a whole-tier miner (existing path) or a shard miner (this path), never both.
+#[derive(Clone)]
+pub struct ShardAssignment {
+    pub model_id: [u8; 32],
+    pub gguf_path: String,
+    pub target_bytes: u64,
+    pub manifest: crate::shard::ShardManifest,
+}
+
+static SHARD_ASSIGNMENTS: OnceLock<Mutex<HashMap<u32, ShardAssignment>>> = OnceLock::new();
+
+fn shard_assignments() -> &'static Mutex<HashMap<u32, ShardAssignment>> {
+    SHARD_ASSIGNMENTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn set_shard_for_device(device_id: u32, model_id: [u8; 32], gguf_path: String, target_bytes: u64, manifest: crate::shard::ShardManifest) {
+    if let Ok(mut g) = shard_assignments().lock() {
+        g.insert(device_id, ShardAssignment { model_id, gguf_path, target_bytes, manifest });
+    }
+}
+
+pub fn shard_for_device(device_id: u32) -> Option<ShardAssignment> {
+    shard_assignments().lock().ok()?.get(&device_id).cloned()
+}
+
+/// The possession index for whatever this device is mining — its shard's index if it's a shard
+/// device, else the whole-model index (existing `active_index_for_model` path). Single lookup
+/// point so callers (the mining loop) don't need to know which kind of device they're on.
+pub fn active_index_for_device(device_id: u32, model_id: [u8; 32]) -> Option<Arc<crate::pom::WeightIndex>> {
+    if shard_for_device(device_id).is_some() {
+        crate::pom::active_shard_index(device_id)
+    } else {
+        crate::pom::active_index_for_model(&model_id)
+    }
+}
+```
+
+`Arc` must be in scope in `pom_gpu.rs` — check the existing `use std::sync::{..., Arc, ...};` at the top of the file (it's almost certainly already imported, since `Arc<CudaContext>` is used at line 619); if not, add it.
+
+- [ ] **Step 2: Branch `ensure_installed_inner` (line 1434) — shard devices take a separate, simpler path**
+
+At the very top of `fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {`, right after the existing `if inference_paused() { return false; }` (line 1437-1439), insert:
+
+```rust
+    if let Some(shard) = shard_for_device(device_id) {
+        return ensure_shard_installed_inner(device_id, &shard);
+    }
+```
+
+Then add a new sibling function, right after `ensure_installed_inner` ends (after line 1621's closing `}`):
+
+```rust
+/// Install path for a shard device: raw scoped upload only, no llama engine, no era-crossing,
+/// own possession index (keyed by device, not model_id — see `pom.rs::POM_SHARD_INDICES`).
+fn ensure_shard_installed_inner(device_id: u32, shard: &ShardAssignment) -> bool {
+    if is_oom_banlisted(device_id, &shard.model_id) {
+        return false;
+    }
+    if crate::pom::active_shard_index(device_id).is_none() {
+        let _guard = match index_build_lock().lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if crate::pom::active_shard_index(device_id).is_none() {
+            let tree_filename = format!("pom-tree.shard{}-{}g.bin", shard.manifest.index, shard.target_bytes / 1_000_000_000);
+            info!(
+                "PoM[gpu{}]: building host index for shard {} (layers {}..{}) — this can take a while...",
+                device_id, shard.manifest.index, shard.manifest.layer_lo, shard.manifest.layer_hi
+            );
+            match crate::pom::WeightIndex::build_from_gguf_subset(&shard.gguf_path, shard.model_id, &shard.manifest.tensor_names, &tree_filename) {
+                Ok(idx) => {
+                    info!("PoM[gpu{}]: shard {} host index ready — N={} chunks", device_id, shard.manifest.index, idx.n_chunks);
+                    crate::pom::set_shard_index(device_id, idx);
+                }
+                Err(e) => {
+                    log::error!("PoM[gpu{}]: shard {} host index build failed: {}", device_id, shard.manifest.index, e);
+                    return false;
+                }
+            }
+        }
+    }
+
+    // Shard devices never run the llama engine and never zero-dup: raw scoped upload only.
+    info!(
+        "PoM[gpu{}]: shard {}/{} — walk uses a raw scoped upload (no zero-dup, no llama engine)",
+        device_id, shard.manifest.index, /* total shard count isn't known to this device in
+        this phase — each process is handed exactly one shard via --shard; log index only */ shard.manifest.index
+    );
+    let loaded = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        PomGpuMiner::load_raw_subset(&shard.gguf_path, device_id as usize, &shard.manifest.tensor_names)
+    }));
+    let gm = match loaded {
+        Ok(Ok(gm)) => gm,
+        Ok(Err(e)) => {
+            log::error!("PoM[gpu{}]: shard {} miner load failed: {}", device_id, shard.manifest.index, e);
+            oom_banlist_add(device_id, shard.model_id);
+            return false;
+        }
+        Err(_) => {
+            log::error!("PoM[gpu{}]: shard {} miner load panicked (likely OOM)", device_id, shard.manifest.index);
+            oom_banlist_add(device_id, shard.model_id);
+            return false;
+        }
+    };
+    let n = gm.n_chunks();
+    if let Some(idx) = crate::pom::active_shard_index(device_id) {
+        if n != idx.n_chunks {
+            log::error!(
+                "PoM[gpu{}]: shard {} gather N={} != shard index N={} — refusing to mine",
+                device_id, shard.manifest.index, n, idx.n_chunks
+            );
+            return false;
+        }
+    }
+    install(device_id, gm);
+    info!("PoM[gpu{}]: shard {} miner ready — N={} chunks resident", device_id, shard.manifest.index, n);
+    true
+}
+```
+
+Before writing this, run `grep -n "fn is_oom_banlisted\|fn oom_banlist_add\|fn index_build_lock\|fn install\b\|n_chunks(&self)" src/pom_gpu.rs` to confirm these helper names/signatures exactly (they are used unchanged from the existing `ensure_installed_inner`/its neighborhood — copy the exact call shape, e.g. whether `oom_banlist_add` takes `model_id` by value or reference, from its existing call site at line 1590).
+
+- [ ] **Step 3: Branch `current_tier` (line 1301) for shard devices**
+
+Current body:
+```rust
+pub fn current_tier(device_id: u32, daa: u64) -> Option<u8> {
+    let model_id = mining_tiers().lock().ok()?.get(&device_id).map(|(id, _)| *id)?;
+    crate::models::pom_tier_index(&model_id, daa)
+}
+```
+
+Change to:
+```rust
+pub fn current_tier(device_id: u32, daa: u64) -> Option<u8> {
+    if let Some(shard) = shard_for_device(device_id) {
+        return crate::models::pom_shard_tier_index(&shard.model_id, shard.target_bytes, shard.manifest.index, daa);
+    }
+    let model_id = mining_tiers().lock().ok()?.get(&device_id).map(|(id, _)| *id)?;
+    crate::models::pom_tier_index(&model_id, daa)
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cargo build --features cuda 2>&1 | tail -80`
+Expected: clean build (still no CLI/main.rs wiring yet — Task 5's `pom_shard_tier_index` must exist first for this to compile; if doing tasks in order, do Task 5 before this build step, or stub `pom_shard_tier_index` temporarily and finish it properly in Task 5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pom_gpu.rs
+git commit -m "feat(pom_gpu): shard device registry + shard-aware install/current_tier paths"
+```
+
+---
+
+### Task 5: Shard tier index (`src/models.rs`)
+
+**Files:**
+- Modify: `src/models.rs` (next to `pom_tier_index` at line 158)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `pub fn pom_shard_tier_index(model_id: &[u8; 32], target_bytes: u64, shard_index: u16, daa: u64) -> Option<u8>` — consumed by Task 4.
+
+This function's output **must match, index-for-index, the order the node pins in `POM_SHARDS_POC`** (Task 9) — that table's row order is what `proof.tier` numbers actually mean on-chain. For this POC there is exactly one sharded model/target combination, so the mapping is trivial; document that constraint so nobody adds a second sharded model without updating both sides together.
+
+- [ ] **Step 1: Write the failing test**
+
+Add near the existing `pom_tier_index` tests (search `grep -n "mod tests" src/models.rs`):
+
+```rust
+    #[test]
+    fn pom_shard_tier_index_offsets_from_h6_table_size() {
+        let daa = crate::pom::pom_v3_activation_daa(); // any DAA at/after H6
+        // Shard 0 and shard 1 of the POC model land at 5 and 6 (H6 table has 5 whole-tier rows).
+        assert_eq!(pom_shard_tier_index(&KIMI_LINEAR_48B.model_id, POC_SHARD_TARGET_BYTES, 0, daa), Some(5));
+        assert_eq!(pom_shard_tier_index(&KIMI_LINEAR_48B.model_id, POC_SHARD_TARGET_BYTES, 1, daa), Some(6));
+        // Wrong model_id -> None.
+        assert_eq!(pom_shard_tier_index(&QWEN3_6_27B.model_id, POC_SHARD_TARGET_BYTES, 0, daa), None);
+        // Wrong target_bytes -> None (not the pinned POC target).
+        assert_eq!(pom_shard_tier_index(&KIMI_LINEAR_48B.model_id, POC_SHARD_TARGET_BYTES + 1, 0, daa), None);
+        // Before H6 activation -> None.
+        assert_eq!(pom_shard_tier_index(&KIMI_LINEAR_48B.model_id, POC_SHARD_TARGET_BYTES, 0, 0), None);
+    }
+```
+
+(`KIMI_LINEAR_48B` and `QWEN3_6_27B` are the existing `ModelSpec` statics already used elsewhere in this file's tests, e.g. line 341/347 — reuse them, don't redefine.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --lib models::tests::pom_shard_tier_index_offsets_from_h6_table_size`
+Expected: FAIL — `pom_shard_tier_index`/`POC_SHARD_TARGET_BYTES` not found.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// The one (model, target_bytes) combination this POC shards. 8 GiB, matching the spec's
+/// suggested target for Kimi-Linear-48B on a 24 GB card (raw-scoped upload leaves headroom for
+/// the rest of the process). A second sharded model/target needs a second constant here AND a
+/// matching second block of rows in the node's `POM_SHARDS_POC` (keryx-node
+/// consensus/core/src/config/params.rs) — the two must stay in lockstep by construction; there
+/// is no dynamic negotiation in this phase.
+pub const POC_SHARD_TARGET_BYTES: u64 = 8 * 1_000_000_000;
+
+/// Shard tier index for the POC sharded model. Mirrors the node's `POM_SHARDS_POC` row order
+/// (index 0 -> tier 5, index 1 -> tier 6, ... immediately after the 5-row H6 table). `None` for
+/// any model/target this POC doesn't shard, or before the H6 gate.
+pub fn pom_shard_tier_index(model_id: &[u8; 32], target_bytes: u64, shard_index: u16, daa: u64) -> Option<u8> {
+    if daa < crate::pom::pom_v3_activation_daa() {
+        return None;
+    }
+    if *model_id != KIMI_LINEAR_48B.model_id || target_bytes != POC_SHARD_TARGET_BYTES {
+        return None;
+    }
+    5u8.checked_add(shard_index as u8)
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test --lib models::tests::pom_shard_tier_index_offsets_from_h6_table_size`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models.rs
+git commit -m "feat(models): add pom_shard_tier_index for the POC sharded model"
+```
+
+---
+
+### Task 6: CLI flags (`src/cli.rs`)
+
+**Files:**
+- Modify: `src/cli.rs` (add flags near `force_model`, line 43-51)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `opt.shard: Option<String>`, `opt.print_shards: Option<String>` — consumed by Task 7.
+
+- [ ] **Step 1: Add the two flags**, matching the existing `force_model` style exactly (same struct, same `help_heading`):
+
+```rust
+    #[clap(
+        long = "shard",
+        value_name = "TIER:TARGET_GIB:IDX[,TIER:TARGET_GIB:IDX...]",
+        help = "Mine one fixed-size shard of a model instead of the whole tier (CUDA-driver order, CSV): \
+                e.g. --shard very-high:8:0 -> GPU0 mines shard 0 of an 8 GiB split of the very-high model. \
+                A GPU listed here mines ONLY its shard, never the whole tier. Requires the model's GGUF to \
+                be present (combine with --force-model naming the same tier so it gets prefetched).",
+        help_heading = "OPoI / Inference"
+    )]
+    pub shard: Option<String>,
+
+    #[clap(
+        long = "print-shards",
+        value_name = "TIER:TARGET_GIB",
+        help = "Compute and print the shard manifest (layer ranges, chunk counts, Merkle roots) for a \
+                tier at a given byte target, then exit without mining. Used to produce the rows pinned \
+                into a private testnet node's shard tier table.",
+        help_heading = "OPoI / Inference"
+    )]
+    pub print_shards: Option<String>,
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cargo build --features cuda 2>&1 | tail -30`
+Expected: clean build (flags parsed but unused yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli.rs
+git commit -m "feat(cli): add --shard and --print-shards flags"
+```
+
+---
+
+### Task 7: Wire `--shard` and `--print-shards` into `main.rs` and the mining loop
+
+**Files:**
+- Modify: `src/main.rs` (two insertion points, both inside the `#[cfg(any(feature = "cuda", ...))]` block — the CPU-only and Vulkan cfg blocks are NOT touched, this POC targets CUDA only)
+- Modify: `src/miner.rs` (one call-site swap, line 523)
+
+**Interfaces:**
+- Consumes: `crate::shard::pack_shards`, `crate::pom_gpu::{set_shard_for_device, active_index_for_device}`, `opt.shard`, `opt.print_shards`.
+- Produces: nothing new (this is the integration task).
+
+- [ ] **Step 1: `--print-shards` early exit**
+
+Find where `Opt::parse()` runs in `main.rs` (`grep -n "Opt::parse()" src/main.rs`) — right after it, before any network/GPU setup, insert:
+
+```rust
+    if let Some(spec) = opt.print_shards.as_deref() {
+        let parts: Vec<&str> = spec.split(':').collect();
+        let (tier_name, target_gib) = match parts.as_slice() {
+            [t, g] => (*t, g.parse::<u64>().map_err(|e| format!("--print-shards: bad TARGET_GIB: {e}"))?),
+            _ => return Err("--print-shards expects TIER:TARGET_GIB, e.g. very-high:8".into()),
+        };
+        let tier = parse_tier_name(tier_name).ok_or_else(|| format!("--print-shards: unrecognised tier '{tier_name}'"))?;
+        let spec = keryx_miner::models::spec_for_tier(tier);
+        let gguf_path = keryx_miner::slm::gguf_path_for(spec).to_string_lossy().into_owned();
+        if !std::path::Path::new(&gguf_path).exists() {
+            return Err(format!("--print-shards: {gguf_path} not found — run once without --print-shards first so the model is fetched, then retry").into());
+        }
+        let mut file = std::fs::File::open(&gguf_path)?;
+        let meta = keryx_miner::gguf::GgufMeta::read(&mut file)?;
+        let target_bytes = target_gib * 1_000_000_000;
+        let shards = keryx_miner::shard::pack_shards(&meta, target_bytes)
+            .map_err(|e| format!("--print-shards: packing failed: {e}"))?;
+        println!("model_id = {}", hex::encode(spec.model_id));
+        println!("target_bytes = {target_bytes}");
+        for s in &shards {
+            let tree_filename = format!("pom-tree.shard{}-{}g.bin", s.index, target_gib);
+            let idx = keryx_miner::pom::WeightIndex::build_from_gguf_subset(&gguf_path, spec.model_id, &s.tensor_names, &tree_filename)?;
+            println!(
+                "shard {} layers=[{},{}) n_chunks={} root={}",
+                s.index, s.layer_lo, s.layer_hi, idx.n_chunks, hex::encode(idx.r_t)
+            );
+        }
+        return Ok(());
+    }
+```
+
+Check the exact function signature `main.rs` uses for its top-level error type (grep for `fn main(` and the surrounding `-> Result<..., ...>` or similar) — `.into()`/`?` above must match whatever error type that function returns; adjust if it's not a plain `String`-convertible boxed error (the existing code around line 1337-1341 already does `return Err(e.into())` in the same function, so mirror that exactly).
+
+- [ ] **Step 2: Register shard devices after the existing tier-assignment loop** (inside the `#[cfg(any(feature = "cuda", all(feature = "cuda-bridge-client", not(feature = "vulkan"))))]` block, right after the loop ending at line 1466 that calls `set_mining_tier`/`set_device_tier`)
+
+```rust
+    // --shard: additive per-device override. A device named here mines ONLY its shard (never
+    // the whole tier) — the tier-assignment loop above already ensured its model's GGUF is on
+    // disk (via --force-model naming the same tier), which load_raw_subset needs.
+    if let Some(raw) = opt.shard.as_deref() {
+        for entry in raw.split(',') {
+            let parts: Vec<&str> = entry.trim().split(':').collect();
+            let (tier_name, target_gib_s, idx_s) = match parts.as_slice() {
+                [t, g, i] => (*t, *g, *i),
+                _ => {
+                    warn!("--shard: malformed entry '{entry}' (want TIER:TARGET_GIB:IDX) — ignoring.");
+                    continue;
+                }
+            };
+            let (Some(tier), Ok(target_gib), Ok(idx)) =
+                (parse_tier_name(tier_name), target_gib_s.parse::<u64>(), idx_s.parse::<u16>())
+            else {
+                warn!("--shard: malformed entry '{entry}' — ignoring.");
+                continue;
+            };
+            let spec = keryx_miner::models::spec_for_tier(tier);
+            let gguf_path = keryx_miner::slm::gguf_path_for(spec).to_string_lossy().into_owned();
+            let target_bytes = target_gib * 1_000_000_000;
+            let mut file = match std::fs::File::open(&gguf_path) {
+                Ok(f) => f,
+                Err(e) => { warn!("--shard: cannot open {gguf_path}: {e} — ignoring entry '{entry}'."); continue; }
+            };
+            let meta = match keryx_miner::gguf::GgufMeta::read(&mut file) {
+                Ok(m) => m,
+                Err(e) => { warn!("--shard: cannot parse {gguf_path}: {e} — ignoring entry '{entry}'."); continue; }
+            };
+            let shards = match keryx_miner::shard::pack_shards(&meta, target_bytes) {
+                Ok(s) => s,
+                Err(e) => { warn!("--shard: packing failed for '{entry}': {e} — ignoring."); continue; }
+            };
+            let Some(manifest) = shards.into_iter().find(|s| s.index == idx) else {
+                warn!("--shard: index {idx} out of range for '{entry}' — ignoring.");
+                continue;
+            };
+            // Device id: --shard is positional-CSV like --force-model, so its Nth entry (in
+            // parse order) targets CUDA device N. This mirrors forced_tiers' indexing exactly.
+            let device_id = raw.split(',').position(|e| e.trim() == entry.trim()).unwrap_or(0) as u32;
+            info!("--shard: GPU {device_id} -> shard {idx} of {} ({target_gib} GiB target, layers [{},{}))", spec.dir_name, manifest.layer_lo, manifest.layer_hi);
+            keryx_miner::pom_gpu::set_shard_for_device(device_id, spec.model_id, gguf_path, target_bytes, manifest);
+        }
+    }
+```
+
+Note on `device_id` derivation above: this positional scheme is simple but fragile if two entries are textually identical; for this POC (one shard per process, one `--shard` entry per invocation per the design's "two processes" model) this is acceptable — flag it as a known simplification, not a bug, in the commit message.
+
+- [ ] **Step 3: Swap the miner.rs call site to the shard-aware lookup** (line 523)
+
+Current:
+```rust
+                                let idx = keryx_miner::pom::active_index_for_model(&model_id)?;
+```
+Change to:
+```rust
+                                let idx = keryx_miner::pom_gpu::active_index_for_device(worker_device_id, model_id)?;
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cargo build --features cuda 2>&1 | tail -80`
+Expected: clean build.
+
+- [ ] **Step 5: Unit-test `--shard`/`--print-shards` CLI parsing behavior in isolation**
+
+Since the parsing logic above lives inline in `main.rs`'s `main()` (not a free function), and `main.rs` functions are typically not directly unit-tested here (confirm: `grep -n "#\[cfg(test)\]" src/main.rs` — if there is no existing test module in `main.rs`, this codebase's convention is to keep `main.rs` parsing logic thin and tested via the CLI/integration path, not unit tests). If that's confirmed, skip a dedicated unit test for this step and rely on Task 8's hardware integration pass to exercise it end-to-end; note this explicitly rather than inventing a test harness the codebase doesn't otherwise use.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main.rs src/miner.rs
+git commit -m "feat(main): wire --shard/--print-shards into tier assignment and the mining loop"
+```
+
+---
+
+### Task 8: Node — testnet-gated shard tier table
+
+**Files:**
+- Modify: `C:\Testnet\keryx-node\.claude\worktrees\shard-poc\consensus\core\src\config\params.rs`
+- Modify: `C:\Testnet\keryx-node\.claude\worktrees\shard-poc\consensus\src\pipeline\body_processor\body_validation_in_isolation.rs`
+- Modify: wherever the struct that owns `check_pom_proof` (the `self` in that method) is constructed from `Params` — find it before editing.
+
+**Interfaces:**
+- Consumes: `crate::pom::PomTier { model_id, root, chunks }` (unchanged), `ForkActivation::{new, never}` (unchanged), the exact shard roots printed by Task 6's `--print-shards` (must be pasted in verbatim, not invented).
+- Produces: `pom_tiers(..., shard_poc_active: bool)` (signature change — the one existing call site is updated in the same task).
+
+**This task cannot be completed until Task 6/7 produce real `--print-shards` output on the actual Kimi-Linear-48B GGUF** (the roots are pinned data, not computable from this plan alone). Steps 1-3 below are the code scaffold; Step 4 is where the real roots get pasted in, gated on having run `--print-shards` for real.
+
+- [ ] **Step 1: Add `POM_SHARDS_POC` with placeholder-but-structurally-real rows**
+
+In `params.rs`, right after `POM_TIERS_H6` (ends at line 579), add:
+
+```rust
+/// Shard possession anchors for the network-shard PoC (see keryx-miner's
+/// `docs/superpowers/specs/2026-09-09-network-fatia-shard-poc-design.md`). Each row is one
+/// fixed-size, layer-aligned slice of Kimi-Linear-48B at the POC's 8 GiB target
+/// (`models::POC_SHARD_TARGET_BYTES` on the miner side — the two must be kept in lockstep by
+/// hand; there is no dynamic negotiation in this phase). Tier indices are 5, 6, ... immediately
+/// after POM_TIERS_H6's 5 rows (`pom_tiers()` below concatenates them). Roots/chunks are pasted
+/// verbatim from `keryx-miner --print-shards very-high:8` output — DO NOT hand-derive them.
+pub const POM_SHARDS_POC: &[crate::pom::PomTier] = &[
+    // TODO(shard-poc): paste real output of `keryx-miner --print-shards very-high:8` here, one
+    // crate::pom::PomTier { model_id: KIMI_LINEAR_48B_MODEL_ID, root: [...], chunks: ... } per
+    // shard line printed. This is the ONLY acceptable source for these values — do not compute
+    // them by hand or guess. Placeholder below MUST be replaced before this branch is usable;
+    // it is intentionally a compile error (deliberately wrong array length vs a real N) to make
+    // "forgot to fill this in" impossible to miss:
+    crate::pom::PomTier { model_id: KIMI_LINEAR_48B_MODEL_ID, root: [0u8; 32], chunks: 0 },
+];
+```
+
+(Use whatever the existing constant for Kimi-Linear-48B's model_id is actually named in this file — `grep -n "KIMI_LINEAR_48B" consensus/core/src/config/params.rs` to get the exact identifier; the miner side's `KIMI_LINEAR_48B.model_id` and the node side's constant must be byte-identical, they're two independent copies of the same 32 bytes pinned in both repos today for the existing tiers too, same pattern.)
+
+- [ ] **Step 2: Add the fork gate**
+
+Find the `ForkActivation` fields already on whatever struct holds `pom_v3_activation` (search `grep -rn "pom_v3_activation:" consensus/core/src/config/params.rs` — likely a `Params` struct field plus one entry per network in `MAINNET_PARAMS`/`TESTNET_PARAMS`/`DEVNET_PARAMS`/`SIMNET_PARAMS`-style consts). Add a new field `shard_poc_activation: ForkActivation` in the struct definition, and in every existing network const's initializer, set it to `ForkActivation::never()` — **except** the user's own private testnet params, which the user will set up separately (this task does not create a new network; it just makes sure the field exists and defaults safe everywhere that already exists). If the user has not yet created private-testnet params in this repo, add a comment marking exactly where they'll add `ForkActivation::new(0)` later, rather than inventing a new network config file.
+
+- [ ] **Step 3: Extend `pom_tiers()` (line 586) and its one call site**
+
+```rust
+pub fn pom_tiers(
+    pom_v3_active: bool,
+    h5_active: bool,
+    coin_age_active: bool,
+    very_light_active: bool,
+    shard_poc_active: bool,
+) -> &'static [crate::pom::PomTier] {
+    if shard_poc_active && pom_v3_active {
+        return pom_tiers_with_shards();
+    }
+    if pom_v3_active {
+        POM_TIERS_H6
+    } else if h5_active {
+        POM_TIERS_H5
+    } else if coin_age_active {
+        POM_TIERS_H4
+    } else if very_light_active {
+        POM_TIERS_H2
+    } else {
+        POM_TIERS
+    }
+}
+
+/// H6 tiers plus the shard-PoC rows, concatenated once. `shard_poc_active` is `never()`
+/// everywhere except a private testnet, so this path is dead code on every real network.
+fn pom_tiers_with_shards() -> &'static [crate::pom::PomTier] {
+    static COMBINED: std::sync::OnceLock<Vec<crate::pom::PomTier>> = std::sync::OnceLock::new();
+    COMBINED.get_or_init(|| POM_TIERS_H6.iter().copied().chain(POM_SHARDS_POC.iter().copied()).collect())
+}
+```
+
+In `body_validation_in_isolation.rs`, the call site at line 252-257 gains a 5th argument:
+
+```rust
+        let tiers = pom_tiers(
+            pom_v3,
+            self.h5_activation.is_active(header.daa_score),
+            self.coin_age_verification_activation.is_active(header.daa_score),
+            self.very_light_activation.is_active(header.daa_score),
+            self.shard_poc_activation.is_active(header.daa_score),
+        );
+```
+
+This requires `self` (whatever struct `check_pom_proof` is a method on) to have a `shard_poc_activation: ForkActivation` field, populated the same way `h5_activation` etc. already are — find that struct's constructor (search `grep -rn "h5_activation:" consensus/src/` outside `params.rs` to find where the processor struct is built from `Params`) and add the mirror line.
+
+- [ ] **Step 4: Build**
+
+Run: `cargo build 2>&1 | tail -80`
+Expected: clean build, with the placeholder `POM_SHARDS_POC` row present (it compiles fine — it's structurally valid Rust, just semantically wrong data — that's fine until Task 9 replaces it with real numbers).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add consensus/core/src/config/params.rs consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+git commit -m "feat(pom): add testnet-gated shard tier table (POM_SHARDS_POC), rows pending real manifest"
+```
+
+---
+
+### Task 9: Pin real shard roots and run Phase A integration (manual, hardware-only)
+
+This task is **not a code-loop task** — same category as the old `tensor-split` design's Task 6 (see its `progress.md`: "manual/hardware-only, not a code-loop task"). It requires the real rig, real models, and a running private testnet node. Do not attempt to simulate or mock this.
+
+- [ ] **Step 1:** Build the miner (`cargo build --release --features cuda`) and run `keryx-miner --print-shards very-high:8`. Record the printed `model_id`, and each shard's `layer_range`, `n_chunks`, `root`.
+
+- [ ] **Step 2:** Paste those exact values into `POM_SHARDS_POC` in the node worktree (replacing Task 8 Step 1's placeholder row, one `PomTier` entry per shard printed). Set `shard_poc_activation` in the private testnet's params to `ForkActivation::new(0)` (or whatever DAA the user's testnet uses for its own PoM-from-genesis convention — match the existing `pom_v3_activation` value already used for that testnet, per this repo's existing "PoM from genesis" pattern noted in the design doc's Testing plan).
+
+- [ ] **Step 3:** Build and run the node (`cargo build --release`, start `keryxd` on the private testnet).
+
+- [ ] **Step 4:** Run two miner processes on the rig, one per GPU (check CUDA ordinal vs. `nvidia-smi` index first — this rig has a known mismatch, see the design spec's citation of `feedback_cuda_ordinal_vs_nvidia_smi_index`):
+   - Process A: `keryx-miner --pom-cuda-device 0 --force-model very-high --shard very-high:8:0 ...`
+   - Process B: `keryx-miner --pom-cuda-device 1 --force-model very-high --shard very-high:8:1 ...`
+   (Exact device ordinals depend on which physical card is 0 vs 1 after the `CUDA_DEVICE_ORDER=PCI_BUS_ID` fix — verify per the existing project precedent before assuming.)
+
+- [ ] **Step 5:** Confirm in each process's logs: `shard N — walk uses a raw scoped upload`, `shard N miner ready — N=<n_chunks> chunks resident` matching the manifest from Step 1, and no OOM.
+
+- [ ] **Step 6:** Let both mine. Gate: blocks with `proof.tier ∈ {5, 6}` are accepted by the node (no `PomUnknownTier`, no `BadPomProofV3` in the node's logs). This is the possession half, end to end, against the real verifier — the exact thing the old `tensor-split` PoC's Task 6 could not achieve.
+
+- [ ] **Step 7 (guard regression check):** Temporarily edit one shard's `tensor_names` in the running miner's manifest computation (e.g. drop one tensor) and confirm the N-guard in `ensure_shard_installed_inner` refuses to mine (logs the "gather N != shard index N" error) rather than silently producing a proof. Revert the edit afterward.
+
+- [ ] **Step 8:** Report results back — this closes out the plan's goal. If OPoI/pipeline serving across the two shards is wanted next, that's the separate follow-up plan for spec §3.3/§3.5 (ggml-rpc), not part of this one.
+
+---
+
+## Self-Review Notes (for whoever picks this plan up)
+
+- **Spec coverage:** This plan implements spec §1 (shard definition) and §4 (node registration) in full, §2 (`--resident-tree` reuse — via the shared `WeightIndex` machinery, not the dense in-RAM tree itself, which stays opt-in and untouched) and §3.1-3.2 (CLI, scoped raw upload, guard) in full. It does **not** implement §3.3-3.5 (ggml-rpc pipeline) — that's the deferred follow-up plan the brainstorming session already flagged.
+- **Corrections vs. the spec doc:** `POM_INDICES` keying (see Global Constraints) and several line-number citations were corrected after reading the actual `shard-poc` worktrees. If further drift is found while executing (concurrent work on `main`/`feature/watchdog-relay-v160`), re-run the relevant `grep -n` before trusting any line number in this plan.
+- **Type consistency check:** `ShardManifest` (Task 1) is used identically in Tasks 2, 4, 6, 7 (`index: u16`, `layer_lo/hi: u32`, `tensor_names: Vec<String>`) — no renamed fields across tasks. `ShardAssignment` (Task 4) is used identically in Task 7's `set_shard_for_device` call and Task 4's `current_tier`/`ensure_shard_installed_inner`.
+- **Placeholder scan:** The only intentional placeholder is Task 8 Step 1's `POM_SHARDS_POC` row, which is explicitly a deliberate compile-fine/semantically-wrong stand-in that Task 9 Step 2 replaces with real, measured data — this is not a "TBD" left for later without a plan to close it; Task 9 is that plan.

--- a/docs/superpowers/specs/2026-09-09-network-fatia-shard-poc-design.md
+++ b/docs/superpowers/specs/2026-09-09-network-fatia-shard-poc-design.md
@@ -1,0 +1,443 @@
+# Fixed-size model shards: PoM possession per shard + ggml-rpc pipeline pinned to shard boundaries (design)
+
+Date: 2026-09-09
+Status: proposed, not yet implemented
+Supersedes (for the "tier bigger than one GPU" goal): `2026-08-08-local-tensor-split-design.md`
+
+## Problem
+
+The local tensor-split POC (`tensor-split` branch, commits `dc24b41..3552ce3`) wires
+`--tensor-split` cleanly, but Task 6 on the real rig proved it cannot *mine* a tier bigger than
+the main GPU. Ledger: `.superpowers/sdd/2026-08-08-local-tensor-split/progress.md`, last entry.
+The exact mechanism:
+
+1. `src/pom_gpu.rs::ensure_installed_inner` (worktree, lines 960-973) forces `load_raw` whenever
+   split is active. That guard is correct: the walk kernel dereferences raw device pointers on ONE
+   device, and llama.cpp may have placed a tensor on the helper card. (`main` now has an even more
+   explicit version of the same guard: `llama_engine::foreign_device_tensor`, `src/pom_gpu.rs:1533`.)
+2. `PomGpuMiner::load_raw` (worktree lines 369-415, `main` line 635) uploads **every** tensor of the
+   canonical GGUF (`meta.sorted_names()`) to one GPU. For Kimi-Linear-48B that is 29.7 GB into a
+   24 GB card → `CUDA_ERROR_OUT_OF_MEMORY`, confirmed in the rig log.
+3. The split FFI (`keryx_llama_load_split`) is never reached by any production caller, so the split
+   engine does not serve inference either.
+
+Root cause is not a bug: possession (walk over the whole tier) and hosting (weights spread across
+GPUs) are coupled by the definition "1 tier = 1 model = 1 root `R_T`". A tier that does not fit one
+GPU cannot be walked from one GPU. The way out is to make the **unit of possession smaller than the
+model**: a shard with its own root, small enough for one GPU, walked entirely from that GPU. That is
+also exactly the unit the network vision needs (one miner = one shard, pipelines assembled from
+complementary shards), so this is the necessary first step before any of the pipeline economics.
+
+Two facts already established, reused as-is:
+
+- Local layer-split inference works and is fast: `llama-bench`, Kimi-Linear-48B Q4_K_M across
+  4090 + 3090, `split_mode=LAYER`: `pp512 = 3081 tok/s`, `tg128 = 103.5 tok/s`.
+- `--resident-tree` (commit `0d64adc`, `src/pom.rs::WeightIndex::build_dense`) and the sparse
+  checkpoint tree (`build_from_gguf`, `merkle_path`) already produce canonical roots and paths over
+  an arbitrary ordered tensor list — the `ChunkSource::Gguf { table }` reader is a list of
+  `(first_chunk_index, file_offset)` per tensor, not a whole-file assumption.
+
+## Branch reality (read before planning tasks)
+
+The `tensor-split` worktree is **153 commits behind `main`** (`git rev-list --count
+tensor-split..main`). `main` has, and the worktree does NOT have:
+
+- `cuda-bridge/` crate + `src/pom_gpu_cuda_bridge.rs` + `--serve-cuda-bridge` (`src/main.rs:805`).
+- The H6/v3 matrix walk (`src/pom_v3.rs`), the v4 re-walk (`src/pom_v4.rs`), H10 one-way seed
+  (`63b7619`), the per-tensor llama reconcile (`19d19c1`), `ensure_loaded(gguf, gpu)` returning
+  `Result` with `is_busy()/is_oom()` (`src/pom_gpu.rs:1507`).
+- The H6 tier table (`models.rs::pom_tier_index`, 5 tiers gated on `pom_v3_activation_daa`).
+
+The node's `master` branch is stuck at v1.4.5 (2026-08-14) and is stale. The correct current base
+is `feature/watchdog-relay-v160` (v1.6.0, 2026-09-04) — strictly ahead of `master`, carries the
+IBD body-swarm sync fix and the watchdog-relay work already deployed for live testing. It is already
+at H6: `check_pom_proof` (`consensus/src/pipeline/body_processor/body_validation_in_isolation.rs:227`)
+dispatches to `verify_pom_proof_v3_container` when `pom_v3_activation` is active (testnet gate = DAA
+1000); `pom_tiers()` is at `consensus/core/src/config/params.rs:586` (line numbers shift slightly
+from `master`, re-check against the actual worktree before editing).
+
+**Decision: this design is implemented on new worktrees off the correct current base on each repo**,
+not on `tensor-split` (miner) or `master` (node):
+
+- Miner: `C:\Testnet\keryx-miner\.worktrees\shard-poc`, branch `shard-poc`, off `main`.
+- Node: `C:\Testnet\keryx-node\.claude\worktrees\shard-poc`, branch `shard-poc`, off
+  `feature/watchdog-relay-v160`.
+
+Only two things are cherry-picked from `tensor-split`: `keryx_llama_load_split`'s pattern for
+building `llama_model_params` (§3.3) and the "one-time `info!` at the guard branch point" testing
+idea. The `--tensor-split` flag itself is not carried forward (it is the ratio-based split this
+design replaces). The `cuda-bridge` crate (§5) stays untouched and out of scope for this phase per
+the user's own steer — it solves a different problem (no-GPU clients), not the shard/pipeline
+question this design is about.
+
+## Scope
+
+**In scope**
+
+1. Shard definition: a deterministic, layer-aligned, fixed-byte-target slice of a canonical GGUF,
+   with its own `(n_chunks, root)` fingerprint, computed with the existing `WeightIndex` machinery.
+2. `load_raw` with scope: upload only the shard's tensors, build the gather over them. Same kernel,
+   same `bases/prefix` tables, same N-guard.
+3. `ensure_installed_inner` guard adjusted so a shard is always walked from a raw scoped upload on
+   the device that holds it (never zero-dup in this phase).
+4. OPoI pipeline over `ggml-rpc`, with llama.cpp's layer→device assignment **pinned by
+   `tensor_buft_overrides`** to the same layer ranges the shards were cut on (not ratios).
+5. Minimal node change: a testnet-only tier-table extension so the existing verifier can look up a
+   shard's `(root, chunks)` by `proof.tier`. Zero new verification code.
+6. Test plan: local 2-GPU rig as two independent miners, then a private testnet with two machines.
+
+**Out of scope** (phase 2, per project leadership's "no consensus change until the physics is
+measured"): any change to `PomProof`/header wire format, difficulty, cohorts, strikes, escrow;
+dynamic pipeline marketplace; payment split per link; link failure detection/penalty/replacement;
+mainnet tier tables. Listed again in "Explicitly not doing".
+
+## Design
+
+### 1. Shard definition
+
+A shard is identified by `ShardId { model_id: [u8;32], target_bytes: u64, index: u16 }` and fully
+determined by the canonical GGUF plus `target_bytes`. No operator choice enters the boundary.
+
+**Packing rule** (new `src/shard.rs`, pure function over `gguf::GgufMeta`):
+
+1. Group tensors by transformer layer: name matches `^blk\.(\d+)\.` → layer `L`. Everything else
+   (`token_embd.weight`, `output_norm.weight`, `output.weight`, rope/attn misc without `blk.`) is
+   "non-layer".
+2. Walk layers in numeric order `0..n_layer`. Open shard 0 with all non-layer tensors that llama.cpp
+   places on the *input* side (`token_embd.*`; see `llama-model.cpp:1309`, `dev_input` is always
+   CPU — it still belongs to shard 0 for possession). Append layer bytes greedily: close the current
+   shard when adding the next layer would exceed `target_bytes`, unless the shard is still empty of
+   layers (a single layer larger than the target is a hard error — pick a bigger target). The last
+   shard additionally takes the output-side non-layer tensors (`output_norm.*`, `output.*`).
+3. Result: `Vec<ShardManifest { index, layer_range: [a, b), tensor_names: Vec<String> }>`. Layer
+   ranges are contiguous and cover `0..n_layer` exactly once.
+
+Why layer-aligned rather than a raw byte range of the canonical file: the canonical chunk order is
+**name-sorted** (`gguf.rs::sorted_names`, `blk.1.` < `blk.10.` < `blk.2.`), so a contiguous byte
+range of the canonical layout is not a contiguous group of layers, and the pipeline (§3.5) can only
+cut on whole layers. Layer alignment gives a boundary that both PoM and ggml-rpc can agree on. The
+byte size is "fixed target, quantised to whole layers" — the deviation is at most one layer.
+
+**Fingerprint**: within a shard the tensors are ordered by the same canonical rule applied to the
+subset (`tensor_names.sort()`), chunked `floor(nbytes/32)` 32 B chunks, blake3 leaves,
+duplicate-last Merkle — i.e. `WeightIndex::build_from_gguf` restricted to `tensor_names`. This
+yields `(n_chunks_shard, root_shard)`. A shard is therefore *structurally a `PomTier`*
+(`keryx-node/consensus/core/src/pom.rs:61`: `{ model_id, root, chunks }`), which is what lets the
+node stay unchanged in §4.
+
+Tile constraint (v3/v4 walks address 64 KB / 1 KB tiles, `n_tiles = n_chunks / TILE_CHUNKS`,
+`src/pom_v4.rs:87`): a shard needs `n_chunks ≥ 2048`; any real `target_bytes` (GiB-scale) satisfies
+this trivially. Tile alignment is relative to the shard's own chunk 0, so no padding is needed.
+
+**Manifest file**: `<models>/<dir_name>/shards-<target_gib>g.json` — `{ model_id, target_bytes,
+shards: [{ index, layer_range, n_chunks, root_hex, tensor_names }] }`. Written by the new
+`--print-shards` CLI (§3.1) and by the node-side pin step (§4). It is derived data (recomputable from
+the GGUF), never trusted over recomputation.
+
+### 2. Reusing `--resident-tree` / `WeightIndex`
+
+Add `WeightIndex::build_from_gguf_subset(path, tensor_names: &[String], tree_path)` in `src/pom.rs`:
+identical to `build_from_gguf` (lines 769-879) except (a) `names` is the sorted subset instead of
+`meta.sorted_names()`, and (b) the tree file is `pom-tree.shard<idx>-<target_gib>g.bin` next to the
+GGUF. `open_existing_tree` (line 686) recomputes expected size from the tensor list, so it gets the
+same subset parameter. `build_dense` (`--resident-tree`) works unchanged over the subset —
+`read_all_chunks_hashed` iterates the `table`. `read_chunk_bytes`, `merkle_path`, the v3/v4 tile
+paths (`pom_v4.rs:101`) are untouched: they only see `n_chunks` and the table.
+
+`POM_INDICES` (`pom.rs:1267`) stays keyed by `tier: u8`; the shard's tier index (§4) is the key.
+
+### 3. `keryx-miner` changes
+
+#### 3.1 CLI (`src/cli.rs`)
+
+```
+--shard <TIER>:<TARGET_GIB>:<IDX>[,<TIER>:<TARGET_GIB>:<IDX>...]
+```
+Per-GPU CSV in CUDA-driver order, same convention as `--force-model` (`main.rs::parse_tier_name`
+call site). Example on the 2-GPU rig, two *processes* (see §5): process A `--shard very-high:8:0`
+binds GPU 0, process B `--shard very-high:8:1` binds GPU 1. Malformed entries: warn + ignore
+(mirrors `--force-model`). A GPU listed here mines that shard instead of a whole tier.
+
+```
+--print-shards <TIER>:<TARGET_GIB>      # compute + print the manifest (roots), exit
+--rpc-serve <BIND_ADDR>                 # run llama.cpp rpc-server for this GPU's shard (§3.5)
+--pipeline <ENDPOINT>[,<ENDPOINT>...]   # head: build the pipeline over these rpc-servers (§3.5)
+```
+
+#### 3.2 `src/pom_gpu.rs` — scoped raw upload
+
+`PomGpuMiner::load_raw_subset(gguf_path, device_id, tensor_names: &[String])`: the body of
+`load_raw` (`main` line 635) with `names.retain(|n| subset.contains(n))` after
+`meta.sorted_names()`. Nothing else changes: `bases/prefix` are built over the retained tensors,
+`n_total_chunks` becomes the shard's N, `select_pom_kernel` is the same. Also `n_tiles` for the
+v3/v4 launches derives from that N exactly as today.
+
+Guard in `ensure_installed_inner` (`main` lines 1503-1560): before the `use_llama` block,
+
+```rust
+if let Some(shard) = shard_for_device(device_id) {   // registry populated from --shard
+    info!("PoM[gpu{}]: shard {}/{} of {} — walk uses a raw scoped upload (no zero-dup)", ...);
+    // use_llama stays false; load path is load_raw_subset(&gguf, dev, &shard.tensor_names)
+}
+```
+
+The existing N-guard (`gm.n_chunks() != idx.n_chunks → refuse`) now compares against the *shard*
+index. This is the one guard that must not regress: a wrong subset silently produces proofs the node
+rejects (no crash), so the one-time `info!` above names the shard and N for any log reviewer.
+
+`set_mining_tier(device_id, model_id, gguf)` (line 819 area) gains the shard: the `MINING_TIERS`
+value becomes `(model_id, gguf, Option<ShardManifest>)`. `current_tier` returns the shard's tier
+index (§4) via a new `models::pom_shard_tier_index(model_id, target_bytes, idx, daa)` that mirrors
+the node table. `advance_mining_tier_if_due` is a no-op for shard devices (no era swap in the POC).
+
+`device_for_model` / OPoI routing (`slm::load_and_run_inference`, `main` around line 454): a shard
+device never hosts a whole-model engine. Inference for a sharded model goes through the pipeline
+head (§3.5); in this phase the head is selected by `--pipeline` on exactly one process.
+
+#### 3.3 FFI (`tools/keryx-llama/keryx_llama.cpp`)
+
+New export, alongside the existing `keryx_llama_load` (single GPU, untouched):
+
+```c
+KeryxLlama* keryx_llama_load_pipeline(const char* gguf_path, int n_ctx,
+                                      const char** endpoints, int n_endpoints,
+                                      const int* layer_lo, const int* layer_hi,   // per endpoint, [lo,hi)
+                                      int local_gpu, int local_lo, int local_hi); // this process's own shard, or -1
+```
+
+Body, in order:
+
+1. `ggml_backend_load_all()` once (the RPC backend is a loadable module; also needs the build change
+   in §3.5).
+2. For each endpoint: `ggml_backend_rpc_add_server(endpoint)` (resolved via
+   `ggml_backend_reg_get_proc_address(reg, "ggml_backend_rpc_add_server")` exactly like
+   `common/arg.cpp:959-965`). Devices come back named `RPC0`, `RPC1`, … in registration order
+   (`ggml-rpc.cpp:1946`); their buffer type is `ggml_backend_dev_buffer_type(dev)`.
+3. Build `llama_model_params.devices` = `[RPC devs..., local CUDA dev]` (NULL-terminated), and
+   `tensor_buft_overrides` = one entry per layer range: pattern
+   `^blk\.(a|a+1|…|b-1)\.` → that device's buft, plus `^output(_norm)?\.` → the last shard's buft
+   (`llama.h:290`, `llama_model_tensor_buft_override { pattern, buft }`; applied per tensor in
+   `llama-model-loader.cpp:1165-1167` before the ratio-based `get_layer_buft_list`). Ratios are left
+   at zero: with overrides covering every `blk.` tensor the ratio path only decides KV/compute
+   placement, and llama.cpp allocates a layer's KV on the device that owns the layer.
+4. `split_mode = LLAMA_SPLIT_MODE_LAYER`, `main_gpu = local_gpu` (or the first RPC device when the
+   head has no local shard), `n_gpu_layers = 999`, `use_mmap = true`.
+
+`keryx_llama_load_split` from `tensor-split` is **not** kept: the ratio it forwards is the thing
+this design removes.
+
+`src/llama_engine.rs`: `LoadPipelineFn` type + `ensure_loaded_pipeline(gguf, cfg)`; `Engine` gains
+`pipeline: Option<PipelineConfig>`; `active_pipeline()` accessor. `tensors()` is unchanged but
+unused in shard mode (§3.2 never zero-dups).
+
+#### 3.4 `src/miner.rs` / `src/main.rs`
+
+`launch_gpu_miner`'s PoM branch (`miner.rs:353-425`) is unchanged in shape: a shard device calls
+`ensure_installed` → `mine` → `generate_block_if_pom(nonce, idx, tier)` where `idx` is the shard's
+`WeightIndex` and `tier` the shard's tier index. `pow.rs::generate_block_if_pom` builds the era's
+proof (`build_proof_v2`/v3/v4) over `index.n_chunks`/`index.r_t` — already shard-agnostic.
+
+`main.rs`: parse `--shard` into a `ShardAssignment` registry next to `pom_assignments`; a shard GPU
+is *not* given a whole-tier `set_mining_tier`; `lineup_from_assignments` announces the parent
+model in `ai:cap` only on the pipeline head (a shard alone cannot serve). Startup computes the
+manifest for each requested `(tier, target)` once (cheap: header arithmetic only, no tensor reads —
+`open_existing_tree`'s N computation shows the pattern) and builds the shard index lazily in
+`ensure_installed_inner` like today.
+
+#### 3.5 `ggml-rpc` bridge — forcing the cut
+
+Mechanism (vendored source, `target/llama-src-b10015`):
+
+- **Holder side** (`--rpc-serve`): run `ggml_backend_rpc_start_server(endpoint, cache_dir,
+  n_threads, 1, &local_dev)` in-process (`ggml-rpc.h:27`; `tools/rpc/rpc-server.cpp:340` is the
+  reference) exposing exactly the one CUDA device that holds the shard. The **same process** also
+  runs the PoM walk over its raw scoped upload — two VRAM copies of the shard on that GPU (raw walk
+  copy + llama's RPC buffer). For an 8 GiB target that is 16 GiB on a 24 GB card; accepted cost this
+  phase (same trade the local design made in its §4). Zero-dup over the RPC buffer is a follow-up.
+- **Weights never cross the wire** — but only if the holder's rpc cache is pre-seeded. The RPC
+  client sends `RPC_CMD_SET_TENSOR_HASH` for tensors > 10 MB (`ggml-rpc.cpp:79,468-479`) carrying
+  an FNV-1a-64 of the tensor bytes (`fnv_hash`, line 233); the server answers from
+  `<cache_dir>/<hash-hex>` if present (`set_tensor_hash`, line 1114; `get_cached_file`). New
+  `--rpc-serve` startup step: for every tensor in the shard, `pread` the raw bytes from the local
+  GGUF (the holder already has the file — it built the fingerprint from it), compute `fnv_hash`,
+  write `<cache_dir>/<hash-hex>` (hard-link or copy). Then the head's load sends only hashes for
+  large tensors. Tensors ≤ 10 MB (norms, biases) still travel; that is KBs-to-MBs once at load, not
+  per token. Measured in §5.
+- **Head side** (`--pipeline`): `keryx_llama_load_pipeline` (§3.3). The head needs the full GGUF on
+  **disk** (llama.cpp mmaps it to compute hashes / send small tensors) but not in VRAM. This is a
+  real asymmetry vs the "every miner is equal" vision — recorded in §6.
+- **Build**: `build.rs` (`main` line 274 area) adds `-DGGML_RPC=ON` next to `-DGGML_CUDA=ON`, and
+  `hiveos/build-keryx-llama.sh:50` likewise. The RPC backend is small and has no extra deps.
+- **Security posture**: `rpc-server` is unauthenticated and its own banner says never expose it
+  (`rpc-server.cpp:301-309`). For this phase it binds to LAN/VPN addresses on the private testnet
+  only. Framing it in the cuda-bridge's authenticated transport is phase 2.
+
+What is deliberately NOT used: `tensor_split[]` ratios (`llama-model.cpp:1261-1305`, the
+`upper_bound(splits, il/act_gpu_layers)` rule) — a float boundary that can shift by one layer under
+rounding and is not something a remote party can verify. `tensor_buft_overrides` is exact.
+
+### 4. `keryx-node` — minimal registration, not new validation
+
+What the node needs, and nothing more: when a block arrives with `proof.tier = t`, `check_pom_proof`
+does `tiers.get(t)` (`body_validation_in_isolation.rs:252`) and feeds `tier.chunks` / `tier.root`
+to the unchanged verifier (lines 291-301 for v3). For a shard to be accepted, `pom_tiers()` must
+return a table that has the shard's `(model_id, root, chunks)` at index `t`.
+
+Change (testnet-only, `consensus/core/src/config/params.rs`):
+
+- New `pub const POM_SHARDS_POC: &[PomTier]` — one row per shard of the POC model (Kimi-Linear-48B
+  at the chosen target), `model_id` = the parent model's id, `root`/`chunks` from the manifest.
+  Roots are pinned the same way `POM_TIERS_H6` roots were (line 516: "from pom-rt-builder over the
+  pinned GGUFs") — here computed by `WeightIndex::build_from_gguf_subset` and cross-checked by the
+  existing `#[ignore]` test pattern `weight_index_matches_pinned_root` (`pom.rs:1405`) extended with
+  a subset variant.
+- New `ForkActivation` field `shard_poc_activation`, `never()` in `MAINNET_PARAMS`, `DEVNET`,
+  `SIMNET`; set (e.g. `new(0)`) only in the user's private testnet params. `pom_tiers()` (line 543)
+  gets one more branch: when active, return `POM_TIERS_H6 ++ POM_SHARDS_POC` (a `&'static` concat
+  built once via `OnceLock`, or a second const slice with the H6 rows repeated). Shard tier indices
+  are therefore `5, 6, …` — `proof.tier` is `u8` and `header.pom_tier` (H6) is `u8`, so up to 251
+  shard rows fit without touching the wire.
+
+That is the whole node diff. Explicitly **not** consensus logic: `check_pom_proof`, the v3
+verifier, `PomProof`, the header, IBD, pruning, `pom_proof_store`/`pom_tier_store` are untouched.
+It is a params-table row behind a gate that is `never()` everywhere except the private testnet.
+
+Two side effects to know about (not fix) in this phase:
+
+- Tier reward: `tier_reward_bps(..).get(tier).unwrap_or(TIER_REWARD_BPS_DIVISOR)`
+  (`utxo_validation.rs:670`) — a shard tier index beyond the 5-entry schedule silently earns the
+  100 % rate. Fine for a private testnet; the real bareme for shards ("mine proportionally to what
+  you carry") is phase-2 economics.
+- Difficulty: shards mine against the same target as tiers. A shard walk over N_shard chunks has
+  the same per-nonce cost as a tier walk (K steps), so a small shard is a cheap way to produce
+  blocks on the testnet. Irrelevant for the physics test; must be part of the phase-2 design.
+
+Optional, purely informational (no consensus, no gate): a `/ai:shard:<model_hex>:<idx>/<n>` tag
+in the coinbase extra data next to `/ai:cap:` (`src/client/grpc.rs:387-391`, parsed like
+`keryx_inference::parse_ai_caps`, `inference/src/lib.rs:95`), so a block explorer / the node's
+`GetBlock` verbose data can show which shard a block was mined on. Payload cap is 2048 bytes on
+testnet (`max_coinbase_payload_len`), so the tag must stay short. Nice-to-have for the test plan's
+log review, not required.
+
+### 5. Relationship with the existing `cuda-bridge`
+
+`cuda-bridge` (`main`, `cuda-bridge/src/{client,server,session,registry,framing,protocol}.rs`)
+moves the **PoM walk** of a whole model to a remote GPU and publishes it by name
+(`PublishModel`/`BindModel`, `registry.rs::ResidentModel { bases_ptr, prefix_ptr, t_count,
+n_total_chunks, tensor_ptrs }`). It does not move inference activations between GPUs; `Generate`
+runs the whole model on the server's local engine.
+
+`ggml-rpc` moves **activations** between GPUs for inference; it has nothing to do with the walk.
+
+They are complementary and stay in parallel:
+
+- Miner **with** a GPU holding a shard: local `load_raw_subset` walk (§3.2) + `--rpc-serve` (§3.5).
+  No cuda-bridge involved.
+- Miner **without** any GPU (the `.21` case): keeps using `cuda-bridge-client` against a
+  `--serve-cuda-bridge` host. Later that host can publish shards instead of whole models — the
+  registry is keyed by name, so `bridge_model_name(spec) + "#shard<i>"` and `load_raw_subset` on the
+  server side is a small follow-up (`pom_gpu_cuda_bridge::publish_zero_dup` would become
+  `publish_shard_raw`). Not in this phase.
+- Transport reuse: the bridge's framing/proto is a candidate wrapper to give `ggml-rpc` an
+  authenticated, signed-per-link channel in phase 2 (each hop signs its activation). Not now.
+
+## Testing plan
+
+Precedent: the cuda-bridge was validated cross-machine on this rig (`.14` = GPU host,
+`.21` = client). Same pattern here, after the local phase.
+
+### Phase A — local, two GPUs as two miners (no network hop for PoM)
+
+0. Build off `main` with the changes above; unit tests: shard packing determinism (same GGUF +
+   target → same manifest, twice; different target → different boundaries; single-layer-too-big →
+   error), `build_from_gguf_subset` root == dense `merkle_root` over the subset leaves (extend the
+   `synth_index`-based tests in `pom.rs:1372-1397` with a subset), `--shard` parsing
+   (malformed → warn + ignore; same GPU twice → reject).
+1. `keryx-miner --print-shards very-high:8` → manifest for Kimi-Linear-48B at 8 GiB. Record each
+   shard's `layer_range`, `n_chunks`, `root`. Pin those rows into the node's `POM_SHARDS_POC`,
+   build `keryxd`, run the private testnet node (testnet params already have PoM from genesis and
+   `pom_v3_activation = 1000`).
+2. Two miner processes on the rig, each bound to one GPU (verify CUDA ordinal vs nvidia-smi index
+   before starting — this rig has bitten us on that): A `--shard very-high:8:0`, B
+   `--shard very-high:8:1` (or `:2`, whichever fits the 3090). Confirm in logs, per process:
+   `shard i/n … raw scoped upload`, `GPU miner ready — N=<n_chunks_shard>` equal to the manifest,
+   no OOM. Let them mine. Gate: blocks with `proof.tier ∈ {5,6,…}` accepted by the node (no
+   `PomUnknownTier`, no `BadPomProofV3`). This is the possession half, end to end, with the real
+   verifier.
+3. Pipeline, same rig: process B adds `--rpc-serve 127.0.0.1:50052` (cache pre-seeded from its
+   GGUF; confirm on the head side that `SET_TENSOR_HASH` hits for every tensor > 10 MB — count
+   `SET_TENSOR` bytes sent, must be ≈ only the small tensors). Process A adds
+   `--pipeline 127.0.0.1:50052` with layer ranges from the manifest. Run the OPoI generate path
+   (`keryx_llama_generate`) on a fixed prompt and measure: `tg` tok/s, per-token wall time, bytes on
+   the socket per token. Reference: 103.5 tok/s for the same model native-local split; the delta is
+   the loopback RPC cost.
+4. Guard check: a deliberately wrong manifest (edit one tensor name) must be refused by the N-guard
+   before any block is produced — proves the "silent wrong proof" failure mode is closed.
+
+### Phase B — private testnet, two machines
+
+5. Move process B to the second machine (real NIC, real latency). Same `--shard … --rpc-serve
+   <lan-ip>:50052` there; head on `.14` with `--pipeline <lan-ip>:50052`. Each machine runs its
+   own `keryxd` on the private testnet (or both point at one). Repeat step 2's gate (blocks from
+   both shards accepted by both nodes) and step 3's measurements; now the per-hop latency is the
+   number leadership asked for (their reference estimate ~30 ms/hop). Record tok/s vs the Phase A
+   loopback number and vs the 103.5 native figure.
+6. Failure physics (measure, do not fix): kill the rpc-server mid-generation → observe how the head
+   fails (`RPC_STATUS_ASSERT` aborts the process today — document it); restart holder → does the
+   head recover without reload? These observations feed the phase-2 "link fails → penalise and
+   replace" design.
+7. Accepted-block corroboration as in the local design's §6.4: presence of accepted shard blocks
+   over a long window is strong evidence; absence in a short window is inconclusive.
+
+## Open questions / risks
+
+- **Execution correctness (Texas's point, unresolved, deliberately deferred).** PoM proves the
+  holder *has* the shard bytes; a per-link signature proves *who* produced an activation; nothing
+  proves the activation was computed *correctly*. A malicious holder can emit garbage with a valid
+  signature and a valid PoM. Leadership's position: real, separate, handled after the pipeline
+  exists via deterministic execution + random redundant stages / challenge, not expensive
+  cryptographic proofs up front. This design does not narrow or widen that gap; it makes the
+  boundary explicit (a shard is a fixed layer range, so a redundant re-execution of one stage has
+  a well-defined input/output) — a prerequisite for whatever audit mechanism phase 2 picks. Logged
+  here so it is not lost.
+- **Head asymmetry.** `ggml-rpc` is one driver + N workers: the head owns the graph, the KV
+  scheduling, and needs the full GGUF on disk. In the network vision every link is a peer. Either
+  the head role becomes a paid pipeline role in phase 2, or the transport is replaced by a
+  peer-to-peer activation relay (each holder runs its own llama instance for its layers — llama.cpp
+  does not support that today). Physics from Phase B decides which is worth building.
+- **Small tensors still travel** (≤ 10 MB, `HASH_THRESHOLD`). Once at load, not per token; measure
+  the total in step 3. If it matters, lowering the threshold is a one-line patch to the vendored
+  `ggml-rpc.cpp`.
+- **`rpc-server` is unauthenticated** and single-purpose-trusting; private testnet only. Wrapping it
+  in an authenticated channel (cuda-bridge framing or otherwise) is phase 2.
+- **Double VRAM on the holder** (raw walk copy + RPC buffer). Fine for 8 GiB shards on 24 GB cards;
+  zero-dup over the RPC buffer needs the `foreign_device_tensor`-style ownership check applied to
+  the RPC buffer's device pointer — follow-up.
+- **Economics not addressed on purpose**: shard difficulty/reward bareme (a shard currently gets
+  the 100 % fallback rate and the same target as a tier), shard replication incentives, which
+  target size(s) the network standardises on. All phase 2, all consensus.
+- **Manifest determinism across GGUF revisions**: the manifest is a function of the pinned CID's
+  bytes; a re-quantised model is a different `model_id` with its own manifest. No versioning field
+  needed in this phase.
+- **Branch drift**: implementing on `tensor-split` instead of `main` would miss the v3/v4 walk and
+  the cuda-bridge entirely (see "Branch reality"). The 8 `tensor-split` commits are reference
+  material, not a base.
+
+## Explicitly not doing
+
+- Not changing `PomProof`, the block header, `verify_pom_proof*`, difficulty, cohorts, strikes,
+  escrow, or any mainnet params. The only node diff is a testnet-gated tier-table row set.
+- Not building the dynamic pipeline marketplace, per-link payment split, or link
+  failure/penalty/replacement — phase 2, with the hard-fork rigour leadership asked for (enumerate
+  non-derivable state, IBD/pruning consequences, adversarial testnet).
+- Not solving execution correctness of intermediate activations (recorded above as a known,
+  deferred risk).
+- Not using `tensor_split[]` ratios anywhere; not carrying `--tensor-split` /
+  `keryx_llama_load_split` forward.
+- Not zero-dupping the walk over llama's RPC buffer on the holder; raw scoped upload only.
+- Not making `models.rs` tier assignment "shard-aware" automatically — the operator states the
+  shard explicitly via `--shard`, exactly as `--force-model` states a tier.
+- Not replacing the cuda-bridge; it stays for the no-GPU client and is not part of this phase's
+  test plan.
+- Not touching the CUDA walk kernels (`cuda/pom_mine*.cu`): they receive a smaller `bases/prefix`
+  table and a smaller N, nothing else.

--- a/examples/shard_guard_poc.rs
+++ b/examples/shard_guard_poc.rs
@@ -1,0 +1,80 @@
+// Plan Step 7 (guard regression check): temporarily corrupt one shard's `tensor_names` in the
+// running miner's manifest computation (drop one tensor) and confirm the N-guard in
+// `ensure_shard_installed_inner` (src/pom_gpu.rs) refuses to mine — logs "gather N != shard index
+// N — refusing to mine" — rather than silently producing a proof over the wrong data.
+//
+// Sequence: install the shard with its real, correct manifest (builds the host index, caches its
+// N). Uninstall just the GPU-resident miner (leaves the host index cache untouched — mirrors a
+// live device reloading its gather without the index ever being rebuilt). Re-register the same
+// device with a manifest missing its last tensor, then try to reinstall: the gather now walks a
+// different (shorter) tensor set than the cached index was built from, so N must mismatch and the
+// guard must refuse. Never edits a source file — the "manifest" here is in-process state private
+// to this disposable process, so there's nothing to revert once it exits.
+
+use clap::Parser;
+use keryx_miner::{gguf, models, pom, pom_gpu};
+use std::fs::File;
+
+#[derive(Parser, Debug)]
+#[clap(name = "shard_guard_poc", about = "Plan Step 7: proves the N-guard refuses to mine when a shard's manifest is corrupted")]
+struct Args {
+    #[clap(long, default_value = r"E:\keryx-miner-v0.4.1-OPoI-win64-amd64\models\Kimi-Linear-48B\model.gguf")]
+    gguf_path: String,
+    #[clap(long, default_value_t = 8_000_000_000)]
+    target_bytes: u64,
+    /// CUDA device to use — pick an idle GPU, this loads real weights onto it.
+    #[clap(long, default_value_t = 0)]
+    device_id: u32,
+    /// Gate PoM activation DAAs as mainnet instead of testnet.
+    #[clap(long)]
+    mainnet: bool,
+}
+
+fn main() {
+    let args = Args::parse();
+    pom::set_testnet(!args.mainnet);
+
+    let device_id: u32 = args.device_id;
+    let spec = &models::KIMI_LINEAR_48B;
+    let gguf_path = args.gguf_path.clone();
+    let target_bytes: u64 = args.target_bytes;
+
+    let mut file = File::open(&gguf_path).expect("open gguf");
+    let meta = gguf::GgufMeta::read(&mut file).expect("parse gguf meta");
+    let shards = keryx_miner::shard::pack_shards(&meta, target_bytes).expect("pack shards");
+    let good_manifest = shards.into_iter().find(|s| s.index == 0).expect("shard 0 in range");
+    println!(
+        "[guard-poc] shard 0: layers [{},{}) — {} tensors (correct manifest)",
+        good_manifest.layer_lo,
+        good_manifest.layer_hi,
+        good_manifest.tensor_names.len()
+    );
+
+    let daa: u64 = pom::pom_v3_activation_daa();
+
+    // Step A: install with the correct manifest — must succeed and cache the host index.
+    pom_gpu::set_shard_for_device(device_id, spec.model_id, gguf_path.clone(), target_bytes, good_manifest.clone());
+    let installed = pom_gpu::ensure_installed(device_id, daa);
+    println!("[guard-poc] correct-manifest install -> {installed}");
+    assert!(installed, "baseline install with the correct manifest must succeed");
+
+    // Step B: release the GPU-resident miner only. The host index cache (built from the correct
+    // manifest) is untouched — this is the load-bearing precondition for the guard to have
+    // anything to check against.
+    pom_gpu::uninstall(device_id);
+
+    // Step C: corrupt the manifest — drop the last tensor, same shard/device/gguf otherwise.
+    let mut bad_manifest = good_manifest.clone();
+    let dropped = bad_manifest.tensor_names.pop().expect("shard has at least one tensor");
+    println!("[guard-poc] corrupting manifest: dropped tensor \"{dropped}\" ({} -> {} tensors)", good_manifest.tensor_names.len(), bad_manifest.tensor_names.len());
+    pom_gpu::set_shard_for_device(device_id, spec.model_id, gguf_path, target_bytes, bad_manifest);
+
+    // Step D: reinstall attempt. The gather now walks a shorter tensor set than the cached index
+    // (still built from the correct manifest) — the N-guard must refuse rather than silently
+    // installing a miner whose proofs wouldn't match the index it claims.
+    let reinstalled = pom_gpu::ensure_installed(device_id, daa);
+    println!("[guard-poc] corrupted-manifest reinstall -> {reinstalled}");
+    assert!(!reinstalled, "N-guard must refuse to mine when the gather no longer matches the cached shard index");
+
+    println!("\n=== GUARD PROVEN: dropping a tensor from the manifest made the gather N diverge from the cached shard index N, and ensure_installed correctly refused rather than installing a miner over mismatched data. ===");
+}

--- a/examples/shard_walk_poc.rs
+++ b/examples/shard_walk_poc.rs
@@ -1,0 +1,89 @@
+// Concept PoC: split a real model into shards, have two independent GPUs each mine (PoM walk)
+// their own shard, and self-verify the produced proof — all in-process, no live node required.
+// Uses the same functions the real miner uses (pom_gpu::mine, pom_gpu::dump_v3,
+// pom_v3::build_proof_v3/verify_proof_v3) with a synthetic pre-pow-hash/target so it doesn't
+// depend on the network ever reaching the PoM activation DAA for real.
+
+use clap::Parser;
+use keryx_miner::{gguf, models, pom, pom_gpu, pom_v3};
+use std::fs::File;
+
+#[derive(Parser, Debug, Clone)]
+#[clap(name = "shard_walk_poc", about = "Concept PoC: split a real GGUF into shards, mine+prove each on its own GPU")]
+struct Args {
+    #[clap(long, default_value = r"E:\keryx-miner-v0.4.1-OPoI-win64-amd64\models\Kimi-Linear-48B\model.gguf")]
+    gguf_path: String,
+    #[clap(long, default_value_t = 8_000_000_000)]
+    target_bytes: u64,
+    /// Gate PoM activation DAAs as mainnet instead of testnet.
+    #[clap(long)]
+    mainnet: bool,
+}
+
+fn run_shard(device_id: u32, shard_idx: u16, args: &Args) {
+    let spec = &models::KIMI_LINEAR_48B;
+    let gguf_path = args.gguf_path.clone();
+    let target_bytes: u64 = args.target_bytes;
+
+    let mut file = File::open(&gguf_path).expect("open gguf");
+    let meta = gguf::GgufMeta::read(&mut file).expect("parse gguf meta");
+    let shards = keryx_miner::shard::pack_shards(&meta, target_bytes).expect("pack shards");
+    let manifest = shards.into_iter().find(|s| s.index == shard_idx).expect("shard index in range");
+    println!("[gpu{device_id}] shard {shard_idx}: layers [{},{})", manifest.layer_lo, manifest.layer_hi);
+
+    pom_gpu::set_shard_for_device(device_id, spec.model_id, gguf_path, target_bytes, manifest);
+
+    let daa: u64 = pom::pom_v3_activation_daa(); // testnet gate, set by main() below
+    println!("[gpu{device_id}] installing shard (expect a raw scoped upload, no llama engine)...");
+    let installed = pom_gpu::ensure_installed(device_id, daa);
+    println!("[gpu{device_id}] ensure_installed -> {installed}");
+    assert!(installed, "shard install failed for device {device_id}");
+
+    // Synthetic pre-pow-hash/timestamp/target: this PoC only needs to prove the walk+proof
+    // round-trip on real shard data, not a real node-issued template.
+    let pph = [0x11u8; 32];
+    let timestamp: u64 = 1_700_000_000_000;
+    let h3 = true;
+    let h5_1 = true;
+    let h5_2 = true;
+    let target_le = [0xffu8; 32]; // trivially easy: any pow_value <= this
+
+    println!("[gpu{device_id}] mining (real GPU walk over the resident shard)...");
+    let mut nonce_cursor: u64 = 1;
+    let batch: u64 = 512;
+    let found = loop {
+        if let Some(n) = pom_gpu::mine(device_id, &pph, timestamp, &target_le, nonce_cursor, batch, h3, true, h5_1, h5_2, true, false, false) {
+            break n;
+        }
+        nonce_cursor = nonce_cursor.wrapping_add(batch);
+    };
+    println!("[gpu{device_id}] found nonce={found}");
+
+    let tier = pom_gpu::current_tier(device_id, daa).expect("shard tier index");
+    let index = pom_gpu::active_index_for_device(device_id, spec.model_id).expect("resident shard index");
+
+    let seed = pom::pom_block_seed(&pph, timestamp, found, h3, h5_1, h5_2);
+    let (states, snippets, final_state) =
+        pom_gpu::dump_v3(device_id, &pph, timestamp, found, h3, h5_1, h5_2).expect("dump_v3 (host re-walk from GPU state)");
+    let pow_value = pom::pom_pow_value(final_state, &pph, h3);
+    assert!(pom::le_leq(&pow_value, &target_le), "pow_value must meet the (trivial) target");
+
+    let v3 = pom_v3::build_proof_v3(tier, &pph, found, seed, &states, &snippets, index.as_ref()).expect("build_proof_v3");
+    assert_eq!(pom_v3::fold64(&v3.roots[pom_v3::POM_V3_K]), final_state, "GPU fold must match host tree fold");
+    let ok = pom_v3::verify_proof_v3(&pph, found, seed, &v3, &index.r_t, index.n_chunks);
+    assert!(ok, "verify_proof_v3 must accept the proof built from this shard's own walk");
+
+    println!("[gpu{device_id}] PROOF BUILT AND SELF-VERIFIED (verify_proof_v3 == true) — tier={tier}");
+}
+
+fn main() {
+    let args = Args::parse();
+    pom::set_testnet(!args.mainnet);
+    let a0 = args.clone();
+    let a1 = args.clone();
+    let t0 = std::thread::spawn(move || run_shard(0, 0, &a0));
+    let t1 = std::thread::spawn(move || run_shard(1, 1, &a1));
+    t0.join().expect("gpu0 thread panicked");
+    t1.join().expect("gpu1 thread panicked");
+    println!("\n=== CONCEPT PROVEN: both GPUs independently mined their own shard of Kimi-Linear-48B and produced a self-verified PoM proof, with no live node involved. ===");
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,6 +51,27 @@ pub struct Opt {
     pub force_model: Option<String>,
 
     #[clap(
+        long = "shard",
+        value_name = "TIER:TARGET_GIB:IDX[,TIER:TARGET_GIB:IDX...]",
+        help = "Mine one fixed-size shard of a model instead of the whole tier (CUDA-driver order, CSV): \
+                e.g. --shard very-high:8:0 -> GPU0 mines shard 0 of an 8 GiB split of the very-high model. \
+                A GPU listed here mines ONLY its shard, never the whole tier. Requires the model's GGUF to \
+                be present (combine with --force-model naming the same tier so it gets prefetched).",
+        help_heading = "OPoI / Inference"
+    )]
+    pub shard: Option<String>,
+
+    #[clap(
+        long = "print-shards",
+        value_name = "TIER:TARGET_GIB",
+        help = "Compute and print the shard manifest (layer ranges, chunk counts, Merkle roots) for a \
+                tier at a given byte target, then exit without mining. Used to produce the rows pinned \
+                into a private testnet node's shard tier table.",
+        help_heading = "OPoI / Inference"
+    )]
+    pub print_shards: Option<String>,
+
+    #[clap(
         long = "ipfs-url",
         help = "IPFS Kubo API URL for uploading inference results",
         help_heading = "OPoI / Inference",

--- a/src/client/grpc.rs
+++ b/src/client/grpc.rs
@@ -145,6 +145,10 @@ pub struct KeryxdHandler {
     /// Last service-bond strike poll instant.
     last_strike_poll: std::time::Instant,
 
+    /// Last time we asked the node for a fresh template on the idle-chain fallback timer
+    /// (see `listen`'s tick handler) — distinct from `last_strike_poll`.
+    last_template_poll: std::time::Instant,
+
     /// Last rendered service-bond status — logged only on change.
     strike_status: Option<String>,
 
@@ -189,11 +193,23 @@ impl Client for KeryxdHandler {
                     // Timer tick: if a regular inference just finished, get a fresh template.
                     if self.inference_rx.is_some() && self.poll_inference().await {
                         self.client_get_block_template().await?;
+                        self.last_template_poll = std::time::Instant::now();
                     // If a challenge is in flight, keep pinging the node so the result is
                     // delivered as soon as the inference task completes. This is critical on
                     // sole-producer nodes where mining suspension stops NewBlockTemplate
                     // notifications and the response would otherwise never be sent.
                     } else if self.challenge_inference_rx.is_some() {
+                        self.client_get_block_template().await?;
+                        self.last_template_poll = std::time::Instant::now();
+                    } else if self.last_template_poll.elapsed().as_millis() >= 500 {
+                        // Idle-chain fallback: nothing is in flight, and on a sole-producer
+                        // chain that never mines a real block (e.g. a fresh private testnet
+                        // stuck below its own PoM activation gate), the node's virtual state
+                        // never changes, so it never sends another NewBlockTemplate
+                        // notification either — the miner would otherwise sit on a stale
+                        // template forever. Re-requesting is cheap and idempotent when
+                        // nothing has actually changed.
+                        self.last_template_poll = std::time::Instant::now();
                         self.client_get_block_template().await?;
                     }
                     if self.escrow_pubkey.is_some() && self.last_strike_poll.elapsed().as_secs() >= 60 {
@@ -297,6 +313,7 @@ impl KeryxdHandler {
             escrow_cert,
             service_identity,
             last_strike_poll: std::time::Instant::now() - std::time::Duration::from_secs(55),
+            last_template_poll: std::time::Instant::now(),
             strike_status: None,
             stats: None,
             misses_seen: std::collections::HashSet::new(),

--- a/src/client/grpc.rs
+++ b/src/client/grpc.rs
@@ -949,7 +949,10 @@ impl KeryxdHandler {
                 }
                 // OPoI is mandatory: refuse to mine if no models are ready.
                 // Covers miners with missing/truncated model files that somehow passed prefetch.
-                if keryx_miner::slm::loaded_model_ids().is_empty() {
+                // Exempt: a process running only shard devices (`--shard`) never loads a full
+                // model by design (see `pom_gpu::any_shard_devices_active`'s doc) — this gate is
+                // for whole-tier devices whose OPoI capability should have come up alongside PoM.
+                if keryx_miner::slm::loaded_model_ids().is_empty() && !keryx_miner::pom_gpu::any_shard_devices_active() {
                     // Throttle to one log per ~200 templates (~every 20s at 10 BPS) to avoid spam.
                     if self.last_known_daa % 200 == 0 {
                         if keryx_miner::slm::publishing_blocked() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod pom;
 pub mod pom_gpu;
 pub mod pom_v3;
 pub mod pom_v4;
+pub mod shard;
 pub mod slm;
 pub mod xoshiro256starstar;
 use libloading::{Library, Symbol};

--- a/src/main.rs
+++ b/src/main.rs
@@ -792,6 +792,40 @@ async fn run() -> Result<(), Error> {
         std::env::set_var("KERYX_MODELS_DIR", "/hive/miners/custom/models");
     }
 
+    // --print-shards: one-shot diagnostic that computes and prints a shard manifest (layer
+    // ranges, chunk counts, Merkle roots) for TIER:TARGET_GIB, then exits before any
+    // network/GPU setup. Placed after the models-dir env-var block above so it honours
+    // --models-dir/--hiveos when resolving the GGUF path, but before everything else.
+    if let Some(spec) = opt.print_shards.as_deref() {
+        let parts: Vec<&str> = spec.split(':').collect();
+        let (tier_name, target_gib) = match parts.as_slice() {
+            [t, g] => (*t, g.parse::<u64>().map_err(|e| format!("--print-shards: bad TARGET_GIB: {e}"))?),
+            _ => return Err("--print-shards expects TIER:TARGET_GIB, e.g. very-high:8".into()),
+        };
+        let tier = parse_tier_name(tier_name).ok_or_else(|| format!("--print-shards: unrecognised tier '{tier_name}'"))?;
+        let spec = keryx_miner::models::spec_for_tier(tier);
+        let gguf_path = keryx_miner::slm::gguf_path_for(spec).to_string_lossy().into_owned();
+        if !std::path::Path::new(&gguf_path).exists() {
+            return Err(format!("--print-shards: {gguf_path} not found — run once without --print-shards first so the model is fetched, then retry").into());
+        }
+        let mut file = std::fs::File::open(&gguf_path)?;
+        let meta = keryx_miner::gguf::GgufMeta::read(&mut file)?;
+        let target_bytes = target_gib * 1_000_000_000;
+        let shards = keryx_miner::shard::pack_shards(&meta, target_bytes)
+            .map_err(|e| format!("--print-shards: packing failed: {e}"))?;
+        println!("model_id = {}", hex::encode(spec.model_id));
+        println!("target_bytes = {target_bytes}");
+        for s in &shards {
+            let tree_filename = format!("pom-tree.shard{}-{}g.bin", s.index, target_gib);
+            let idx = keryx_miner::pom::WeightIndex::build_from_gguf_subset(&gguf_path, spec.model_id, &s.tensor_names, &tree_filename)?;
+            println!(
+                "shard {} layers=[{},{}) n_chunks={} root={}",
+                s.index, s.layer_lo, s.layer_hi, idx.n_chunks, hex::encode(idx.r_t)
+            );
+        }
+        return Ok(());
+    }
+
     let is_tty = std::io::stdout().is_terminal();
     let shutdown_requested = Arc::new(AtomicBool::new(false));
     {
@@ -1153,6 +1187,55 @@ async fn run() -> Result<(), Error> {
                 "PoM: GPU {} → {} (index + GPU walk load lazily once the lineup is active).",
                 device_id, spec.dir_name
             );
+        }
+    }
+
+    // --shard: additive per-device override. A device named here mines ONLY its shard (never
+    // the whole tier) — the tier-assignment loop above already ensured its model's GGUF is on
+    // disk (via --force-model naming the same tier), which load_raw_subset needs.
+    if let Some(raw) = opt.shard.as_deref() {
+        for entry in raw.split(',') {
+            let parts: Vec<&str> = entry.trim().split(':').collect();
+            let (tier_name, target_gib_s, idx_s) = match parts.as_slice() {
+                [t, g, i] => (*t, *g, *i),
+                _ => {
+                    warn!("--shard: malformed entry '{entry}' (want TIER:TARGET_GIB:IDX) — ignoring.");
+                    continue;
+                }
+            };
+            let (Some(tier), Ok(target_gib), Ok(idx)) =
+                (parse_tier_name(tier_name), target_gib_s.parse::<u64>(), idx_s.parse::<u16>())
+            else {
+                warn!("--shard: malformed entry '{entry}' — ignoring.");
+                continue;
+            };
+            let spec = keryx_miner::models::spec_for_tier(tier);
+            let gguf_path = keryx_miner::slm::gguf_path_for(spec).to_string_lossy().into_owned();
+            let target_bytes = target_gib * 1_000_000_000;
+            let mut file = match std::fs::File::open(&gguf_path) {
+                Ok(f) => f,
+                Err(e) => { warn!("--shard: cannot open {gguf_path}: {e} — ignoring entry '{entry}'."); continue; }
+            };
+            let meta = match keryx_miner::gguf::GgufMeta::read(&mut file) {
+                Ok(m) => m,
+                Err(e) => { warn!("--shard: cannot parse {gguf_path}: {e} — ignoring entry '{entry}'."); continue; }
+            };
+            let shards = match keryx_miner::shard::pack_shards(&meta, target_bytes) {
+                Ok(s) => s,
+                Err(e) => { warn!("--shard: packing failed for '{entry}': {e} — ignoring."); continue; }
+            };
+            let Some(manifest) = shards.into_iter().find(|s| s.index == idx) else {
+                warn!("--shard: index {idx} out of range for '{entry}' — ignoring.");
+                continue;
+            };
+            // Device id: --shard is positional-CSV like --force-model, so its Nth entry (in
+            // parse order) targets CUDA device N. This mirrors forced_tiers' indexing exactly.
+            // KNOWN SIMPLIFICATION: this positional scheme is fragile if two entries are
+            // textually identical (position() finds the first match for both) — acceptable for
+            // this POC's one-shard-per-process, one-entry-per-invocation design.
+            let device_id = raw.split(',').position(|e| e.trim() == entry.trim()).unwrap_or(0) as u32;
+            info!("--shard: GPU {device_id} -> shard {idx} of {} ({target_gib} GiB target, layers [{},{}))", spec.dir_name, manifest.layer_lo, manifest.layer_hi);
+            keryx_miner::pom_gpu::set_shard_for_device(device_id, spec.model_id, gguf_path, target_bytes, manifest);
         }
     }
 

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -421,7 +421,7 @@ impl MinerManager {
                             let built = state.as_ref().and_then(|s| {
                                 let tier = keryx_miner::pom_gpu::current_tier(worker_device_id, s.daa_score)?;
                                 let model_id = keryx_miner::pom_gpu::mining_model_id(worker_device_id)?;
-                                let idx = keryx_miner::pom::active_index_for_model(&model_id)?;
+                                let idx = keryx_miner::pom_gpu::active_index_for_device(worker_device_id, model_id)?;
                                 s.generate_block_if_pom(nonce, idx.as_ref(), tier, worker_device_id)
                             });
                             if let Some(mut block_seed) = built {

--- a/src/models.rs
+++ b/src/models.rs
@@ -174,6 +174,27 @@ pub fn pom_tier_index(model_id: &[u8; 32], daa: u64) -> Option<u8> {
     }
 }
 
+/// The one (model, target_bytes) combination this POC shards. 8 GiB, matching the spec's
+/// suggested target for Kimi-Linear-48B on a 24 GB card (raw-scoped upload leaves headroom for
+/// the rest of the process). A second sharded model/target needs a second constant here AND a
+/// matching second block of rows in the node's `POM_SHARDS_POC` (keryx-node
+/// consensus/core/src/config/params.rs) — the two must stay in lockstep by construction; there
+/// is no dynamic negotiation in this phase.
+pub const POC_SHARD_TARGET_BYTES: u64 = 8 * 1_000_000_000;
+
+/// Shard tier index for the POC sharded model. Mirrors the node's `POM_SHARDS_POC` row order
+/// (index 0 -> tier 5, index 1 -> tier 6, ... immediately after the 5-row H6 table). `None` for
+/// any model/target this POC doesn't shard, or before the H6 gate.
+pub fn pom_shard_tier_index(model_id: &[u8; 32], target_bytes: u64, shard_index: u16, daa: u64) -> Option<u8> {
+    if daa < crate::pom::pom_v3_activation_daa() {
+        return None;
+    }
+    if *model_id != KIMI_LINEAR_48B.model_id || target_bytes != POC_SHARD_TARGET_BYTES {
+        return None;
+    }
+    5u8.checked_add(shard_index as u8)
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum Tier {
     VeryLight,
@@ -337,5 +358,19 @@ mod tests {
             assert_eq!(pom_tier_index(&QWEN3_5_9B_ABLITERATED.model_id, gate - 1), None);
             assert!(pom_model_for_tier(gate - 1, Tier::Default).is_none());
         }
+    }
+
+    #[test]
+    fn pom_shard_tier_index_offsets_from_h6_table_size() {
+        let daa = crate::pom::pom_v3_activation_daa(); // any DAA at/after H6
+        // Shard 0 and shard 1 of the POC model land at 5 and 6 (H6 table has 5 whole-tier rows).
+        assert_eq!(pom_shard_tier_index(&KIMI_LINEAR_48B.model_id, POC_SHARD_TARGET_BYTES, 0, daa), Some(5));
+        assert_eq!(pom_shard_tier_index(&KIMI_LINEAR_48B.model_id, POC_SHARD_TARGET_BYTES, 1, daa), Some(6));
+        // Wrong model_id -> None.
+        assert_eq!(pom_shard_tier_index(&QWEN3_6_27B.model_id, POC_SHARD_TARGET_BYTES, 0, daa), None);
+        // Wrong target_bytes -> None (not the pinned POC target).
+        assert_eq!(pom_shard_tier_index(&KIMI_LINEAR_48B.model_id, POC_SHARD_TARGET_BYTES + 1, 0, daa), None);
+        // Before H6 activation -> None.
+        assert_eq!(pom_shard_tier_index(&KIMI_LINEAR_48B.model_id, POC_SHARD_TARGET_BYTES, 0, 0), None);
     }
 }

--- a/src/pom.rs
+++ b/src/pom.rs
@@ -2210,14 +2210,21 @@ mod tests {
         let tensor_data_offset = (header.len() as u64).div_ceil(ALIGNMENT) * ALIGNMENT;
         let mut buf = header;
         buf.resize(tensor_data_offset as usize, 0u8);
-        for (i, &(_, nbytes)) in tensor_sizes.iter().enumerate() {
+        for (i, &(name, nbytes)) in tensor_sizes.iter().enumerate() {
             let start = (tensor_data_offset + offsets[i]) as usize;
             let end = start + nbytes as usize;
             if buf.len() < end {
                 buf.resize(end, 0u8);
             }
+            // Content is keyed by the tensor NAME (not its positional index or file offset) so
+            // the same tensor gets byte-identical content across different synthetic files —
+            // needed for tests that compare a subset built from one file against a reference
+            // index built from a second file containing only some of the same-named tensors.
+            let name_seed: u64 = name.bytes().fold(0xcbf2_9ce4_8422_2325u64, |acc, b| {
+                (acc ^ b as u64).wrapping_mul(0x0000_0100_0000_01b3)
+            });
             for (j, b) in buf[start..end].iter_mut().enumerate() {
-                *b = ((i as u64 * 7 + j as u64) % 251) as u8; // distinguishable, deterministic content
+                *b = (name_seed.wrapping_add(j as u64) % 251) as u8; // distinguishable, deterministic content
             }
         }
 
@@ -2228,8 +2235,11 @@ mod tests {
     fn build_from_gguf_subset_root_matches_full_dense_tree_over_same_leaves() {
         let dir = tempfile::tempdir().unwrap();
         let gguf_path = dir.path().join("model.gguf");
+        // Distinct per-tensor sizes so a wrong-tensor-selected bug would also show up as a
+        // wrong `n_chunks`, not just a different root (a same-size swap could otherwise slip
+        // past a chunk-count-only check).
         write_synthetic_gguf(&gguf_path, &[
-            ("blk.0.a", 320), ("blk.0.b", 320), ("blk.1.a", 320), ("output.weight", 320),
+            ("blk.0.a", 320), ("blk.0.b", 352), ("blk.1.a", 384), ("output.weight", 416),
         ]);
         let model_id = [7u8; 32];
 
@@ -2242,10 +2252,21 @@ mod tests {
             gguf_path.to_str().unwrap(), model_id, &subset_names, "pom-tree.shard0-test.bin",
         ).unwrap();
 
-        // Subset root must differ from the full root (fewer leaves) but subset n_chunks must
-        // equal exactly the chunk count of the 3 included tensors (320*3/32 = 30).
+        // Independent reference: a SECOND GGUF containing only the 3 intended tensors (same
+        // names/sizes/order), indexed through the unmodified whole-file `build_from_gguf` path.
+        // If the subset filter selected the wrong 3-of-4 tensors (e.g. dropped `blk.0.b` instead
+        // of `blk.1.a`), `subset.r_t`/`n_chunks` would NOT match this reference — unlike a bare
+        // "differs from the full root" check, which any 3-of-4 selection would also satisfy.
+        let ref_gguf_path = dir.path().join("model-shard0-reference.gguf");
+        write_synthetic_gguf(&ref_gguf_path, &[("blk.0.a", 320), ("blk.0.b", 352), ("output.weight", 416)]);
+        let reference = WeightIndex::build_from_gguf(ref_gguf_path.to_str().unwrap(), model_id).unwrap();
+
+        assert_eq!(subset.n_chunks, reference.n_chunks);
+        assert_eq!(subset.r_t, reference.r_t, "subset root must match an independently-built index over exactly the intended tensors");
+
+        // Sanity: the subset is still a proper subset of the full model (root differs, fewer chunks).
         assert_ne!(subset.r_t, full.r_t);
-        assert_eq!(subset.n_chunks, 30);
+        assert_eq!(subset.n_chunks, (320 + 352 + 416) / 32);
     }
 
 }

--- a/src/pom.rs
+++ b/src/pom.rs
@@ -946,10 +946,21 @@ fn compute_checkpoint_offsets(n_chunks: u64) -> (Vec<StoredLevel>, u32) {
 
 /// Open an existing checkpoint tree file and reconstruct the WeightIndex.
 /// Detects legacy full-tree files (size mismatch) and returns an error so the caller can rebuild.
-fn open_existing_tree(tree_path: &Path, gguf_path: &str, expected_model_id: [u8; 32]) -> Result<WeightIndex> {
+fn open_existing_tree(
+    tree_path: &Path,
+    gguf_path: &str,
+    expected_model_id: [u8; 32],
+    subset: Option<&[String]>,
+) -> Result<WeightIndex> {
     let mut file = File::open(gguf_path)?;
     let meta = crate::gguf::GgufMeta::read(&mut file)?;
-    let names = meta.sorted_names();
+    let names: Vec<String> = match subset {
+        Some(s) => {
+            let want: std::collections::HashSet<&str> = s.iter().map(|x| x.as_str()).collect();
+            meta.sorted_names().into_iter().filter(|n| want.contains(n.as_str())).collect()
+        }
+        None => meta.sorted_names(),
+    };
 
     // Compute n_chunks (fast — header arithmetic only, no tensor data reads).
     let mut n_chunks: u64 = 0;
@@ -1043,8 +1054,33 @@ impl WeightIndex {
     /// GGUF: only every K-th level is stored (~N/(2^K-1) nodes vs ~2N for a full tree). On
     /// subsequent restarts the existing tree is reused (GGUF is immutable), avoiding a rebuild.
     pub fn build_from_gguf(path: &str, model_id: [u8; 32]) -> Result<Self> {
+        Self::build_from_gguf_impl(path, model_id, None, "pom-tree.bin")
+    }
+
+    /// Same as `build_from_gguf`, but over only `tensor_names` (already sorted or not — this
+    /// re-sorts). `tree_filename` must be unique per (model, shard) pair so different shards'
+    /// checkpoint trees never collide on disk next to the same GGUF.
+    pub fn build_from_gguf_subset(
+        path: &str,
+        model_id: [u8; 32],
+        tensor_names: &[String],
+        tree_filename: &str,
+    ) -> Result<Self> {
+        Self::build_from_gguf_impl(path, model_id, Some(tensor_names), tree_filename)
+    }
+
+    /// Shared implementation behind `build_from_gguf`/`build_from_gguf_subset` — `subset = None`
+    /// indexes every tensor in the file (whole-model, unchanged behavior); `Some(names)` indexes
+    /// only the given tensors (a shard). `tree_filename` names the sparse checkpoint tree file
+    /// persisted next to the GGUF.
+    fn build_from_gguf_impl(
+        path: &str,
+        model_id: [u8; 32],
+        subset: Option<&[String]>,
+        tree_filename: &str,
+    ) -> Result<Self> {
         let dir = std::path::Path::new(path).parent().unwrap_or_else(|| std::path::Path::new("."));
-        let tree_path = dir.join("pom-tree.bin");
+        let tree_path = dir.join(tree_filename);
 
         // Clean up old PID-named files left by previous versions.
         if let Ok(entries) = std::fs::read_dir(dir) {
@@ -1060,7 +1096,7 @@ impl WeightIndex {
 
         // Reuse existing checkpoint tree if valid.
         if tree_path.exists() {
-            match open_existing_tree(&tree_path, path, model_id) {
+            match open_existing_tree(&tree_path, path, model_id, subset) {
                 Ok(idx) => {
                     log::info!("PoM: reusing cached weight index — {} chunks", idx.n_chunks);
                     return Ok(idx);
@@ -1075,7 +1111,13 @@ impl WeightIndex {
 
         let mut file = File::open(path)?;
         let meta = crate::gguf::GgufMeta::read(&mut file)?;
-        let names = meta.sorted_names(); // canonical order
+        let names: Vec<String> = match subset {
+            Some(s) => {
+                let want: std::collections::HashSet<&str> = s.iter().map(|x| x.as_str()).collect();
+                meta.sorted_names().into_iter().filter(|n| want.contains(n.as_str())).collect()
+            }
+            None => meta.sorted_names(),
+        }; // canonical order (filtered to `subset` when given)
 
         // Phase 0: hash leaves from GGUF chunks → write first checkpoint level (level K) to disk.
         // Process in batches of 2^K leaves, building a mini-tree per batch and writing only
@@ -1600,6 +1642,28 @@ pub fn any_active_index() -> Option<([u8; 32], Arc<WeightIndex>)> {
     pom_indices().lock().ok().and_then(|g| g.iter().min_by_key(|(m, _)| **m).map(|(m, i)| (*m, i.clone())))
 }
 
+/// Possession index for a SHARD, keyed by the CUDA device mining it (not by model_id — a shard
+/// shares its parent model's model_id, so keying by model_id would collide with or shadow the
+/// whole-model entry in `POM_INDICES`). This phase is one shard per device per process, so
+/// device-keying is sufficient; a future multi-shard-per-device design would need a composite key.
+static POM_SHARD_INDICES: OnceLock<Mutex<HashMap<u32, Arc<WeightIndex>>>> = OnceLock::new();
+
+fn pom_shard_indices() -> &'static Mutex<HashMap<u32, Arc<WeightIndex>>> {
+    POM_SHARD_INDICES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Install a shard's possession index for the device mining it. Idempotent per device.
+pub fn set_shard_index(device_id: u32, index: WeightIndex) {
+    if let Ok(mut g) = pom_shard_indices().lock() {
+        g.insert(device_id, Arc::new(index));
+    }
+}
+
+/// The shard possession index active for a specific device, if built.
+pub fn active_shard_index(device_id: u32) -> Option<Arc<WeightIndex>> {
+    pom_shard_indices().lock().ok()?.get(&device_id).cloned()
+}
+
 /// Test-only WeightIndex over arbitrary RAM chunks (`data` = chunk-aligned canonical bytes) —
 /// real checkpoint tree + merkle paths, no GGUF.
 #[cfg(test)]
@@ -2101,6 +2165,87 @@ mod tests {
         // The proof verifies against the same target the node would use.
         assert!(verify_proof(&pph, nonce, seed, &proof, idx.n_chunks, k, t, &idx.r_t, &target, false));
         assert_eq!(proof.tier, 1);
+    }
+
+    /// Write a minimal synthetic GGUF (v3, 1 kv: `general.alignment`=32, all tensors F32) that
+    /// round-trips through the real `GgufMeta::read` parser — mirrors `gguf.rs`'s own
+    /// `parses_minimal_gguf` fixture, generalized to N named tensors with real backing data so
+    /// `WeightIndex::build_from_gguf`/`build_from_gguf_subset` can pread real bytes from it.
+    /// `tensor_sizes` values are on-disk byte lengths and must each be a multiple of 4 (F32).
+    fn write_synthetic_gguf(path: &std::path::Path, tensor_sizes: &[(&str, u64)]) {
+        const ALIGNMENT: u64 = 32;
+
+        let mut header: Vec<u8> = Vec::new();
+        header.extend_from_slice(&0x4655_4747u32.to_le_bytes()); // "GGUF" magic
+        header.extend_from_slice(&3u32.to_le_bytes()); // version
+        header.extend_from_slice(&(tensor_sizes.len() as u64).to_le_bytes()); // tensor_count
+        header.extend_from_slice(&1u64.to_le_bytes()); // kv_count
+        // kv: general.alignment = u32 32
+        let key = b"general.alignment";
+        header.extend_from_slice(&(key.len() as u64).to_le_bytes());
+        header.extend_from_slice(key);
+        header.extend_from_slice(&4u32.to_le_bytes()); // value type: u32
+        header.extend_from_slice(&(ALIGNMENT as u32).to_le_bytes());
+
+        // Per-tensor offsets within the data section, each aligned (matches real GGUF writers).
+        let mut offsets: Vec<u64> = Vec::with_capacity(tensor_sizes.len());
+        let mut cur: u64 = 0;
+        for &(_, nbytes) in tensor_sizes {
+            assert!(nbytes % 4 == 0, "synthetic tensor size must be a multiple of 4 (F32)");
+            offsets.push(cur);
+            cur = (cur + nbytes).div_ceil(ALIGNMENT) * ALIGNMENT;
+        }
+
+        for (i, &(name, nbytes)) in tensor_sizes.iter().enumerate() {
+            header.extend_from_slice(&(name.len() as u64).to_le_bytes());
+            header.extend_from_slice(name.as_bytes());
+            header.extend_from_slice(&1u32.to_le_bytes()); // n_dims = 1
+            header.extend_from_slice(&(nbytes / 4).to_le_bytes()); // ne0 (element count, F32)
+            header.extend_from_slice(&0u32.to_le_bytes()); // dtype = F32
+            header.extend_from_slice(&offsets[i].to_le_bytes());
+        }
+
+        // Data section starts at the first alignment-multiple at/after the header end — same
+        // arithmetic `GgufMeta::read` uses.
+        let tensor_data_offset = (header.len() as u64).div_ceil(ALIGNMENT) * ALIGNMENT;
+        let mut buf = header;
+        buf.resize(tensor_data_offset as usize, 0u8);
+        for (i, &(_, nbytes)) in tensor_sizes.iter().enumerate() {
+            let start = (tensor_data_offset + offsets[i]) as usize;
+            let end = start + nbytes as usize;
+            if buf.len() < end {
+                buf.resize(end, 0u8);
+            }
+            for (j, b) in buf[start..end].iter_mut().enumerate() {
+                *b = ((i as u64 * 7 + j as u64) % 251) as u8; // distinguishable, deterministic content
+            }
+        }
+
+        std::fs::write(path, &buf).unwrap();
+    }
+
+    #[test]
+    fn build_from_gguf_subset_root_matches_full_dense_tree_over_same_leaves() {
+        let dir = tempfile::tempdir().unwrap();
+        let gguf_path = dir.path().join("model.gguf");
+        write_synthetic_gguf(&gguf_path, &[
+            ("blk.0.a", 320), ("blk.0.b", 320), ("blk.1.a", 320), ("output.weight", 320),
+        ]);
+        let model_id = [7u8; 32];
+
+        // Full index over everything.
+        let full = WeightIndex::build_from_gguf(gguf_path.to_str().unwrap(), model_id).unwrap();
+
+        // Subset index over just layer 0's tensors + output (skip blk.1.a).
+        let subset_names = vec!["blk.0.a".to_string(), "blk.0.b".to_string(), "output.weight".to_string()];
+        let subset = WeightIndex::build_from_gguf_subset(
+            gguf_path.to_str().unwrap(), model_id, &subset_names, "pom-tree.shard0-test.bin",
+        ).unwrap();
+
+        // Subset root must differ from the full root (fewer leaves) but subset n_chunks must
+        // equal exactly the chunk count of the 3 included tensors (320*3/32 = 30).
+        assert_ne!(subset.r_t, full.r_t);
+        assert_eq!(subset.n_chunks, 30);
     }
 
 }

--- a/src/pom_gpu.rs
+++ b/src/pom_gpu.rs
@@ -1317,6 +1317,16 @@ pub fn shard_for_device(device_id: u32) -> Option<ShardAssignment> {
     shard_assignments().lock().ok()?.get(&device_id).cloned()
 }
 
+/// True when at least one device on this process is mining a shard (`--shard`). A shard device
+/// never loads the full model, so it can never satisfy the whole-model OPoI-mandatory mining gate
+/// (`grpc.rs`'s "no models ready" check) — that check is written for whole-tier devices, which are
+/// always expected to become OPoI-capable once their model finishes loading. Callers use this to
+/// skip that gate only when the reason `loaded_model_ids()` is empty is "this process only runs
+/// shard devices by design," not "a whole-tier model failed to load and OPoI is being dodged."
+pub fn any_shard_devices_active() -> bool {
+    shard_assignments().lock().map(|g| !g.is_empty()).unwrap_or(false)
+}
+
 /// The possession index for whatever this device is mining — its shard's index if it's a shard
 /// device, else the whole-model index (existing `active_index_for_model` path). Single lookup
 /// point so callers (the mining loop) don't need to know which kind of device they're on.

--- a/src/pom_gpu.rs
+++ b/src/pom_gpu.rs
@@ -909,6 +909,63 @@ impl PomGpuMiner {
         })
     }
 
+    /// Same as `load_raw`, but uploads only `tensor_names` instead of every tensor in the GGUF.
+    /// Used for a shard: the walk gathers over exactly this device's own slice of the canonical
+    /// bytes, so no cross-GPU pointer dependency exists and no other GPU needs to be involved.
+    pub fn load_raw_subset(gguf_path: &str, device_id: usize, tensor_names: &[String]) -> Result<Self> {
+        let ctx = CudaContext::new(device_id)?;
+        ctx.bind_to_thread()?;
+        let stream = ctx.default_stream();
+
+        let mut file = std::fs::File::open(gguf_path)?;
+        let meta = crate::gguf::GgufMeta::read(&mut file)?;
+        let want: std::collections::HashSet<&str> = tensor_names.iter().map(|s| s.as_str()).collect();
+        let names: Vec<String> = meta.sorted_names().into_iter().filter(|n| want.contains(n.as_str())).collect();
+        if names.len() != tensor_names.len() {
+            return Err(anyhow!(
+                "PoM GPU: shard subset requested {} tensors, but only {} were found in the GGUF — manifest/GGUF mismatch",
+                tensor_names.len(), names.len()
+            ));
+        }
+
+        let mut uploads: Vec<CudaSlice<u8>> = Vec::with_capacity(names.len());
+        let mut bases: Vec<u64> = Vec::new();
+        let mut prefix: Vec<u64> = vec![0];
+        let mut host_buf: Vec<u8> = Vec::new();
+        for name in &names {
+            let t = &meta.tensors[name];
+            let chunks = t.nbytes / CHUNK_BYTES as u64;
+            if chunks == 0 {
+                continue;
+            }
+            host_buf.resize(t.nbytes as usize, 0);
+            crate::pom::read_exact_at(&file, &mut host_buf, meta.tensor_data_offset + t.offset)?;
+            let dev = stream.clone_htod(host_buf.as_slice())?;
+            bases.push(dev.device_ptr(&stream).0 as u64);
+            uploads.push(dev);
+            prefix.push(prefix.last().unwrap() + chunks);
+        }
+        let n_total_chunks = *prefix.last().unwrap();
+        if n_total_chunks == 0 {
+            return Err(anyhow!("PoM GPU: shard produced 0 chunks"));
+        }
+
+        let bases_dev = stream.clone_htod(bases.as_slice())?;
+        let prefix_dev = stream.clone_htod(prefix.as_slice())?;
+        let kernel = select_pom_kernel(device_id)?;
+
+        Ok(Self {
+            ctx,
+            stream,
+            kernel,
+            bases_dev,
+            prefix_dev,
+            t_count: bases.len() as u32,
+            n_total_chunks,
+            _uploads: uploads,
+        })
+    }
+
     /// Gather over the IN-PROCESS llama.cpp engine in canonical GGUF (name-sorted) order.
     /// A tensor whose resident copy matches the GGUF unambiguously (unique name, exact size)
     /// is walked zero-dup in place; host-resident tensors get a small device upload of our

--- a/src/pom_gpu.rs
+++ b/src/pom_gpu.rs
@@ -1291,6 +1291,43 @@ fn mining_tiers() -> &'static Mutex<HashMap<u32, ([u8; 32], String)>> {
     MINING_TIERS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// A device's shard assignment (from `--shard`). Disjoint from `MINING_TIERS`: a device is
+/// either a whole-tier miner (existing path) or a shard miner (this path), never both.
+#[derive(Clone)]
+pub struct ShardAssignment {
+    pub model_id: [u8; 32],
+    pub gguf_path: String,
+    pub target_bytes: u64,
+    pub manifest: crate::shard::ShardManifest,
+}
+
+static SHARD_ASSIGNMENTS: OnceLock<Mutex<HashMap<u32, ShardAssignment>>> = OnceLock::new();
+
+fn shard_assignments() -> &'static Mutex<HashMap<u32, ShardAssignment>> {
+    SHARD_ASSIGNMENTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn set_shard_for_device(device_id: u32, model_id: [u8; 32], gguf_path: String, target_bytes: u64, manifest: crate::shard::ShardManifest) {
+    if let Ok(mut g) = shard_assignments().lock() {
+        g.insert(device_id, ShardAssignment { model_id, gguf_path, target_bytes, manifest });
+    }
+}
+
+pub fn shard_for_device(device_id: u32) -> Option<ShardAssignment> {
+    shard_assignments().lock().ok()?.get(&device_id).cloned()
+}
+
+/// The possession index for whatever this device is mining — its shard's index if it's a shard
+/// device, else the whole-model index (existing `active_index_for_model` path). Single lookup
+/// point so callers (the mining loop) don't need to know which kind of device they're on.
+pub fn active_index_for_device(device_id: u32, model_id: [u8; 32]) -> Option<Arc<crate::pom::WeightIndex>> {
+    if shard_for_device(device_id).is_some() {
+        crate::pom::active_shard_index(device_id)
+    } else {
+        crate::pom::active_index_for_model(&model_id)
+    }
+}
+
 /// Record a GPU's mining tier so its miner can be rebuilt after an inference swapped the model away.
 pub fn set_mining_tier(device_id: u32, model_id: [u8; 32], gguf_path: String) {
     if let Ok(mut g) = mining_tiers().lock() {
@@ -1542,6 +1579,9 @@ pub fn ensure_installed(device_id: u32, daa: u64) -> bool {
 /// at index-build time): below the H4 gate it is None, so the miner never claims a tier for a
 /// block outside the lineup's era.
 pub fn current_tier(device_id: u32, daa: u64) -> Option<u8> {
+    if let Some(shard) = shard_for_device(device_id) {
+        return crate::models::pom_shard_tier_index(&shard.model_id, shard.target_bytes, shard.manifest.index, daa);
+    }
     let model_id = mining_tiers().lock().ok()?.get(&device_id).map(|(id, _)| *id)?;
     crate::models::pom_tier_index(&model_id, daa)
 }
@@ -1679,6 +1719,9 @@ fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
     // pause was raised must not reload the mining model while inference is still generating.
     if inference_paused() {
         return false;
+    }
+    if let Some(shard) = shard_for_device(device_id) {
+        return ensure_shard_installed_inner(device_id, &shard);
     }
     let (model_id, gguf) = match mining_tiers().lock().ok().and_then(|g| g.get(&device_id).cloned()) {
         Some(x) => x,
@@ -1857,6 +1900,72 @@ fn ensure_installed_inner(device_id: u32, daa: u64) -> bool {
     }
     install(device_id, gm);
     info!("PoM[gpu{}]: GPU miner ready — N={} chunks resident (matches shared index)", device_id, n);
+    true
+}
+
+/// Install path for a shard device: raw scoped upload only, no llama engine, no era-crossing,
+/// own possession index (keyed by device, not model_id — see `pom.rs::POM_SHARD_INDICES`).
+fn ensure_shard_installed_inner(device_id: u32, shard: &ShardAssignment) -> bool {
+    if is_oom_banlisted(device_id, &shard.model_id) {
+        return false;
+    }
+    if crate::pom::active_shard_index(device_id).is_none() {
+        let _guard = match index_build_lock().lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        if crate::pom::active_shard_index(device_id).is_none() {
+            let tree_filename = format!("pom-tree.shard{}-{}g.bin", shard.manifest.index, shard.target_bytes / 1_000_000_000);
+            info!(
+                "PoM[gpu{}]: building host index for shard {} (layers {}..{}) — this can take a while...",
+                device_id, shard.manifest.index, shard.manifest.layer_lo, shard.manifest.layer_hi
+            );
+            match crate::pom::WeightIndex::build_from_gguf_subset(&shard.gguf_path, shard.model_id, &shard.manifest.tensor_names, &tree_filename) {
+                Ok(idx) => {
+                    info!("PoM[gpu{}]: shard {} host index ready — N={} chunks", device_id, shard.manifest.index, idx.n_chunks);
+                    crate::pom::set_shard_index(device_id, idx);
+                }
+                Err(e) => {
+                    log::error!("PoM[gpu{}]: shard {} host index build failed: {}", device_id, shard.manifest.index, e);
+                    return false;
+                }
+            }
+        }
+    }
+
+    // Shard devices never run the llama engine and never zero-dup: raw scoped upload only.
+    info!(
+        "PoM[gpu{}]: shard {} — walk uses a raw scoped upload (no zero-dup, no llama engine)",
+        device_id, shard.manifest.index
+    );
+    let loaded = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        PomGpuMiner::load_raw_subset(&shard.gguf_path, device_id as usize, &shard.manifest.tensor_names)
+    }));
+    let gm = match loaded {
+        Ok(Ok(gm)) => gm,
+        Ok(Err(e)) => {
+            log::error!("PoM[gpu{}]: shard {} miner load failed: {}", device_id, shard.manifest.index, e);
+            oom_banlist_add(device_id, shard.model_id);
+            return false;
+        }
+        Err(_) => {
+            log::error!("PoM[gpu{}]: shard {} miner load panicked (likely OOM)", device_id, shard.manifest.index);
+            oom_banlist_add(device_id, shard.model_id);
+            return false;
+        }
+    };
+    let n = gm.n_chunks();
+    if let Some(idx) = crate::pom::active_shard_index(device_id) {
+        if n != idx.n_chunks {
+            log::error!(
+                "PoM[gpu{}]: shard {} gather N={} != shard index N={} — refusing to mine",
+                device_id, shard.manifest.index, n, idx.n_chunks
+            );
+            return false;
+        }
+    }
+    install(device_id, gm);
+    info!("PoM[gpu{}]: shard {} miner ready — N={} chunks resident", device_id, shard.manifest.index, n);
     true
 }
 

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -1,0 +1,160 @@
+use std::collections::HashMap;
+use anyhow::{anyhow, Result};
+use crate::gguf::{GgufMeta, TensorMeta};
+
+/// One fixed-size, layer-aligned slice of a model's canonical GGUF. Fully determined by the
+/// GGUF's own tensor directory plus `target_bytes` — no operator choice enters the boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShardManifest {
+    /// Position of this shard among its siblings, 0-based, in ascending layer order.
+    pub index: u16,
+    /// Transformer layer range this shard owns, `[layer_lo, layer_hi)`. Non-layer tensors are
+    /// attached to shard 0 (input side) or the last shard (output side) — see `pack_shards`.
+    pub layer_lo: u32,
+    pub layer_hi: u32,
+    /// Tensor names in this shard, already in canonical (sorted) order.
+    pub tensor_names: Vec<String>,
+}
+
+/// Split a GGUF's tensors into fixed-byte-target, layer-aligned shards.
+///
+/// Grouping rule: tensors named `blk.<N>.*` belong to layer `N`; everything else is
+/// "non-layer" (`token_embd.*` → shard 0, `output*` → last shard). Layers are walked in
+/// numeric order and packed greedily: a shard closes when adding the next layer would push it
+/// over `target_bytes`, unless the shard has no layers yet (a single layer bigger than
+/// `target_bytes` is a hard error — the caller must raise the target). Layer ranges are
+/// contiguous and cover every layer in the GGUF exactly once.
+pub fn pack_shards(meta: &GgufMeta, target_bytes: u64) -> Result<Vec<ShardManifest>> {
+    if target_bytes == 0 {
+        return Err(anyhow!("shard: target_bytes must be > 0"));
+    }
+
+    // Bucket every tensor by layer index; collect non-layer names separately.
+    let mut by_layer: HashMap<u32, Vec<String>> = HashMap::new();
+    let mut input_side: Vec<String> = Vec::new(); // token_embd.*
+    let mut output_side: Vec<String> = Vec::new(); // output*, output_norm.*
+    let mut max_layer: Option<u32> = None;
+
+    for name in meta.sorted_names() {
+        if let Some(rest) = name.strip_prefix("blk.") {
+            let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if !digits.is_empty() && rest.as_bytes().get(digits.len()) == Some(&b'.') {
+                let layer: u32 = digits.parse().map_err(|e| anyhow!("shard: bad layer index in '{name}': {e}"))?;
+                max_layer = Some(max_layer.map_or(layer, |m| m.max(layer)));
+                by_layer.entry(layer).or_default().push(name);
+                continue;
+            }
+        }
+        if name.starts_with("output") {
+            output_side.push(name);
+        } else {
+            input_side.push(name);
+        }
+    }
+    let Some(max_layer) = max_layer else {
+        return Err(anyhow!("shard: GGUF has no 'blk.<N>.*' tensors to shard"));
+    };
+    let n_layers = max_layer + 1;
+
+    let tensor_bytes = |name: &str| -> Result<u64> {
+        meta.tensors.get(name).map(|t: &TensorMeta| t.nbytes).ok_or_else(|| anyhow!("shard: tensor '{name}' missing from GgufMeta"))
+    };
+    let layer_bytes = |l: u32| -> Result<u64> {
+        by_layer.get(&l).ok_or_else(|| anyhow!("shard: layer {l} has no tensors (gap in blk.N numbering)"))?
+            .iter().map(|n| tensor_bytes(n)).sum::<Result<u64>>()
+    };
+
+    let mut shards: Vec<ShardManifest> = Vec::new();
+    let mut cur_names: Vec<String> = input_side.clone();
+    let mut cur_bytes: u64 = input_side.iter().map(|n| tensor_bytes(n)).sum::<Result<u64>>()?;
+    let mut cur_lo: u32 = 0;
+
+    for l in 0..n_layers {
+        let lb = layer_bytes(l)?;
+        if lb > target_bytes {
+            return Err(anyhow!("shard: layer {l} alone is {lb} bytes, over target_bytes={target_bytes} — raise the target"));
+        }
+        let would_be = cur_bytes + lb;
+        let shard_has_layers = cur_lo < l; // at least one layer already accepted into this shard
+        if shard_has_layers && would_be > target_bytes {
+            shards.push(ShardManifest { index: shards.len() as u16, layer_lo: cur_lo, layer_hi: l, tensor_names: { let mut v = cur_names.clone(); v.sort(); v } });
+            cur_names = Vec::new();
+            cur_bytes = 0;
+            cur_lo = l;
+        }
+        cur_names.extend(by_layer[&l].iter().cloned());
+        cur_bytes += lb;
+    }
+    cur_names.extend(output_side.iter().cloned());
+    shards.push(ShardManifest { index: shards.len() as u16, layer_lo: cur_lo, layer_hi: n_layers, tensor_names: { let mut v = cur_names; v.sort(); v } });
+
+    Ok(shards)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(layers: u32, bytes_per_layer: u64, extra: &[(&str, u64)]) -> GgufMeta {
+        let mut tensors = HashMap::new();
+        for l in 0..layers {
+            tensors.insert(format!("blk.{l}.attn.weight"), TensorMeta { offset: 0, nbytes: bytes_per_layer });
+        }
+        for (name, nbytes) in extra {
+            tensors.insert((*name).to_string(), TensorMeta { offset: 0, nbytes: *nbytes });
+        }
+        GgufMeta { tensors, tensor_data_offset: 0 }
+    }
+
+    #[test]
+    fn packs_by_fixed_byte_target() {
+        // 10 layers x 100 bytes, target 250 -> 2 layers per shard except a possible remainder.
+        let m = meta(10, 100, &[("token_embd.weight", 10), ("output.weight", 10)]);
+        let shards = pack_shards(&m, 250).unwrap();
+        // Every layer covered exactly once, ranges contiguous, ranges cover 0..10.
+        let mut lo = 0u32;
+        for s in &shards {
+            assert_eq!(s.layer_lo, lo);
+            assert!(s.layer_hi > s.layer_lo);
+            lo = s.layer_hi;
+        }
+        assert_eq!(lo, 10);
+        // input tensor is in shard 0, output tensor is in the last shard.
+        assert!(shards[0].tensor_names.contains(&"token_embd.weight".to_string()));
+        assert!(shards.last().unwrap().tensor_names.contains(&"output.weight".to_string()));
+    }
+
+    #[test]
+    fn deterministic_same_input_same_output() {
+        let m = meta(7, 50, &[]);
+        let a = pack_shards(&m, 130).unwrap();
+        let b = pack_shards(&m, 130).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_target_gives_different_boundaries() {
+        let m = meta(7, 50, &[]);
+        let small = pack_shards(&m, 60).unwrap();
+        let big = pack_shards(&m, 400).unwrap();
+        assert!(small.len() > big.len());
+    }
+
+    #[test]
+    fn single_layer_too_big_is_an_error() {
+        let m = meta(3, 500, &[]);
+        let err = pack_shards(&m, 100).unwrap_err();
+        assert!(err.to_string().contains("over target_bytes"));
+    }
+
+    #[test]
+    fn tensor_names_within_a_shard_are_sorted() {
+        let m = meta(3, 10, &[]);
+        let shards = pack_shards(&m, 1000).unwrap();
+        for s in &shards {
+            let mut sorted = s.tensor_names.clone();
+            sorted.sort();
+            assert_eq!(s.tensor_names, sorted);
+        }
+    }
+}


### PR DESCRIPTION
Proof of concept, not a finished feature. See SHARD_POSSESSION_POC.md (English) and
SHARD_POSSESSION_POC.pt-BR.md (Portuguese) in this branch for the full writeup: motivation,
what changed, the environment/model used for validation (2x GPU, Kimi-Linear-48B), real-hardware
results (live network acceptance, 1,230 blocks accepted / 0 rejected, N-guard regression check),
and an explicit list of what is intentionally not done yet.

Companion PR in keryx-node.

Opened as a draft on purpose: this is exploratory research meant to be reviewed and discussed,
not merged as-is.